### PR TITLE
add digitalocean_records data source

### DIFF
--- a/digitalocean/datasource_digitalocean_droplet.go
+++ b/digitalocean/datasource_digitalocean_droplet.go
@@ -50,7 +50,7 @@ func dataSourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceDa
 
 		foundDroplet = *droplet
 	} else if v, ok := d.GetOk("tag"); ok {
-		dropletList, err := getDigitalOceanDroplets(meta)
+		dropletList, err := getDigitalOceanDroplets(meta, nil)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -62,7 +62,7 @@ func dataSourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceDa
 
 		foundDroplet = *droplet
 	} else if v, ok := d.GetOk("name"); ok {
-		dropletList, err := getDigitalOceanDroplets(meta)
+		dropletList, err := getDigitalOceanDroplets(meta, nil)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -78,7 +78,7 @@ func dataSourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error: specify either a name, tag, or id to use to look up the droplet")
 	}
 
-	flattenedDroplet, err := flattenDigitalOceanDroplet(foundDroplet, meta)
+	flattenedDroplet, err := flattenDigitalOceanDroplet(foundDroplet, meta, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/digitalocean/datasource_digitalocean_image.go
+++ b/digitalocean/datasource_digitalocean_image.go
@@ -108,7 +108,7 @@ func dataSourceDigitalOceanImageRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("Illegal state: one of id, name, or slug must be set")
 	}
 
-	flattenedImage, err := flattenDigitalOceanImage(*foundImage, meta)
+	flattenedImage, err := flattenDigitalOceanImage(*foundImage, meta, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -38,7 +38,7 @@ func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceDa
 		}
 		foundProject = thisProject
 	} else if name, ok := d.GetOk("name"); ok {
-		projects, err := getDigitalOceanProjects(meta)
+		projects, err := getDigitalOceanProjects(meta, nil)
 		if err != nil {
 			return diag.Errorf("Unable to load projects: %s", err)
 		}
@@ -70,7 +70,7 @@ func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("No project found.")
 	}
 
-	flattenedProject, err := flattenDigitalOceanProject(*foundProject, meta)
+	flattenedProject, err := flattenDigitalOceanProject(*foundProject, meta, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/digitalocean/datasource_digitalocean_records.go
+++ b/digitalocean/datasource_digitalocean_records.go
@@ -1,0 +1,23 @@
+package digitalocean
+
+import (
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/datalist"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDigitalOceanRecords() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema:        recordsSchema(),
+		ResultAttributeName: "records",
+		ExtraQuerySchema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+		FlattenRecordWithExtraQuery: flattenDigitalOceanRecord,
+		GetRecordsWithExtraQuery:    getDigitalOceanRecords,
+	}
+
+	return datalist.NewResource(dataListConfig)
+}

--- a/digitalocean/datasource_digitalocean_records.go
+++ b/digitalocean/datasource_digitalocean_records.go
@@ -15,8 +15,8 @@ func dataSourceDigitalOceanRecords() *schema.Resource {
 				Required: true,
 			},
 		},
-		FlattenRecordWithExtraQuery: flattenDigitalOceanRecord,
-		GetRecordsWithExtraQuery:    getDigitalOceanRecords,
+		FlattenRecord: flattenDigitalOceanRecord,
+		GetRecords:    getDigitalOceanRecords,
 	}
 
 	return datalist.NewResource(dataListConfig)

--- a/digitalocean/datasource_digitalocean_records_test.go
+++ b/digitalocean/datasource_digitalocean_records_test.go
@@ -53,6 +53,7 @@ data "digitalocean_records" "result" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.digitalocean_records.result", "records.#", "1"),
 					resource.TestCheckResourceAttr("data.digitalocean_records.result", "records.0.domain", name1),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.id", "digitalocean_record.www", "id"),
 					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.name", "digitalocean_record.www", "name"),
 					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.type", "digitalocean_record.www", "type"),
 					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.value", "digitalocean_record.www", "value"),

--- a/digitalocean/datasource_digitalocean_records_test.go
+++ b/digitalocean/datasource_digitalocean_records_test.go
@@ -1,0 +1,69 @@
+package digitalocean
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccDataSourceDigitalOceanRecords_Basic(t *testing.T) {
+	name1 := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resourcesConfig := fmt.Sprintf(`
+resource "digitalocean_domain" "foo" {
+  name = "%s"
+}
+
+resource "digitalocean_record" "mail" {
+  name = "mail"
+  domain = digitalocean_domain.foo.name
+  type = "MX"
+  priority = 10
+  value = "mail.example.com."
+}
+
+resource "digitalocean_record" "www" {
+  name = "www"
+  domain = digitalocean_domain.foo.name
+  type = "A"
+  value = "192.168.1.1"
+}
+`, name1)
+
+	datasourceConfig := fmt.Sprintf(`
+data "digitalocean_records" "result" {
+  domain = "%s"
+  filter {
+    key = "type"
+    values = ["A"]
+  }
+}
+`, name1)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesConfig,
+			},
+			{
+				Config: resourcesConfig + datasourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_records.result", "records.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_records.result", "records.0.domain", name1),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.name", "digitalocean_record.www", "name"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.type", "digitalocean_record.www", "type"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.value", "digitalocean_record.www", "value"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.priority", "digitalocean_record.www", "priority"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.port", "digitalocean_record.www", "port"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.ttl", "digitalocean_record.www", "ttl"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.weight", "digitalocean_record.www", "weight"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.flags", "digitalocean_record.www", "flags"),
+					resource.TestCheckResourceAttrPair("data.digitalocean_records.result", "records.0.tag", "digitalocean_record.www", "tag"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -42,7 +42,7 @@ func dataSourceDigitalOceanRegion() *schema.Resource {
 }
 
 func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	regions, err := getDigitalOceanRegions(meta)
+	regions, err := getDigitalOceanRegions(meta, nil)
 	if err != nil {
 		return diag.Errorf("Unable to load regions: %s", err)
 	}
@@ -61,7 +61,7 @@ func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("Region does not exist: %s", slug)
 	}
 
-	flattenedRegion, err := flattenRegion(*regionForSlug, meta)
+	flattenedRegion, err := flattenRegion(*regionForSlug, meta, nil)
 	if err != nil {
 		return nil
 	}

--- a/digitalocean/datasource_digitalocean_sizes.go
+++ b/digitalocean/datasource_digitalocean_sizes.go
@@ -58,7 +58,7 @@ func dataSourceDigitalOceanSizes() *schema.Resource {
 	return datalist.NewResource(dataListConfig)
 }
 
-func getDigitalOceanSizes(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanSizes(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	sizes := []interface{}{}
@@ -93,7 +93,7 @@ func getDigitalOceanSizes(meta interface{}) ([]interface{}, error) {
 	return sizes, nil
 }
 
-func flattenDigitalOceanSize(size, meta interface{}) (map[string]interface{}, error) {
+func flattenDigitalOceanSize(size, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	s := size.(godo.Size)
 
 	flattenedSize := map[string]interface{}{}

--- a/digitalocean/datasource_digitalocean_spaces_bucket.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket.go
@@ -60,7 +60,7 @@ func dataSourceDigitalOceanSpacesBucketRead(ctx context.Context, d *schema.Resou
 		region: region,
 	}
 
-	flattenedBucket, err := flattenSpacesBucket(&metadata, meta)
+	flattenedBucket, err := flattenSpacesBucket(&metadata, meta, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/digitalocean/datasource_digitalocean_tags.go
+++ b/digitalocean/datasource_digitalocean_tags.go
@@ -42,7 +42,7 @@ func dataSourceDigitalOceanTags() *schema.Resource {
 	return datalist.NewResource(dataListConfig)
 }
 
-func getDigitalOceanTags(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanTags(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	tagsList := []interface{}{}
@@ -77,7 +77,7 @@ func getDigitalOceanTags(meta interface{}) ([]interface{}, error) {
 	return tagsList, nil
 }
 
-func flattenDigitalOceanTag(tag, meta interface{}) (map[string]interface{}, error) {
+func flattenDigitalOceanTag(tag, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	t := tag.(godo.Tag)
 
 	flattenedTag := map[string]interface{}{}

--- a/digitalocean/domains.go
+++ b/digitalocean/domains.go
@@ -25,7 +25,7 @@ func domainSchema() map[string]*schema.Schema {
 	}
 }
 
-func getDigitalOceanDomains(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanDomains(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.ListOptions{
@@ -61,7 +61,7 @@ func getDigitalOceanDomains(meta interface{}) ([]interface{}, error) {
 	return allDomains, nil
 }
 
-func flattenDigitalOceanDomain(rawDomain, meta interface{}) (map[string]interface{}, error) {
+func flattenDigitalOceanDomain(rawDomain, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	domain := rawDomain.(godo.Domain)
 
 	flattenedDomain := map[string]interface{}{

--- a/digitalocean/droplets.go
+++ b/digitalocean/droplets.go
@@ -113,7 +113,7 @@ func dropletSchema() map[string]*schema.Schema {
 	}
 }
 
-func getDigitalOceanDroplets(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanDroplets(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.ListOptions{
@@ -149,7 +149,7 @@ func getDigitalOceanDroplets(meta interface{}) ([]interface{}, error) {
 	return dropletList, nil
 }
 
-func flattenDigitalOceanDroplet(rawDroplet, meta interface{}) (map[string]interface{}, error) {
+func flattenDigitalOceanDroplet(rawDroplet, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	droplet := rawDroplet.(godo.Droplet)
 
 	flattenedDroplet := map[string]interface{}{

--- a/digitalocean/images.go
+++ b/digitalocean/images.go
@@ -77,7 +77,7 @@ func imageSchema() map[string]*schema.Schema {
 	}
 }
 
-func getDigitalOceanImages(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanImages(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 	return listDigitalOceanImages(client.Images.List)
 }
@@ -115,7 +115,7 @@ func listDigitalOceanImages(listImages imageListFunc) ([]interface{}, error) {
 	return allImages, nil
 }
 
-func flattenDigitalOceanImage(rawImage interface{}, meta interface{}) (map[string]interface{}, error) {
+func flattenDigitalOceanImage(rawImage interface{}, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	image, ok := rawImage.(godo.Image)
 	if !ok {
 		return nil, fmt.Errorf("Unable to convert to godo.Image")

--- a/digitalocean/projects.go
+++ b/digitalocean/projects.go
@@ -50,7 +50,7 @@ func projectSchema() map[string]*schema.Schema {
 	}
 }
 
-func getDigitalOceanProjects(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanProjects(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	var allProjects []interface{}
@@ -86,7 +86,7 @@ func getDigitalOceanProjects(meta interface{}) ([]interface{}, error) {
 	return allProjects, nil
 }
 
-func flattenDigitalOceanProject(rawProject interface{}, meta interface{}) (map[string]interface{}, error) {
+func flattenDigitalOceanProject(rawProject interface{}, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	project, ok := rawProject.(godo.Project)

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -62,6 +62,7 @@ func Provider() *schema.Provider {
 			"digitalocean_project":               dataSourceDigitalOceanProject(),
 			"digitalocean_projects":              dataSourceDigitalOceanProjects(),
 			"digitalocean_record":                dataSourceDigitalOceanRecord(),
+			"digitalocean_records":               dataSourceDigitalOceanRecords(),
 			"digitalocean_region":                dataSourceDigitalOceanRegion(),
 			"digitalocean_regions":               dataSourceDigitalOceanRegions(),
 			"digitalocean_sizes":                 dataSourceDigitalOceanSizes(),

--- a/digitalocean/records.go
+++ b/digitalocean/records.go
@@ -1,0 +1,113 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func recordsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"domain": {
+			Type:        schema.TypeString,
+			Description: "domain of the name record",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Description: "name of the record",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Description: "type of the name record",
+		},
+		"value": {
+			Type:        schema.TypeString,
+			Description: "name record data",
+		},
+		"priority": {
+			Type:        schema.TypeInt,
+			Description: "priority of the name record",
+		},
+		"port": {
+			Type:        schema.TypeInt,
+			Description: "port of the name record",
+		},
+		"ttl": {
+			Type:        schema.TypeInt,
+			Description: "ttl of the name record",
+		},
+		"weight": {
+			Type:        schema.TypeInt,
+			Description: "weight of the name record",
+		},
+		"flags": {
+			Type:        schema.TypeInt,
+			Description: "flags of the name record",
+		},
+		"tag": {
+			Type:        schema.TypeString,
+			Description: "tag of the name record",
+		},
+	}
+}
+
+func getDigitalOceanRecords(meta interface{}, d *schema.ResourceData) ([]interface{}, error) {
+	client := meta.(*CombinedConfig).godoClient()
+	domain := d.Get("domain").(string)
+
+	var allRecords []interface{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		records, resp, err := client.Domains.Records(context.Background(), domain, opts)
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving records: %s", err)
+		}
+
+		for _, record := range records {
+			allRecords = append(allRecords, record)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving projects: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allRecords, nil
+}
+
+func flattenDigitalOceanRecord(rawRecord interface{}, meta interface{}, d *schema.ResourceData) (map[string]interface{}, error) {
+	domain := d.Get("domain").(string)
+
+	record, ok := rawRecord.(godo.DomainRecord)
+	if !ok {
+		return nil, fmt.Errorf("unable to convert to godo.DomainRecord")
+	}
+
+	flattenedRecord := map[string]interface{}{
+		"domain":   domain,
+		"name":     record.Name,
+		"type":     record.Type,
+		"value":    record.Data,
+		"priority": record.Priority,
+		"port":     record.Port,
+		"ttl":      record.TTL,
+		"weight":   record.Weight,
+		"flags":    record.Flags,
+		"tag":      record.Tag,
+	}
+
+	return flattenedRecord, nil
+}

--- a/digitalocean/records.go
+++ b/digitalocean/records.go
@@ -56,9 +56,13 @@ func recordsSchema() map[string]*schema.Schema {
 	}
 }
 
-func getDigitalOceanRecords(meta interface{}, d *schema.ResourceData) ([]interface{}, error) {
+func getDigitalOceanRecords(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
-	domain := d.Get("domain").(string)
+
+	domain, ok := extra["domain"].(string)
+	if !ok {
+		return nil, fmt.Errorf("unable to find `domain` key from query data")
+	}
 
 	var allRecords []interface{}
 
@@ -92,8 +96,11 @@ func getDigitalOceanRecords(meta interface{}, d *schema.ResourceData) ([]interfa
 	return allRecords, nil
 }
 
-func flattenDigitalOceanRecord(rawRecord interface{}, meta interface{}, d *schema.ResourceData) (map[string]interface{}, error) {
-	domain := d.Get("domain").(string)
+func flattenDigitalOceanRecord(rawRecord interface{}, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
+	domain, ok := extra["domain"].(string)
+	if !ok {
+		return nil, fmt.Errorf("unable to find `domain` key from query data")
+	}
 
 	record, ok := rawRecord.(godo.DomainRecord)
 	if !ok {

--- a/digitalocean/records.go
+++ b/digitalocean/records.go
@@ -9,6 +9,10 @@ import (
 
 func recordsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeInt,
+			Description: "ID of the record",
+		},
 		"domain": {
 			Type:        schema.TypeString,
 			Description: "domain of the name record",
@@ -97,6 +101,7 @@ func flattenDigitalOceanRecord(rawRecord interface{}, meta interface{}, d *schem
 	}
 
 	flattenedRecord := map[string]interface{}{
+		"id":       record.ID,
 		"domain":   domain,
 		"name":     record.Name,
 		"type":     record.Type,

--- a/digitalocean/regions.go
+++ b/digitalocean/regions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func getDigitalOceanRegions(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanRegions(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
 	allRegions := []interface{}{}
@@ -44,7 +44,7 @@ func getDigitalOceanRegions(meta interface{}) ([]interface{}, error) {
 	return allRegions, nil
 }
 
-func flattenRegion(rawRegion, meta interface{}) (map[string]interface{}, error) {
+func flattenRegion(rawRegion, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	region := rawRegion.(godo.Region)
 
 	flattenedRegion := map[string]interface{}{}

--- a/digitalocean/spaces_buckets.go
+++ b/digitalocean/spaces_buckets.go
@@ -50,7 +50,7 @@ func getSpacesBucketsInRegion(meta interface{}, region string) ([]*s3.Bucket, er
 	return output.Buckets, nil
 }
 
-func getDigitalOceanBuckets(meta interface{}) ([]interface{}, error) {
+func getDigitalOceanBuckets(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	// The DigitalOcean API does not currently return what regions have Spaces available. Thus, this
 	// function hard-codes the regions in which Spaces operates.
 	//
@@ -78,7 +78,7 @@ func getDigitalOceanBuckets(meta interface{}) ([]interface{}, error) {
 	return buckets, nil
 }
 
-func flattenSpacesBucket(rawBucketMetadata, meta interface{}) (map[string]interface{}, error) {
+func flattenSpacesBucket(rawBucketMetadata, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
 	bucketMetadata := rawBucketMetadata.(*bucketMetadataStruct)
 
 	name := bucketMetadata.name

--- a/docs/data-sources/records.md
+++ b/docs/data-sources/records.md
@@ -1,0 +1,76 @@
+---
+page_title: "DigitalOcean: digitalocean_records"
+---
+
+# digitalocean_record
+
+Retrieve information about all DNS records within a domain, with the ability to filter and sort the results.
+If no filters are specified, all records will be returned.
+
+## Example Usage
+
+Get data for all MX records in a domain:
+
+```hcl
+data "digitalocean_records" "example" {
+  domain = "example.com"
+  filter {
+    key = "type"
+    values = ["MX"]
+  }
+}
+
+output "mail_servers" {
+  value = join(",", data.digitalocean_records.example.records)
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The domain name to search for DNS records
+
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+
+`filter` supports the following arguments:
+
+* `key` - (Required) Filter the projects by this key. This may be one of `domain`, `flags`, `name`, `port`,
+  `priority`, `tag`, `ttl`, `type`, `value`, or `weight`.
+  
+* `values` - (Required) A list of values to match against the `key` field. Only retrieves projects
+  where the `key` field takes on one or more of the values provided here.
+
+* `match_by` - (Optional) One of `exact` (default), `re`, or `substring`. For string-typed fields, specify `re` to
+  match by using the `values` as regular expressions, or specify `substring` to match by treating the `values` as
+  substrings to find within the string field.
+  
+* `all` - (Optional) Set to `true` to require that a field match all of the `values` instead of just one or more of
+  them. This is useful when matching against multi-valued fields such as lists or sets where you want to ensure
+  that all of the `values` are present in the list or set.
+
+`sort` supports the following arguments:
+
+* `key` - (Required) Sort the projects by this key. This may be one of `domain`, `flags`, `name`, `port`,
+  `priority`, `tag`, `ttl`, `type`, `value`, or `weight`.
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id`: The ID of the record.
+* `domain`: Domain of the DNS record.
+* `name`: The name of the DNS record.
+* `type`:	The type of the DNS record.
+* `value`:	Variable data depending on record type. For example, the "data" value for an A record would be the IPv4 address to which the domain will be mapped. For a CAA record, it would contain the domain name of the CA being granted permission to issue certificates.
+* `priority`:	The priority for SRV and MX records.
+* `port`:	The port for SRV records.
+* `ttl`: This value is the time to live for the record, in seconds. This defines the time frame that clients can cache queried information before a refresh should be requested.
+* `weight`:	The weight for SRV records.
+* `flags`: An unsigned integer between 0-255 used for CAA records.
+* `tag`: The parameter tag for CAA records.

--- a/internal/datalist/schema.go
+++ b/internal/datalist/schema.go
@@ -80,7 +80,7 @@ func NewResource(config *ResourceConfig) *schema.Resource {
 
 	return &schema.Resource{
 		ReadContext: dataListResourceRead(config),
-		Schema: datasourceSchema,
+		Schema:      datasourceSchema,
 	}
 }
 


### PR DESCRIPTION
Adds a `digitalocean_records` data source to access DNS records of a domain.

Note: This PR modifies the `datalist` package to support "extra queries." I've exposed that by having an alternate set of callbacks that take a `*schema.ResourceData`. It might be better to just port the existing datalist uses to take that argument and avoid having two sets of functions. Thoughts?
