### PR TITLE
registry credentials: Update default expiry and don't ignore error

### DIFF
--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
@@ -73,7 +73,10 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsRead(d *schema.Resour
 	d.Set("registry_name", reg.Name)
 	d.Set("write", write)
 
-	updateExpiredDockerCredentials(d, write, client)
+	err = updateExpiredDockerCredentials(d, write, client)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-const expirySecondsDefault = 2147483647 // Max value of signed 32 bit integer
+const expirySecondsDefault = 1576800000 // Max allowed by the API, roughly 50 years
 
 func resourceDigitalOceanContainerRegistryDockerCredentials() *schema.Resource {
 	return &schema.Resource{
@@ -37,7 +37,7 @@ func resourceDigitalOceanContainerRegistryDockerCredentials() *schema.Resource {
 			"expiry_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  expirySecondsDefault, // Relatively close to max value of Duration
+				Default:  expirySecondsDefault,
 			},
 			"docker_credentials": {
 				Type:      schema.TypeString,

--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials_test.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials_test.go
@@ -27,6 +27,33 @@ func TestAccDigitalOceanContainerRegistryDockerCredentials_Basic(t *testing.T) {
 						"digitalocean_container_registry_docker_credentials.foobar", "registry_name", "foobar"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry_docker_credentials.foobar", "write", "true"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_container_registry_docker_credentials.foobar", "docker_credentials"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_container_registry_docker_credentials.foobar", "credential_expiration_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanContainerRegistryDockerCredentials_withExpiry(t *testing.T) {
+	var reg godo.Registry
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanContainerRegistryDockerCredentialsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists("digitalocean_container_registry.foobar", &reg),
+					testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(&reg),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry_docker_credentials.foobar", "registry_name", "foobar"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry_docker_credentials.foobar", "write", "true"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry_docker_credentials.foobar", "expiry_seconds", "3600"),
 					resource.TestCheckResourceAttrSet(
@@ -97,6 +124,16 @@ func testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists(n string, 
 }
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_basic = `
+resource "digitalocean_container_registry" "foobar" {
+	name = "foobar"
+}
+
+resource "digitalocean_container_registry_docker_credentials" "foobar" {
+	registry_name = digitalocean_container_registry.foobar.name
+	write = true
+}`
+
+var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry = `
 resource "digitalocean_container_registry" "foobar" {
 	name = "foobar"
 }

--- a/website/docs/r/container_registry_docker_credentials.html.markdown
+++ b/website/docs/r/container_registry_docker_credentials.html.markdown
@@ -49,10 +49,10 @@ provider "docker" {
 
 ### Kubernetes Example
 
-Combined with the Kubernetes Provider's `kubernetes_secret` resource, you can 
+Combined with the Kubernetes Provider's `kubernetes_secret` resource, you can
 access the registry from inside your cluster:
 
-```
+```hcl
 resource "digitalocean_container_registry_docker_credentials" "example" {
   registry_name = "example"
 }


### PR DESCRIPTION
The API has placed a new upper limit on the accepted expiry seconds for registry credentials. The problem was hidden due to error response when calling `updateExpiredDockerCredentials` getting ignored.

Fixes: #466