### PR TITLE
fix broken links in docs

### DIFF
--- a/website/docs/d/droplets.html.md
+++ b/website/docs/d/droplets.html.md
@@ -14,7 +14,7 @@ If no filters are specified, all Droplets will be returned.
 This data source is useful if the Droplets in question are not managed by Terraform or you need to
 utilize any of the Droplets' data.
 
-Note: You can use the [`digitalocean_droplet`](/docs/providers/do/d/droplet.html) data source to obtain metadata
+Note: You can use the [`digitalocean_droplet`](droplet) data source to obtain metadata
 about a single Droplet if you already know the `id`, unique `name`, or unique `tag` to retrieve.
 
 ## Example Usage
@@ -61,10 +61,10 @@ data "digitalocean_droplets" "small-with-backups" {
 
 `filter` supports the following arguments:
 
-* `key` - (Required) Filter the Droplets by this key. This may be one of '`backups`, `created_at`, `disk`, `id`,
+* `key` - (Required) Filter the Droplets by this key. This may be one of `backups`, `created_at`, `disk`, `id`,
   `image`, `ipv4_address`, `ipv4_address_private`, `ipv6`, `ipv6_address`, `ipv6_address_private`, `locked`,
   `memory`, `monitoring`, `name`, `price_hourly`, `price_monthly`, `private_networking`, `region`, `size`,
-  `status`, `tags`, `urn`, `vcpus`, `volume_ids`, or `vpc_uuid`'.
+  `status`, `tags`, `urn`, `vcpus`, `volume_ids`, or `vpc_uuid`.
 
 * `values` - (Required) A list of values to match against the `key` field. Only retrieves Droplets
   where the `key` field takes on one or more of the values provided here.

--- a/website/docs/d/images.html.md
+++ b/website/docs/d/images.html.md
@@ -15,7 +15,7 @@ all images will be returned.
 This data source is useful if the image in question is not managed by Terraform or you need to utilize any
 of the image's data.
 
-Note: You can use the [`digitalocean_image`](/docs/providers/do/d/image.html) data source to obtain metadata
+Note: You can use the [`digitalocean_image`](image) data source to obtain metadata
 about a single image if you already know the `slug`, unique `name`, or `id` to retrieve.
 
 ## Example Usage

--- a/website/docs/d/projects.html.md
+++ b/website/docs/d/projects.html.md
@@ -12,7 +12,7 @@ Retrieve information about all DigitalOcean projects associated with an account,
 the ability to filter and sort the results. If no filters are specified, all projects
 will be returned.
 
-Note: You can use the [`digitalocean_project`](/docs/providers/do/d/project.html) data source to
+Note: You can use the [`digitalocean_project`](project) data source to
 obtain metadata about a single project if you already know the `id` to retrieve or the unique
 `name` of the project.
 

--- a/website/docs/d/regions.html.md
+++ b/website/docs/d/regions.html.md
@@ -11,7 +11,7 @@ description: |-
 Retrieve information about all supported DigitalOcean regions, with the ability to
 filter and sort the results. If no filters are specified, all regions will be returned.
 
-Note: You can use the [`digitalocean_region`](/docs/providers/do/d/region.html) data source
+Note: You can use the [`digitalocean_region`](region) data source
 to obtain metadata about a single region if you already know the `slug` to retrieve.
 
 ## Example Usage

--- a/website/docs/d/spaces_buckets.html.md
+++ b/website/docs/d/spaces_buckets.html.md
@@ -11,7 +11,7 @@ description: |-
 Get information on Spaces buckets for use in other resources, with the ability to filter and sort the results.
 If no filters are specified, all Spaces buckets will be returned.
 
-Note: You can use the [`digitalocean_spaces_bucket`](/docs/providers/do/d/spaces_bucket.html) data source to
+Note: You can use the [`digitalocean_spaces_bucket`](spaces_bucket) data source to
 obtain metadata about a single bucket if you already know its `name` and `region`.
 
 ## Example Usage


### PR DESCRIPTION
Fix some broken links in the docs by using a relative path to the linked page. Plus remove some extraneous quote marks.