### PR TITLE
Add created to SortKeys

### DIFF
--- a/digitalocean/datasource_digitalocean_images.go
+++ b/digitalocean/datasource_digitalocean_images.go
@@ -35,6 +35,7 @@ func dataSourceDigitalOceanImages() *schema.Resource {
 			"size_gigabytes",
 			"status",
 			"error_message",
+			"created",
 		},
 		ResultAttributeName: "images",
 		FlattenRecord:       flattenDigitalOceanImage,


### PR DESCRIPTION
This resolves #477, See the issue for more detail.

* [The API returns `created_at`](https://developers.digitalocean.com/documentation/v2/#list-all-images)
* [DO's Go client converts that to `created`](https://github.com/digitalocean/terraform-provider-digitalocean/blob/master/vendor/github.com/digitalocean/godo/images.go#L46)
* [The TF docs use `created`](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/images)