### PR TITLE
New Goreleaser and GitHub Actions-based release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+# This GitHub action will publish assets for release when a tag is created
+# that matches the pattern "v*" (ie. v0.1.0).
+#
+# Based on the configuration provided at:
+# https://github.com/hashicorp/terraform-provider-scaffolding
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ website/vendor
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/
+
+# Local release artifacts
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,50 @@
+# Based on the Goreleaser configuration provided at:
+# https://github.com/hashicorp/terraform-provider-scaffolding
+#
+# Artifacts must be produced matching the layout described at:
+# https://www.terraform.io/docs/registry/providers/publishing.html
+before:
+  hooks:
+    - go mod tidy
+builds:
+- env:
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  draft: true
+changelog:
+  skip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ services:
 - docker
 language: go
 go:
-  - "1.12.x"
-  - "1.13.x"
+  - "1.14.x"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ $ make testacc TESTARGS='-run=TestAccDigitalOceanDomain_Basic'
 ```
 
 For information about writing acceptance tests, see the main Terraform [contributing guide](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md#writing-acceptance-tests).
+
+Releasing the Provider
+----------------------
+
+This repository contains a GitHub Action configured to automatically build and
+publish assets for release when a tag is pushed that matches the pattern `v*`
+(ie. `v0.1.0`).
+
+A [Gorelaser](https://goreleaser.com/) configuration is provided that produce
+build artifacts matching the [layout required](https://www.terraform.io/docs/registry/providers/publishing.html#manually-preparing-a-release)
+to publish the provider in the Terraform Registry.
+
+Releases will as drafts. Once marked as published on the GitHub Releases page,
+they will become available via the Terraform Registry.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.14 (to build the provider plugin)
 
 Building The Provider
 ---------------------


### PR DESCRIPTION
This new release pipeline has two parts:

* A Gorelaser configuration that should produce build artifacts matching the [layout required](https://www.terraform.io/docs/registry/providers/publishing.html#manually-preparing-a-release) to publish the provider in the Terraform Registry.

* A GitHub Action that workflow should be configured to automatically build and publish assets for release when a tag is pushed that matches the pattern `v*` (ie. `v0.1.0`).

Both the Goreleaser configuration and the release workflow are essentially unchanged from the version provided at:

https://github.com/hashicorp/terraform-provider-scaffolding

in order to share a consistent approach to building and releasing with other providers.