### PR TITLE
Remove website-test from CI and Makefile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
 script:
 - make test
 - make vet
-- make website-test
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,5 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=digitalocean
 SLUG=do
 
@@ -45,18 +44,7 @@ test-compile:
 	go test -c $(TEST) $(TESTARGS)
 
 website:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME) PROVIDER_SLUG=$(SLUG)
+	@echo "Use this site to preview markdown rendering: https://registry.terraform.io/tools/doc-preview"
 
-website-test:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME) PROVIDER_SLUG=$(SLUG)
-
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website
 


### PR DESCRIPTION
As part of the repo transition, our docs have been removed from terraform.io They now redirect to our page in the registry.

https://github.com/hashicorp/terraform-website/commit/e832984aa69102de12938775cade42cce5b9bbc3

This leads to test failures in CI. These test can be removed as they are no longer relevant.

HashiCorp has provided a tool for previewing how markdown will render on the registry.