### PR TITLE
Fix and extend acceptance test sweeper.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,6 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=digitalocean
-SLUG=do
 
 default: build
 
@@ -25,6 +24,9 @@ vet:
 		exit 1; \
 	fi
 
+sweep:
+	go test $(TEST) -v -sweep=1
+
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
@@ -33,7 +35,6 @@ fmtcheck:
 
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
-
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
@@ -46,5 +47,4 @@ test-compile:
 website:
 	@echo "Use this site to preview markdown rendering: https://registry.terraform.io/tools/doc-preview"
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website
-
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website sweep

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,6 +25,7 @@ vet:
 	fi
 
 sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test $(TEST) -v -sweep=1
 
 fmt:

--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -77,10 +77,6 @@ func (c *Config) Client() (*CombinedConfig, error) {
 		return nil, err
 	}
 
-	if c.APIEndpoint == "" {
-		c.APIEndpoint = "https://api.digitalocean.com"
-	}
-
 	apiURL, err := url.Parse(c.APIEndpoint)
 	if err != nil {
 		return nil, err

--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -77,6 +77,10 @@ func (c *Config) Client() (*CombinedConfig, error) {
 		return nil, err
 	}
 
+	if c.APIEndpoint == "" {
+		c.APIEndpoint = "https://api.digitalocean.com"
+	}
+
 	apiURL, err := url.Parse(c.APIEndpoint)
 	if err != nil {
 		return nil, err

--- a/digitalocean/sweeper_test.go
+++ b/digitalocean/sweeper_test.go
@@ -17,8 +17,20 @@ func sharedConfigForRegion(region string) (interface{}, error) {
 		return nil, fmt.Errorf("empty DIGITALOCEAN_TOKEN")
 	}
 
+	apiEndpoint := os.Getenv("DIGITALOCEAN_API_URL")
+	if apiEndpoint == "" {
+		apiEndpoint = "https://api.digitalocean.com"
+	}
+
+	spacesEndpoint := os.Getenv("SPACES_ENDPOINT_URL")
+	if spacesEndpoint == "" {
+		spacesEndpoint = "https://{{.Region}}.digitaloceanspaces.com"
+	}
+
 	config := Config{
-		Token: os.Getenv("DIGITALOCEAN_TOKEN"),
+		Token:             os.Getenv("DIGITALOCEAN_TOKEN"),
+		APIEndpoint:       apiEndpoint,
+		SpacesAPIEndpoint: spacesEndpoint,
 	}
 
 	// configures a default client for the region, using the above env vars


### PR DESCRIPTION
I noticed that the acceptance test sweeper has not been running. This was this was because it does not have access to the provider's `DefaultFunc` at runtime. In particular, `DIGITALOCEAN_API_URL` was not being correctly set.

This resolves that issue as well as adding sweepers for database clusters and Kubernetes clusters.