### PR TITLE
Use certificate name as primary identifier instead of ID

### DIFF
--- a/digitalocean/datasource_digitalocean_certificate.go
+++ b/digitalocean/datasource_digitalocean_certificate.go
@@ -102,7 +102,7 @@ func findCertificateByName(client *godo.Client, name string) (*godo.Certificate,
 			return nil, nil
 		}
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving ssh keys: %s", err)
+			return nil, fmt.Errorf("Error retrieving certificates: %s", err)
 		}
 
 		for _, cert := range certs {
@@ -117,7 +117,7 @@ func findCertificateByName(client *godo.Client, name string) (*godo.Certificate,
 
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving ssh keys: %s", err)
+			return nil, fmt.Errorf("Error retrieving certificates: %s", err)
 		}
 
 		opts.Page = page + 1

--- a/digitalocean/datasource_digitalocean_certificate.go
+++ b/digitalocean/datasource_digitalocean_certificate.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -21,6 +22,17 @@ func dataSourceDigitalOceanCertificate() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			// computed attributes
+
+			// When the certificate type is lets_encrypt, the certificate
+			// ID will change when it's renewed, so we have to rely on the
+			// certificate name as the primary identifier instead.
+			// We include the UUID as another computed field for use in the
+			// short-term refresh function that waits for it to be ready.
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "uuid of the certificate",
+			},
 			"type": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -54,46 +66,18 @@ func dataSourceDigitalOceanCertificate() *schema.Resource {
 func dataSourceDigitalOceanCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
+	// When the certificate type is lets_encrypt, the certificate
+	// ID will change when it's renewed, so we have to rely on the
+	// certificate name as the primary identifier instead.
 	name := d.Get("name").(string)
-
-	opts := &godo.ListOptions{
-		Page:    1,
-		PerPage: 200,
-	}
-
-	certList := []godo.Certificate{}
-
-	for {
-		certs, resp, err := client.Certificates.List(context.Background(), opts)
-
-		if err != nil {
-			return fmt.Errorf("Error retrieving ssh keys: %s", err)
-		}
-
-		for _, cert := range certs {
-			certList = append(certList, cert)
-		}
-
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return fmt.Errorf("Error retrieving ssh keys: %s", err)
-		}
-
-		opts.Page = page + 1
-	}
-
-	cert, err := findCertificateByName(certList, name)
-
+	cert, err := findCertificateByName(client, name)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(cert.ID)
+	d.SetId(cert.Name)
 	d.Set("name", cert.Name)
+	d.Set("uuid", cert.ID)
 	d.Set("type", cert.Type)
 	d.Set("state", cert.State)
 	d.Set("not_after", cert.NotAfter)
@@ -106,18 +90,38 @@ func dataSourceDigitalOceanCertificateRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func findCertificateByName(certs []godo.Certificate, name string) (*godo.Certificate, error) {
-	results := make([]godo.Certificate, 0)
-	for _, v := range certs {
-		if v.Name == name {
-			results = append(results, v)
+func findCertificateByName(client *godo.Client, name string) (*godo.Certificate, error) {
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		certs, resp, err := client.Certificates.List(context.Background(), opts)
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
 		}
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving ssh keys: %s", err)
+		}
+
+		for _, cert := range certs {
+			if cert.Name == name {
+				return &cert, nil
+			}
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving ssh keys: %s", err)
+		}
+
+		opts.Page = page + 1
 	}
-	if len(results) == 1 {
-		return &results[0], nil
-	}
-	if len(results) == 0 {
-		return nil, fmt.Errorf("no certificate found with name %s", name)
-	}
-	return nil, fmt.Errorf("too many certificate found with name %s (found %d, expected 1)", name, len(results))
+
+	return nil, fmt.Errorf("Certificate %s not found", name)
 }

--- a/digitalocean/datasource_digitalocean_certificate_test.go
+++ b/digitalocean/datasource_digitalocean_certificate_test.go
@@ -1,7 +1,6 @@
 package digitalocean
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -26,6 +25,8 @@ func TestAccDataSourceDigitalOceanCertificate_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanCertificateExists("data.digitalocean_certificate.foobar", &certificate),
 					resource.TestCheckResourceAttr(
+						"data.digitalocean_certificate.foobar", "id", name),
+					resource.TestCheckResourceAttr(
 						"data.digitalocean_certificate.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_certificate.foobar", "type", "custom"),
@@ -49,14 +50,9 @@ func testAccCheckDataSourceDigitalOceanCertificateExists(n string, certificate *
 
 		client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 
-		foundCertificate, _, err := client.Certificates.Get(context.Background(), rs.Primary.ID)
-
+		foundCertificate, err := findCertificateByName(client, rs.Primary.ID)
 		if err != nil {
 			return err
-		}
-
-		if foundCertificate.ID != rs.Primary.ID {
-			return fmt.Errorf("Certificate not found")
 		}
 
 		*certificate = *foundCertificate

--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -258,7 +258,12 @@ func dataSourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("[DEBUG] Error setting Load Balancer healthcheck - error: %#v", err)
 	}
 
-	if err := d.Set("forwarding_rule", flattenForwardingRules(loadbalancer.ForwardingRules)); err != nil {
+	forwardingRules, err := flattenForwardingRules(client, loadbalancer.ForwardingRules)
+	if err != nil {
+		return fmt.Errorf("[DEBUG] Error building Load Balancer forwarding rules - error: %#v", err)
+	}
+
+	if err := d.Set("forwarding_rule", forwardingRules); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting Load Balancer forwarding_rule - error: %#v", err)
 	}
 

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -13,13 +13,12 @@ import (
 )
 
 func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
 	expectedURNRegEx, _ := regexp.Compile(`do:loadbalancer:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -64,11 +63,10 @@ func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
 }
 
 func TestAccDataSourceDigitalOceanLoadBalancer_multipleRules(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rName := randomTestName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,

--- a/digitalocean/resource_digitalocean_cdn.go
+++ b/digitalocean/resource_digitalocean_cdn.go
@@ -12,20 +12,6 @@ import (
 )
 
 func resourceDigitalOceanCDN() *schema.Resource {
-	cdnV1Schema := map[string]*schema.Schema{
-		"certificate_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-	}
-	for k, v := range resourceDigitalOceanCDNv0().Schema {
-		cdnV1Schema[k] = v
-	}
-
-	cdnV1Schema["certificate_id"].Computed = true
-	cdnV1Schema["certificate_id"].Deprecated = "Certificate IDs may change, for example when a Let's Encrypt certificate is auto-renewed. Please specify 'certificate_name' instead."
-
 	return &schema.Resource{
 		Create: resourceDigitalOceanCDNCreate,
 		Read:   resourceDigitalOceanCDNRead,
@@ -44,8 +30,26 @@ func resourceDigitalOceanCDN() *schema.Resource {
 			},
 		},
 
-		Schema: cdnV1Schema,
+		Schema: resourceDigitalOceanCDNv1(),
 	}
+}
+
+func resourceDigitalOceanCDNv1() map[string]*schema.Schema {
+	cdnV1Schema := map[string]*schema.Schema{
+		"certificate_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+	}
+
+	for k, v := range resourceDigitalOceanCDNv0().Schema {
+		cdnV1Schema[k] = v
+	}
+	cdnV1Schema["certificate_id"].Computed = true
+	cdnV1Schema["certificate_id"].Deprecated = "Certificate IDs may change, for example when a Let's Encrypt certificate is auto-renewed. Please specify 'certificate_name' instead."
+
+	return cdnV1Schema
 }
 
 func resourceDigitalOceanCDNv0() *schema.Resource {

--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -13,6 +13,28 @@ import (
 )
 
 func resourceDigitalOceanCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanCertificateCreate,
+		Read:   resourceDigitalOceanCertificateRead,
+		Delete: resourceDigitalOceanCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: resourceDigitalOceanCertificateV1(),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceDigitalOceanCertificateV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: migrateCertificateStateV0toV1,
+				Version: 0,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanCertificateV1() map[string]*schema.Schema {
 	certificateV1Schema := map[string]*schema.Schema{
 		// Note that this UUID will change on auto-renewal of a
 		// lets_encrypt certificate.
@@ -26,25 +48,7 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 		certificateV1Schema[k] = v
 	}
 
-	return &schema.Resource{
-		Create: resourceDigitalOceanCertificateCreate,
-		Read:   resourceDigitalOceanCertificateRead,
-		Delete: resourceDigitalOceanCertificateDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-
-		Schema: certificateV1Schema,
-
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceDigitalOceanCertificateV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: migrateCertificateStateV0toV1,
-				Version: 0,
-			},
-		},
-	}
+	return certificateV1Schema
 }
 
 func resourceDigitalOceanCertificateV0() *schema.Resource {

--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -55,6 +56,34 @@ func testSweepCertificate(region string) error {
 	}
 
 	return nil
+}
+
+func testCertificateStateDataV0() map[string]interface{} {
+	return map[string]interface{}{
+		"name": "test",
+		"id":   "aaa-bbb-123-ccc",
+	}
+}
+
+func testCertificateStateDataV1() map[string]interface{} {
+	v0 := testCertificateStateDataV0()
+	return map[string]interface{}{
+		"name": v0["name"],
+		"uuid": v0["id"],
+		"id":   v0["name"],
+	}
+}
+
+func TestResourceExampleInstanceStateUpgradeV0(t *testing.T) {
+	expected := testCertificateStateDataV1()
+	actual, err := migrateCertificateStateV0toV1(testCertificateStateDataV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", actual, expected)
+	}
 }
 
 func TestAccDigitalOceanCertificate_Basic(t *testing.T) {

--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -58,13 +58,12 @@ func testSweepCertificate(region string) error {
 }
 
 func TestAccDigitalOceanCertificate_Basic(t *testing.T) {
-	t.Parallel()
 	var cert godo.Certificate
 	rInt := acctest.RandInt()
 	name := fmt.Sprintf("certificate-%d", rInt)
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := generateTestCertMaterial(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanCertificateDestroy,
@@ -90,11 +89,10 @@ func TestAccDigitalOceanCertificate_Basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanCertificate_ExpectedErrors(t *testing.T) {
-	t.Parallel()
 	rInt := acctest.RandInt()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := generateTestCertMaterial(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanCertificateDestroy,

--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -58,6 +58,7 @@ func testSweepCertificate(region string) error {
 }
 
 func TestAccDigitalOceanCertificate_Basic(t *testing.T) {
+	t.Parallel()
 	var cert godo.Certificate
 	rInt := acctest.RandInt()
 	name := fmt.Sprintf("certificate-%d", rInt)
@@ -89,6 +90,7 @@ func TestAccDigitalOceanCertificate_Basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanCertificate_ExpectedErrors(t *testing.T) {
+	t.Parallel()
 	rInt := acctest.RandInt()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := generateTestCertMaterial(t)
 

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -337,7 +337,7 @@ func migrateLoadBalancerStateV0toV1(instance *terraform.InstanceState, meta inte
 }
 
 func buildLoadBalancerRequest(client *godo.Client, d *schema.ResourceData) (*godo.LoadBalancerRequest, error) {
-	forwardingRules, err := expandForwardingRules(client, d.Get("forwarding_rule").([]interface{}))
+	forwardingRules, err := expandForwardingRules(client, d.Get("forwarding_rule").(*schema.Set).List())
 	if err != nil {
 		return nil, err
 	}

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -94,9 +94,16 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.IntBetween(1, 65535),
 						},
+						"certificate_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.NoZeroValues,
+						},
 						"certificate_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
+							Deprecated:   "Certificate IDs may change, for example when a Let's Encrypt certificate is auto-renewed. Please specify 'certificate_name' instead.",
 							ValidateFunc: validation.NoZeroValues,
 						},
 						"tls_passthrough": {
@@ -330,7 +337,9 @@ func migrateLoadBalancerStateV0toV1(instance *terraform.InstanceState, meta inte
 		}
 
 		certIDKey := fmt.Sprintf("forwarding_rule.%d.certificate_id", i)
+		certNameKey := fmt.Sprintf("forwarding_rule.%d.certificate_name", i)
 		instance.Attributes[certIDKey] = cert.Name
+		instance.Attributes[certNameKey] = cert.Name
 	}
 
 	return instance, nil

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -51,13 +51,12 @@ func testSweepLoadbalancer(region string) error {
 }
 
 func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
 	expectedURNRegEx, _ := regexp.Compile(`do:loadbalancer:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -103,11 +102,10 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -181,11 +179,10 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -223,11 +220,10 @@ func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -273,11 +269,10 @@ func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -323,12 +318,11 @@ func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := generateTestCertMaterial(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -354,11 +348,10 @@ func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_multipleRules(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rName := randomTestName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
@@ -396,11 +389,10 @@ func TestAccDigitalOceanLoadbalancer_multipleRules(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_WithVPC(t *testing.T) {
-	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	lbName := randomTestName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,

--- a/website/docs/d/certificate.html.md
+++ b/website/docs/d/certificate.html.md
@@ -35,7 +35,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id`: The ID of the certificate.
+* `id`: The unique name of the certificate.
+* `uuid`: The ID of the certificate.
 * `type`: The type of the certificate.
 * `state`: the current state of the certificate.
 * `domains`: Domains for which the certificate was issued.

--- a/website/docs/r/cdn.html.markdown
+++ b/website/docs/r/cdn.html.markdown
@@ -52,9 +52,9 @@ resource "digitalocean_certificate" "cert" {
 
 # Add a CDN endpoint with a custom sub-domain to the Spaces Bucket
 resource "digitalocean_cdn" "mycdn" {
-  origin         = digitalocean_spaces_bucket.mybucket.bucket_domain_name
-  custom_domain  = "static.example.com"
-  certificate_id = digitalocean_certificate.cert.id
+  origin           = digitalocean_spaces_bucket.mybucket.bucket_domain_name
+  custom_domain    = "static.example.com"
+  certificate_name = digitalocean_certificate.cert.name
 }
 ```
 
@@ -64,7 +64,8 @@ The following arguments are supported:
 
 * `origin` - (Required) The fully qualified domain name, (FQDN) for a Space.
 * `ttl` - (Optional) The time to live for the CDN Endpoint, in seconds. Default is 3600 seconds.
-* `certificate_id`- (Optional) The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+* `certificate_name`- (Optional) The unique name of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+* `certificate_id`- (Optional) **Deprecated** The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
 * `custom_domain` - (Optional) The fully qualified domain name (FQDN) of the custom subdomain used with the CDN Endpoint.
 
 ## Attributes Reference
@@ -76,6 +77,7 @@ The following attributes are exported:
 * `endpoint` - The fully qualified domain name (FQDN) from which the CDN-backed content is served.
 * `created_at` - The date and time when the CDN Endpoint was created.
 * `ttl` - The time to live for the CDN Endpoint, in seconds.
+* `certificate_name`- The unique name of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
 * `certificate_id`- The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
 * `custom_domain` - The fully qualified domain name (FQDN) of the custom subdomain used with the CDN Endpoint.
 

--- a/website/docs/r/certificate.html.markdown
+++ b/website/docs/r/certificate.html.markdown
@@ -64,7 +64,7 @@ resource "digitalocean_loadbalancer" "public" {
     target_port     = 80
     target_protocol = "http"
 
-    certificate_id = digitalocean_certificate.cert.id
+    certificate_name = digitalocean_certificate.cert.name
   }
 }
 ```
@@ -92,7 +92,8 @@ DigitalOcean's DNS. Only valid when type is `lets_encrypt`.
 
 The following attributes are exported:
 
-* `id` - The unique ID of the certificate
+* `id` - The unique name of the certificate
+* `uuid` - The UUID of the certificate
 * `name` - The name of the certificate
 * `not_after` - The expiration date of the certificate
 * `sha1_fingerprint` - The SHA-1 fingerprint of the certificate
@@ -100,8 +101,8 @@ The following attributes are exported:
 
 ## Import
 
-Certificates can be imported using the certificate `id`, e.g.
+Certificates can be imported using the certificate `name`, e.g.
 
 ```
-terraform import digitalocean_certificate.mycertificate 892071a0-bb95-49bc-8021-3afd67a210bf
+terraform import digitalocean_certificate.mycertificate cert-01
 ```

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -77,7 +77,7 @@ resource "digitalocean_loadbalancer" "public" {
     target_port = 80
     target_protocol = "http"
 
-    certificate_id = digitalocean_certificate.cert.id
+    certificate_name = digitalocean_certificate.cert.name
   }
 
   healthcheck {
@@ -121,7 +121,8 @@ the backend service. Default value is `false`.
 * `entry_port` - (Required) An integer representing the port on which the Load Balancer instance will listen.
 * `target_protocol` - (Required) The protocol used for traffic from the Load Balancer to the backend Droplets. The possible values are: `http`, `https`, `http2` or `tcp`.
 * `target_port` - (Required) An integer representing the port on the backend Droplets to which the Load Balancer will send traffic.
-* `certificate_id` - (Optional) The ID of the TLS certificate to be used for SSL termination.
+* `certificate_name` - (Optional) The unique name of the TLS certificate to be used for SSL termination.
+* `certificate_id` - (Optional) **Deprecated** The ID of the TLS certificate to be used for SSL termination.
 * `tls_passthrough` - (Optional) A boolean value indicating whether SSL encrypted traffic will be passed through to the backend Droplets. The default value is `false`.
 
 `sticky_sessions` supports the following:


### PR DESCRIPTION
This builds on the work originally done by @snormore in https://github.com/digitalocean/terraform-provider-digitalocean/pull/320 making `name` the primary identifier for a certificate. This is needed as when the certificate type is lets_encrypt, the certificate ID will change on renewal (after 3 months). 

This goes further than that PR in a few ways:

* It uses v0.12 Terraform SDK [state migrations](https://www.terraform.io/docs/extend/resources/state-migration.html#terraform-v0-12-sdk-state-migrations) rather than the older v0.11 `StateUpgrader`.
* It handles the changes needed in the `digitalocean_cdn` resource as well as the `digitalocean_loadbalancer` and `digitalocean_certificate` resources.
* For  `digitalocean_cdn` and `digitalocean_loadbalancer`, it deprecates the `certificate_id` attribute in favor of `certificate_name` for clarity.

```
$ make testacc TESTARGS="-run='TestAccDigitalOceanLoadbalancer|TestAccDigitalOceanCertificate|TestAccDigitalOceanCDN' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanLoadbalancer|TestAccDigitalOceanCertificate|TestAccDigitalOceanCDN' -parallel=20 -count=1 -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanCertificate_importBasic
--- PASS: TestAccDigitalOceanCertificate_importBasic (12.93s)
=== RUN   TestAccDigitalOceanCDN_Create
--- PASS: TestAccDigitalOceanCDN_Create (28.78s)
=== RUN   TestAccDigitalOceanCDN_Create_with_TTL
--- PASS: TestAccDigitalOceanCDN_Create_with_TTL (27.75s)
=== RUN   TestAccDigitalOceanCDN_Create_and_Update
--- PASS: TestAccDigitalOceanCDN_Create_and_Update (32.77s)
=== RUN   TestAccDigitalOceanCertificate_Basic
=== PAUSE TestAccDigitalOceanCertificate_Basic
=== RUN   TestAccDigitalOceanCertificate_ExpectedErrors
=== PAUSE TestAccDigitalOceanCertificate_ExpectedErrors
=== RUN   TestAccDigitalOceanLoadbalancer_Basic
=== PAUSE TestAccDigitalOceanLoadbalancer_Basic
=== RUN   TestAccDigitalOceanLoadbalancer_Updated
=== PAUSE TestAccDigitalOceanLoadbalancer_Updated
=== RUN   TestAccDigitalOceanLoadbalancer_dropletTag
=== PAUSE TestAccDigitalOceanLoadbalancer_dropletTag
=== RUN   TestAccDigitalOceanLoadbalancer_minimal
=== PAUSE TestAccDigitalOceanLoadbalancer_minimal
=== RUN   TestAccDigitalOceanLoadbalancer_stickySessions
=== PAUSE TestAccDigitalOceanLoadbalancer_stickySessions
=== RUN   TestAccDigitalOceanLoadbalancer_sslTermination
=== PAUSE TestAccDigitalOceanLoadbalancer_sslTermination
=== RUN   TestAccDigitalOceanLoadbalancer_sslCertByName
=== PAUSE TestAccDigitalOceanLoadbalancer_sslCertByName
=== RUN   TestAccDigitalOceanLoadbalancer_multipleRules
=== PAUSE TestAccDigitalOceanLoadbalancer_multipleRules
=== RUN   TestAccDigitalOceanLoadbalancer_WithVPC
=== PAUSE TestAccDigitalOceanLoadbalancer_WithVPC
=== CONT  TestAccDigitalOceanCertificate_Basic
=== CONT  TestAccDigitalOceanLoadbalancer_stickySessions
=== CONT  TestAccDigitalOceanLoadbalancer_multipleRules
=== CONT  TestAccDigitalOceanLoadbalancer_minimal
=== CONT  TestAccDigitalOceanLoadbalancer_Basic
=== CONT  TestAccDigitalOceanLoadbalancer_dropletTag
=== CONT  TestAccDigitalOceanCertificate_ExpectedErrors
=== CONT  TestAccDigitalOceanLoadbalancer_sslCertByName
=== CONT  TestAccDigitalOceanLoadbalancer_WithVPC
=== CONT  TestAccDigitalOceanLoadbalancer_sslTermination
=== CONT  TestAccDigitalOceanLoadbalancer_Updated
--- PASS: TestAccDigitalOceanCertificate_ExpectedErrors (0.16s)
--- PASS: TestAccDigitalOceanCertificate_Basic (12.62s)
--- PASS: TestAccDigitalOceanLoadbalancer_multipleRules (70.09s)
--- PASS: TestAccDigitalOceanLoadbalancer_sslTermination (83.53s)
--- PASS: TestAccDigitalOceanLoadbalancer_sslCertByName (103.48s)
--- PASS: TestAccDigitalOceanLoadbalancer_dropletTag (115.16s)
--- PASS: TestAccDigitalOceanLoadbalancer_minimal (134.06s)
--- PASS: TestAccDigitalOceanLoadbalancer_stickySessions (134.09s)
--- PASS: TestAccDigitalOceanLoadbalancer_Basic (134.34s)
--- PASS: TestAccDigitalOceanLoadbalancer_WithVPC (135.01s)
--- PASS: TestAccDigitalOceanLoadbalancer_Updated (160.71s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    263.117s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       0.006s [no tests to run]
```
 
Closes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/318