### PR TITLE
add digitalocean_domains data source

### DIFF
--- a/digitalocean/datasource_digitalocean_domains.go
+++ b/digitalocean/datasource_digitalocean_domains.go
@@ -1,0 +1,27 @@
+package digitalocean
+
+import (
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/datalist"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceDigitalOceanDomains() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema: domainSchema(),
+		FilterKeys: []string{
+			"name",
+			"urn",
+			"ttl",
+		},
+		SortKeys: []string{
+			"name",
+			"urn",
+			"ttl",
+		},
+		ResultAttributeName: "domains",
+		GetRecords:          getDigitalOceanDomains,
+		FlattenRecord:       flattenDigitalOceanDomain,
+	}
+
+	return datalist.NewResource(dataListConfig)
+}

--- a/digitalocean/datasource_digitalocean_domains.go
+++ b/digitalocean/datasource_digitalocean_domains.go
@@ -7,17 +7,7 @@ import (
 
 func dataSourceDigitalOceanDomains() *schema.Resource {
 	dataListConfig := &datalist.ResourceConfig{
-		RecordSchema: domainSchema(),
-		FilterKeys: []string{
-			"name",
-			"urn",
-			"ttl",
-		},
-		SortKeys: []string{
-			"name",
-			"urn",
-			"ttl",
-		},
+		RecordSchema:        domainSchema(),
 		ResultAttributeName: "domains",
 		GetRecords:          getDigitalOceanDomains,
 		FlattenRecord:       flattenDigitalOceanDomain,

--- a/digitalocean/datasource_digitalocean_domains_test.go
+++ b/digitalocean/datasource_digitalocean_domains_test.go
@@ -1,0 +1,56 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanDomains_Basic(t *testing.T) {
+	name1 := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	name2 := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resourcesConfig := fmt.Sprintf(`
+resource "digitalocean_domain" "foo" {
+  name     = "%s"
+}
+
+resource "digitalocean_domain" "bar" {
+  name     = "%s"
+}
+`, name1, name2)
+
+	datasourceConfig := fmt.Sprintf(`
+data "digitalocean_domains" "result" {
+  filter {
+    key = "name"
+    values = ["%s"]
+  }
+}
+`, name1)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesConfig,
+			},
+			{
+				Config: resourcesConfig + datasourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_domains.result", "domains.#", "1"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_domains.result", "domains.0.name", "digitalocean_domain.foo", "name"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_domains.result", "domains.0.urn", "digitalocean_domain.foo", "urn"),
+					// skip checking `ttl` because digitalocean_domain does not expose the default TTL yet
+					//resource.TestCheckResourceAttrPair("data.digitalocean_domains.result", "domains.0.ttl", "digitalocean_domain.foo", "ttl"),
+				),
+			},
+			{
+				Config: resourcesConfig,
+			},
+		},
+	})
+}

--- a/digitalocean/domains.go
+++ b/digitalocean/domains.go
@@ -1,0 +1,74 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func domainSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Description: "name of the domain",
+		},
+		"urn": {
+			Type:        schema.TypeString,
+			Description: "the uniform resource name for the domain",
+		},
+		"ttl": {
+			Type:        schema.TypeInt,
+			Description: "ttl of the domain",
+		},
+	}
+}
+
+func getDigitalOceanDomains(meta interface{}) ([]interface{}, error) {
+	client := meta.(*CombinedConfig).godoClient()
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	var allDomains []interface{}
+
+	for {
+		domains, resp, err := client.Domains.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving domains: %s", err)
+		}
+
+		for _, domain := range domains {
+			allDomains = append(allDomains, domain)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving domains: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allDomains, nil
+}
+
+func flattenDigitalOceanDomain(rawDomain, meta interface{}) (map[string]interface{}, error) {
+	domain := rawDomain.(godo.Domain)
+
+	flattenedDomain := map[string]interface{}{
+		"name": domain.Name,
+		"urn":  domain.URN(),
+		"ttl":  domain.TTL,
+	}
+
+	return flattenedDomain, nil
+}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -49,6 +49,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_container_registry":    dataSourceDigitalOceanContainerRegistry(),
 			"digitalocean_database_cluster":      dataSourceDigitalOceanDatabaseCluster(),
 			"digitalocean_domain":                dataSourceDigitalOceanDomain(),
+			"digitalocean_domains":               dataSourceDigitalOceanDomains(),
 			"digitalocean_droplet":               dataSourceDigitalOceanDroplet(),
 			"digitalocean_droplets":              dataSourceDigitalOceanDroplets(),
 			"digitalocean_droplet_snapshot":      dataSourceDigitalOceanDropletSnapshot(),

--- a/website/docs/d/domains.html.md
+++ b/website/docs/d/domains.html.md
@@ -1,0 +1,60 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_domains"
+sidebar_current: "docs-do-datasource-domains"
+description: |-
+  Retrieve information on Domains.
+---
+
+# digitalocean_droplets
+
+Get information on domains for use in other resources, with the ability to filter and sort the results.
+If no filters are specified, all domains will be returned.
+
+This data source is useful if the domains in question are not managed by Terraform or you need to
+utilize any of the domains' data.
+
+Note: You can use the [`digitalocean_domain`](domain) data source to obtain metadata
+about a single domain if you already know the `name`.
+
+## Example Usage
+
+Use the `filter` block with a `key` string and `values` list to filter domains.
+
+```hcl
+data "digitalocean_domains" "ttl300" {
+  filter {
+    key = "ttl"
+    values = ["300"]
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+
+`filter` supports the following arguments:
+
+* `key` - (Required) Filter the domains by this key. This may be one of `name`, `urn`, and `ttl`.
+
+* `values` - (Required) A list of values to match against the `key` field. Only retrieves domains
+  where the `key` field takes on one or more of the values provided here.
+
+`sort` supports the following arguments:
+
+* `key` - (Required) Sort the domains by this key. This may be one of `name`, `urn`, and `ttl`.
+
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
+
+## Attributes Reference
+
+* `domains` - A list of domains satisfying any `filter` and `sort` criteria. Each domain has the following attributes:  
+
+  - `name` - (Required) The name of the domain.
+  - `ttl`-  The TTL of the domain.
+  - `urn` - The uniform resource name of the domain


### PR DESCRIPTION
Add a `digitalocean_domains` data source as the list version of `digitalocean_domain`. This data source is not as useful it could be since `datalist` does not support regex or substring matching yet.