### PR TITLE
port data sources and resources to use the context-related methods

### DIFF
--- a/digitalocean/datasource_digitalocean_account.go
+++ b/digitalocean/datasource_digitalocean_account.go
@@ -2,8 +2,8 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -50,12 +50,12 @@ func dataSourceDigitalOceanAccount() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	account, _, err := client.Account.Get(context.Background())
 	if err != nil {
-		return fmt.Errorf("Error retrieving account: %s", err)
+		return diag.Errorf("Error retrieving account: %s", err)
 	}
 
 	d.SetId(account.UUID)

--- a/digitalocean/datasource_digitalocean_account.go
+++ b/digitalocean/datasource_digitalocean_account.go
@@ -9,7 +9,7 @@ import (
 
 func dataSourceDigitalOceanAccount() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanAccountRead,
+		ReadContext: dataSourceDigitalOceanAccountRead,
 		Schema: map[string]*schema.Schema{
 			"droplet_limit": {
 				Type:        schema.TypeInt,
@@ -50,7 +50,7 @@ func dataSourceDigitalOceanAccount() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanAccountRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	account, _, err := client.Account.Get(context.Background())

--- a/digitalocean/datasource_digitalocean_app.go
+++ b/digitalocean/datasource_digitalocean_app.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -50,8 +51,8 @@ func dataSourceDigitalOceanApp() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	d.SetId(d.Get("app_id").(string))
 
-	return resourceDigitalOceanAppRead(d, meta)
+	return resourceDigitalOceanAppRead(ctx, d, meta)
 }

--- a/digitalocean/datasource_digitalocean_app.go
+++ b/digitalocean/datasource_digitalocean_app.go
@@ -1,12 +1,14 @@
 package digitalocean
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceDigitalOceanApp() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanAppRead,
+		ReadContext: dataSourceDigitalOceanAppRead,
 		Schema: map[string]*schema.Schema{
 			"app_id": {
 				Type:     schema.TypeString,
@@ -48,7 +50,7 @@ func dataSourceDigitalOceanApp() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanAppRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	d.SetId(d.Get("app_id").(string))
 
 	return resourceDigitalOceanAppRead(d, meta)

--- a/digitalocean/datasource_digitalocean_certificate.go
+++ b/digitalocean/datasource_digitalocean_certificate.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -63,7 +64,7 @@ func dataSourceDigitalOceanCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// When the certificate type is lets_encrypt, the certificate
@@ -72,7 +73,7 @@ func dataSourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resour
 	name := d.Get("name").(string)
 	cert, err := findCertificateByName(client, name)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(cert.Name)
@@ -84,7 +85,7 @@ func dataSourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resour
 	d.Set("sha1_fingerprint", cert.SHA1Fingerprint)
 
 	if err := d.Set("domains", flattenDigitalOceanCertificateDomains(cert.DNSNames)); err != nil {
-		return fmt.Errorf("Error setting `domain`: %+v", err)
+		return diag.Errorf("Error setting `domain`: %+v", err)
 	}
 
 	return nil

--- a/digitalocean/datasource_digitalocean_certificate.go
+++ b/digitalocean/datasource_digitalocean_certificate.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDigitalOceanCertificate() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanCertificateRead,
+		ReadContext: dataSourceDigitalOceanCertificateRead,
 		Schema: map[string]*schema.Schema{
 
 			"name": {
@@ -63,7 +63,7 @@ func dataSourceDigitalOceanCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanCertificateRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// When the certificate type is lets_encrypt, the certificate

--- a/digitalocean/datasource_digitalocean_container_registry.go
+++ b/digitalocean/datasource_digitalocean_container_registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -32,16 +33,16 @@ func dataSourceDigitalOceanContainerRegistry() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	reg, response, err := client.Registry.Get(context.Background())
 
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
-			return fmt.Errorf("registry not found: %s", err)
+			return diag.Errorf("registry not found: %s", err)
 		}
-		return fmt.Errorf("Error retrieving registry: %s", err)
+		return diag.Errorf("Error retrieving registry: %s", err)
 	}
 
 	d.SetId(reg.Name)

--- a/digitalocean/datasource_digitalocean_container_registry.go
+++ b/digitalocean/datasource_digitalocean_container_registry.go
@@ -12,7 +12,7 @@ const RegistryHostname = "registry.digitalocean.com"
 
 func dataSourceDigitalOceanContainerRegistry() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanContainerRegistryRead,
+		ReadContext: dataSourceDigitalOceanContainerRegistryRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -32,7 +32,7 @@ func dataSourceDigitalOceanContainerRegistry() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanContainerRegistryRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	reg, response, err := client.Registry.Get(context.Background())

--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanDatabaseClusterRead,
+		ReadContext: dataSourceDigitalOceanDatabaseClusterRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -120,7 +120,7 @@ func dataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -2,9 +2,9 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -120,7 +120,7 @@ func dataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)
@@ -135,7 +135,7 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 	for {
 		databases, resp, err := client.Databases.List(context.Background(), opts)
 		if err != nil {
-			return fmt.Errorf("Error retrieving DatabaseClusters: %s", err)
+			return diag.Errorf("Error retrieving DatabaseClusters: %s", err)
 		}
 
 		for _, d := range databases {
@@ -148,14 +148,14 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			return fmt.Errorf("Error retrieving DatabaseClusters: %s", err)
+			return diag.Errorf("Error retrieving DatabaseClusters: %s", err)
 		}
 
 		opts.Page = page + 1
 	}
 
 	if len(databaseList) == 0 {
-		return fmt.Errorf("Unable to find any database clusters")
+		return diag.Errorf("Unable to find any database clusters")
 	}
 
 	for _, db := range databaseList {
@@ -172,7 +172,7 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 
 			if _, ok := d.GetOk("maintenance_window"); ok {
 				if err := d.Set("maintenance_window", flattenMaintWindowOpts(*db.MaintenanceWindow)); err != nil {
-					return fmt.Errorf("[DEBUG] Error setting maintenance_window - error: %#v", err)
+					return diag.Errorf("[DEBUG] Error setting maintenance_window - error: %#v", err)
 				}
 			}
 

--- a/digitalocean/datasource_digitalocean_domain.go
+++ b/digitalocean/datasource_digitalocean_domain.go
@@ -2,8 +2,8 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -39,7 +39,7 @@ func dataSourceDigitalOceanDomain() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)
@@ -47,9 +47,9 @@ func dataSourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceDat
 	domain, resp, err := client.Domains.Get(context.Background(), name)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
-			return fmt.Errorf("domain not found: %s", err)
+			return diag.Errorf("domain not found: %s", err)
 		}
-		return fmt.Errorf("Error retrieving domain: %s", err)
+		return diag.Errorf("Error retrieving domain: %s", err)
 	}
 
 	d.SetId(domain.Name)

--- a/digitalocean/datasource_digitalocean_domain.go
+++ b/digitalocean/datasource_digitalocean_domain.go
@@ -10,7 +10,7 @@ import (
 
 func dataSourceDigitalOceanDomain() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanDomainRead,
+		ReadContext: dataSourceDigitalOceanDomainRead,
 		Schema: map[string]*schema.Schema{
 
 			"name": {
@@ -39,7 +39,7 @@ func dataSourceDigitalOceanDomain() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_droplet.go
+++ b/digitalocean/datasource_digitalocean_droplet.go
@@ -31,12 +31,12 @@ func dataSourceDigitalOceanDroplet() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Read:   dataSourceDigitalOceanDropletRead,
-		Schema: recordSchema,
+		ReadContext: dataSourceDigitalOceanDropletRead,
+		Schema:      recordSchema,
 	}
 }
 
-func dataSourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	var foundDroplet godo.Droplet

--- a/digitalocean/datasource_digitalocean_droplet_snapshot.go
+++ b/digitalocean/datasource_digitalocean_droplet_snapshot.go
@@ -13,7 +13,7 @@ import (
 
 func dataSourceDigitalOceanDropletSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanDropletSnapshotRead,
+		ReadContext: dataSourceDigitalOceanDropletSnapshotRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -67,7 +67,7 @@ func dataSourceDigitalOceanDropletSnapshot() *schema.Resource {
 }
 
 // dataSourceDoSnapshotRead performs the Snapshot lookup.
-func dataSourceDigitalOceanDropletSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name, hasName := d.GetOk("name")

--- a/digitalocean/datasource_digitalocean_floating_ip.go
+++ b/digitalocean/datasource_digitalocean_floating_ip.go
@@ -2,8 +2,8 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -39,7 +39,7 @@ func dataSourceDigitalOceanFloatingIp() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanFloatingIpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanFloatingIpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ipAddress := d.Get("ip_address").(string)
@@ -47,9 +47,9 @@ func dataSourceDigitalOceanFloatingIpRead(ctx context.Context, d *schema.Resourc
 	floatingIp, resp, err := client.FloatingIPs.Get(context.Background(), ipAddress)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
-			return fmt.Errorf("floating ip not found: %s", err)
+			return diag.Errorf("floating ip not found: %s", err)
 		}
-		return fmt.Errorf("Error retrieving floating ip: %s", err)
+		return diag.Errorf("Error retrieving floating ip: %s", err)
 	}
 
 	d.SetId(floatingIp.IP)

--- a/digitalocean/datasource_digitalocean_floating_ip.go
+++ b/digitalocean/datasource_digitalocean_floating_ip.go
@@ -10,7 +10,7 @@ import (
 
 func dataSourceDigitalOceanFloatingIp() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanFloatingIpRead,
+		ReadContext: dataSourceDigitalOceanFloatingIpRead,
 		Schema: map[string]*schema.Schema{
 
 			"ip_address": {
@@ -39,7 +39,7 @@ func dataSourceDigitalOceanFloatingIp() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanFloatingIpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ipAddress := d.Get("ip_address").(string)

--- a/digitalocean/datasource_digitalocean_image.go
+++ b/digitalocean/datasource_digitalocean_image.go
@@ -39,12 +39,12 @@ func dataSourceDigitalOceanImage() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Read:   dataSourceDigitalOceanImageRead,
-		Schema: recordSchema,
+		ReadContext: dataSourceDigitalOceanImageRead,
+		Schema:      recordSchema,
 	}
 }
 
-func dataSourceDigitalOceanImageRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	var foundImage *godo.Image

--- a/digitalocean/datasource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster.go
@@ -2,9 +2,9 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -146,16 +146,16 @@ func dataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanKubernetesClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanKubernetesClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	clusters, resp, err := client.Kubernetes.List(context.Background(), &godo.ListOptions{})
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
-			return fmt.Errorf("No clusters found")
+			return diag.Errorf("No clusters found")
 		}
 
-		return fmt.Errorf("Error listing Kuberentes clusters: %s", err)
+		return diag.Errorf("Error listing Kuberentes clusters: %s", err)
 	}
 
 	// select the correct cluster
@@ -167,5 +167,5 @@ func dataSourceDigitalOceanKubernetesClusterRead(ctx context.Context, d *schema.
 		}
 	}
 
-	return fmt.Errorf("Unable to find cluster with name: %s", d.Get("name").(string))
+	return diag.Errorf("Unable to find cluster with name: %s", d.Get("name").(string))
 }

--- a/digitalocean/datasource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanKubernetesClusterRead,
+		ReadContext: dataSourceDigitalOceanKubernetesClusterRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -146,7 +146,7 @@ func dataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanKubernetesClusterRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanKubernetesClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	clusters, resp, err := client.Kubernetes.List(context.Background(), &godo.ListOptions{})

--- a/digitalocean/datasource_digitalocean_kubernetes_versions.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_versions.go
@@ -2,9 +2,9 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -30,12 +30,12 @@ func dataSourceDigitalOceanKubernetesVersions() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanKubernetesVersionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanKubernetesVersionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	k8sOptions, _, err := client.Kubernetes.GetOptions(context.Background())
 	if err != nil {
-		return fmt.Errorf("Error retrieving Kubernetes options: %s", err)
+		return diag.Errorf("Error retrieving Kubernetes options: %s", err)
 	}
 
 	d.SetId(resource.UniqueId())

--- a/digitalocean/datasource_digitalocean_kubernetes_versions.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_versions.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceDigitalOceanKubernetesVersions() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanKubernetesVersionsRead,
+		ReadContext: dataSourceDigitalOceanKubernetesVersionsRead,
 		Schema: map[string]*schema.Schema{
 			"version_prefix": {
 				Type:     schema.TypeString,
@@ -30,7 +30,7 @@ func dataSourceDigitalOceanKubernetesVersions() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanKubernetesVersionsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanKubernetesVersionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	k8sOptions, _, err := client.Kubernetes.GetOptions(context.Background())

--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanLoadbalancerRead,
+		ReadContext: dataSourceDigitalOceanLoadbalancerRead,
 		Schema: map[string]*schema.Schema{
 
 			"name": {
@@ -190,7 +190,7 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -21,12 +21,12 @@ func dataSourceDigitalOceanProject() *schema.Resource {
 	recordSchema["name"].Optional = true
 
 	return &schema.Resource{
-		Read:   dataSourceDigitalOceanProjectRead,
-		Schema: recordSchema,
+		ReadContext: dataSourceDigitalOceanProjectRead,
+		Schema:      recordSchema,
 	}
 }
 
-func dataSourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Load the specified project, otherwise load the default project.

--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -2,9 +2,9 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -26,7 +26,7 @@ func dataSourceDigitalOceanProject() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Load the specified project, otherwise load the default project.
@@ -34,13 +34,13 @@ func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceDa
 	if projectId, ok := d.GetOk("id"); ok {
 		thisProject, _, err := client.Projects.Get(context.Background(), projectId.(string))
 		if err != nil {
-			return fmt.Errorf("Unable to load project ID %s: %s", projectId, err)
+			return diag.Errorf("Unable to load project ID %s: %s", projectId, err)
 		}
 		foundProject = thisProject
 	} else if name, ok := d.GetOk("name"); ok {
 		projects, err := getDigitalOceanProjects(meta)
 		if err != nil {
-			return fmt.Errorf("Unable to load projects: %s", err)
+			return diag.Errorf("Unable to load projects: %s", err)
 		}
 
 		var projectsWithName []godo.Project
@@ -51,9 +51,9 @@ func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceDa
 			}
 		}
 		if len(projectsWithName) == 0 {
-			return fmt.Errorf("No projects found with name '%s'", name)
+			return diag.Errorf("No projects found with name '%s'", name)
 		} else if len(projectsWithName) > 1 {
-			return fmt.Errorf("Multiple projects found with name '%s'", name)
+			return diag.Errorf("Multiple projects found with name '%s'", name)
 		}
 
 		// Single result so choose that project.
@@ -61,22 +61,22 @@ func dataSourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceDa
 	} else {
 		defaultProject, _, err := client.Projects.GetDefault(context.Background())
 		if err != nil {
-			return fmt.Errorf("Unable to load default project: %s", err)
+			return diag.Errorf("Unable to load default project: %s", err)
 		}
 		foundProject = defaultProject
 	}
 
 	if foundProject == nil {
-		return fmt.Errorf("No project found.")
+		return diag.Errorf("No project found.")
 	}
 
 	flattenedProject, err := flattenDigitalOceanProject(*foundProject, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if err := setResourceDataFromMap(d, flattenedProject); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(foundProject.ID)

--- a/digitalocean/datasource_digitalocean_record.go
+++ b/digitalocean/datasource_digitalocean_record.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDigitalOceanRecord() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanRecordRead,
+		ReadContext: dataSourceDigitalOceanRecordRead,
 		Schema: map[string]*schema.Schema{
 
 			"domain": {
@@ -72,7 +72,7 @@ func dataSourceDigitalOceanRecord() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	domain := d.Get("domain").(string)
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_record.go
+++ b/digitalocean/datasource_digitalocean_record.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -72,7 +73,7 @@ func dataSourceDigitalOceanRecord() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	domain := d.Get("domain").(string)
 	name := d.Get("name").(string)
@@ -82,14 +83,14 @@ func dataSourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceDat
 	records, resp, err := client.Domains.Records(context.Background(), domain, opts)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
-			return fmt.Errorf("domain not found: %s", err)
+			return diag.Errorf("domain not found: %s", err)
 		}
-		return fmt.Errorf("Error retrieving domain: %s", err)
+		return diag.Errorf("Error retrieving domain: %s", err)
 	}
 
 	record, err := findRecordByName(records, name)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.Itoa(record.ID))

--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/digitalocean/godo"
@@ -11,7 +12,7 @@ import (
 
 func dataSourceDigitalOceanRegion() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanRegionRead,
+		ReadContext: dataSourceDigitalOceanRegionRead,
 		Schema: map[string]*schema.Schema{
 			"slug": {
 				Type:         schema.TypeString,
@@ -40,7 +41,7 @@ func dataSourceDigitalOceanRegion() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanRegionRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	regions, err := getDigitalOceanRegions(meta)
 	if err != nil {
 		return fmt.Errorf("Unable to load regions: %s", err)

--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -2,9 +2,9 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -41,10 +41,10 @@ func dataSourceDigitalOceanRegion() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	regions, err := getDigitalOceanRegions(meta)
 	if err != nil {
-		return fmt.Errorf("Unable to load regions: %s", err)
+		return diag.Errorf("Unable to load regions: %s", err)
 	}
 
 	slug := d.Get("slug").(string)
@@ -58,7 +58,7 @@ func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if regionForSlug == nil {
-		return fmt.Errorf("Region does not exist: %s", slug)
+		return diag.Errorf("Region does not exist: %s", slug)
 	}
 
 	flattenedRegion, err := flattenRegion(*regionForSlug, meta)
@@ -67,7 +67,7 @@ func dataSourceDigitalOceanRegionRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err := setResourceDataFromMap(d, flattenedRegion); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(resource.UniqueId())

--- a/digitalocean/datasource_digitalocean_spaces_bucket.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket.go
@@ -1,7 +1,9 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -21,12 +23,12 @@ func dataSourceDigitalOceanSpacesBucket() *schema.Resource {
 	recordSchema["name"].Computed = false
 
 	return &schema.Resource{
-		Read:   dataSourceDigitalOceanSpacesBucketRead,
-		Schema: recordSchema,
+		ReadContext: dataSourceDigitalOceanSpacesBucketRead,
+		Schema:      recordSchema,
 	}
 }
 
-func dataSourceDigitalOceanSpacesBucketRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSpacesBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	name := d.Get("name").(string)
 

--- a/digitalocean/datasource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_object.go
@@ -16,7 +16,7 @@ import (
 
 func dataSourceDigitalOceanSpacesBucketObject() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanSpacesBucketObjectRead,
+		ReadContext: dataSourceDigitalOceanSpacesBucketObjectRead,
 
 		Schema: map[string]*schema.Schema{
 			"bucket": {
@@ -101,7 +101,7 @@ func dataSourceDigitalOceanSpacesBucketObject() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanSpacesBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 	if err != nil {

--- a/digitalocean/datasource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_object.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -101,11 +103,11 @@ func dataSourceDigitalOceanSpacesBucketObject() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	conn := s3.New(client)
@@ -134,10 +136,10 @@ func dataSourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema
 	log.Printf("[DEBUG] Reading S3 Bucket Object: %s", input)
 	out, err := conn.HeadObject(&input)
 	if err != nil {
-		return fmt.Errorf("Failed getting S3 object: %s Bucket: %q Object: %q", err, bucket, key)
+		return diag.Errorf("Failed getting S3 object: %s Bucket: %q Object: %q", err, bucket, key)
 	}
 	if out.DeleteMarker != nil && *out.DeleteMarker {
-		return fmt.Errorf("Requested S3 object %q%s has been deleted",
+		return diag.Errorf("Requested S3 object %q%s has been deleted",
 			bucket+key, versionText)
 	}
 
@@ -173,13 +175,13 @@ func dataSourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema
 		}
 		out, err := conn.GetObject(&input)
 		if err != nil {
-			return fmt.Errorf("Failed getting S3 object: %s", err)
+			return diag.Errorf("Failed getting S3 object: %s", err)
 		}
 
 		buf := new(bytes.Buffer)
 		bytesRead, err := buf.ReadFrom(out.Body)
 		if err != nil {
-			return fmt.Errorf("Failed reading content of S3 object (%s): %s",
+			return diag.Errorf("Failed reading content of S3 object (%s): %s",
 				uniqueId, err)
 		}
 		log.Printf("[INFO] Saving %d bytes from S3 object %s", bytesRead, uniqueId)

--- a/digitalocean/datasource_digitalocean_spaces_bucket_objects.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_objects.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,7 +15,7 @@ const keyRequestPageSize = 1000
 
 func dataSourceDigitalOceanSpacesBucketObjects() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanSpacesBucketObjectsRead,
+		ReadContext: dataSourceDigitalOceanSpacesBucketObjectsRead,
 
 		Schema: map[string]*schema.Schema{
 			"bucket": {
@@ -67,7 +68,7 @@ func dataSourceDigitalOceanSpacesBucketObjects() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanSpacesBucketObjectsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSpacesBucketObjectsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 	if err != nil {

--- a/digitalocean/datasource_digitalocean_spaces_bucket_objects.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_objects.go
@@ -2,10 +2,10 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -68,11 +68,11 @@ func dataSourceDigitalOceanSpacesBucketObjects() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanSpacesBucketObjectsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSpacesBucketObjectsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	conn := s3.New(client)
@@ -133,19 +133,19 @@ func dataSourceDigitalOceanSpacesBucketObjectsRead(ctx context.Context, d *schem
 	})
 
 	if err != nil {
-		return fmt.Errorf("error listing Spaces Bucket (%s) Objects: %s", bucket, err)
+		return diag.Errorf("error listing Spaces Bucket (%s) Objects: %s", bucket, err)
 	}
 
 	if err := d.Set("common_prefixes", commonPrefixes); err != nil {
-		return fmt.Errorf("error setting common_prefixes: %s", err)
+		return diag.Errorf("error setting common_prefixes: %s", err)
 	}
 
 	if err := d.Set("keys", keys); err != nil {
-		return fmt.Errorf("error setting keys: %s", err)
+		return diag.Errorf("error setting keys: %s", err)
 	}
 
 	if err := d.Set("owners", owners); err != nil {
-		return fmt.Errorf("error setting owners: %s", err)
+		return diag.Errorf("error setting owners: %s", err)
 	}
 
 	return nil

--- a/digitalocean/datasource_digitalocean_ssh_key.go
+++ b/digitalocean/datasource_digitalocean_ssh_key.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -36,7 +37,7 @@ func dataSourceDigitalOceanSSHKey() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)
@@ -52,7 +53,7 @@ func dataSourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceDat
 		keys, resp, err := client.Keys.List(context.Background(), opts)
 
 		if err != nil {
-			return fmt.Errorf("Error retrieving ssh keys: %s", err)
+			return diag.Errorf("Error retrieving ssh keys: %s", err)
 		}
 
 		for _, key := range keys {
@@ -65,7 +66,7 @@ func dataSourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceDat
 
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			return fmt.Errorf("Error retrieving ssh keys: %s", err)
+			return diag.Errorf("Error retrieving ssh keys: %s", err)
 		}
 
 		opts.Page = page + 1
@@ -74,7 +75,7 @@ func dataSourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceDat
 	key, err := findKeyByName(keyList, name)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.Itoa(key.ID))

--- a/digitalocean/datasource_digitalocean_ssh_key.go
+++ b/digitalocean/datasource_digitalocean_ssh_key.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDigitalOceanSSHKey() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanSSHKeyRead,
+		ReadContext: dataSourceDigitalOceanSSHKeyRead,
 		Schema: map[string]*schema.Schema{
 
 			"name": {
@@ -36,7 +36,7 @@ func dataSourceDigitalOceanSSHKey() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_tag.go
+++ b/digitalocean/datasource_digitalocean_tag.go
@@ -9,7 +9,7 @@ import (
 
 func dataSourceDigitalOceanTag() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanTagRead,
+		ReadContext: dataSourceDigitalOceanTagRead,
 		Schema: map[string]*schema.Schema{
 
 			"name": {
@@ -46,7 +46,7 @@ func dataSourceDigitalOceanTag() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanTagRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_tag.go
+++ b/digitalocean/datasource_digitalocean_tag.go
@@ -2,8 +2,8 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -46,7 +46,7 @@ func dataSourceDigitalOceanTag() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)
@@ -54,9 +54,9 @@ func dataSourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, 
 	tag, resp, err := client.Tags.Get(context.Background(), name)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
-			return fmt.Errorf("tag not found: %s", err)
+			return diag.Errorf("tag not found: %s", err)
 		}
-		return fmt.Errorf("Error retrieving tag: %s", err)
+		return diag.Errorf("Error retrieving tag: %s", err)
 	}
 
 	d.SetId(tag.Name)

--- a/digitalocean/datasource_digitalocean_volume.go
+++ b/digitalocean/datasource_digitalocean_volume.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -68,7 +69,7 @@ func dataSourceDigitalOceanVolume() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)
@@ -91,7 +92,7 @@ func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceDat
 		volumes, resp, err := client.Storage.ListVolumes(context.Background(), opts)
 
 		if err != nil {
-			return fmt.Errorf("Error retrieving volumes: %s", err)
+			return diag.Errorf("Error retrieving volumes: %s", err)
 		}
 
 		for _, volume := range volumes {
@@ -104,7 +105,7 @@ func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceDat
 
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			return fmt.Errorf("Error retrieving load balancers: %s", err)
+			return diag.Errorf("Error retrieving load balancers: %s", err)
 		}
 
 		opts.ListOptions.Page = page + 1
@@ -113,7 +114,7 @@ func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceDat
 	volume, err := findVolumeByName(volumeList, name)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(volume.ID)
@@ -135,7 +136,7 @@ func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err = d.Set("droplet_ids", flattenDigitalOceanVolumeDropletIds(volume.DropletIDs)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting droplet_ids: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting droplet_ids: %#v", err)
 	}
 
 	return nil

--- a/digitalocean/datasource_digitalocean_volume.go
+++ b/digitalocean/datasource_digitalocean_volume.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDigitalOceanVolume() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanVolumeRead,
+		ReadContext: dataSourceDigitalOceanVolumeRead,
 		Schema: map[string]*schema.Schema{
 
 			"name": {
@@ -68,7 +68,7 @@ func dataSourceDigitalOceanVolume() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name := d.Get("name").(string)

--- a/digitalocean/datasource_digitalocean_volume_snapshot.go
+++ b/digitalocean/datasource_digitalocean_volume_snapshot.go
@@ -16,7 +16,7 @@ import (
 
 func dataSourceDigitalOceanVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanVolumeSnapshotRead,
+		ReadContext: dataSourceDigitalOceanVolumeSnapshotRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -71,7 +71,7 @@ func dataSourceDigitalOceanVolumeSnapshot() *schema.Resource {
 }
 
 // dataSourceDoSnapshotRead performs the Snapshot lookup.
-func dataSourceDigitalOceanVolumeSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name, hasName := d.GetOk("name")

--- a/digitalocean/datasource_digitalocean_volume_snapshot.go
+++ b/digitalocean/datasource_digitalocean_volume_snapshot.go
@@ -2,7 +2,6 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"regexp"
 	"sort"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -71,7 +71,7 @@ func dataSourceDigitalOceanVolumeSnapshot() *schema.Resource {
 }
 
 // dataSourceDoSnapshotRead performs the Snapshot lookup.
-func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	name, hasName := d.GetOk("name")
@@ -79,7 +79,7 @@ func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Res
 	region, hasRegion := d.GetOk("region")
 
 	if !hasName && !hasNameRegex {
-		return fmt.Errorf("One of `name` or `name_regex` must be assigned")
+		return diag.Errorf("One of `name` or `name_regex` must be assigned")
 	}
 
 	opts := &godo.ListOptions{
@@ -93,7 +93,7 @@ func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Res
 		snapshots, resp, err := client.Snapshots.ListVolume(context.Background(), opts)
 
 		if err != nil {
-			return fmt.Errorf("Error retrieving volume snapshots: %s", err)
+			return diag.Errorf("Error retrieving volume snapshots: %s", err)
 		}
 
 		for _, s := range snapshots {
@@ -106,7 +106,7 @@ func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Res
 
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			return fmt.Errorf("Error retrieving volume snapshots: %s", err)
+			return diag.Errorf("Error retrieving volume snapshots: %s", err)
 		}
 
 		opts.Page = page + 1
@@ -125,14 +125,14 @@ func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Res
 	// Get the queried snapshot or fail if it can't be determined
 	var snapshot *godo.Snapshot
 	if len(snapshotList) == 0 {
-		return fmt.Errorf("no volume snapshot found with name %s", name)
+		return diag.Errorf("no volume snapshot found with name %s", name)
 	}
 	if len(snapshotList) > 1 {
 		recent := d.Get("most_recent").(bool)
 		if recent {
 			snapshot = findMostRecentSnapshot(snapshotList)
 		} else {
-			return fmt.Errorf("too many volume snapshots found with name %s (found %d, expected 1)", name, len(snapshotList))
+			return diag.Errorf("too many volume snapshots found with name %s (found %d, expected 1)", name, len(snapshotList))
 		}
 	} else {
 		snapshot = &snapshotList[0]

--- a/digitalocean/datasource_digitalocean_vpc.go
+++ b/digitalocean/datasource_digitalocean_vpc.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceDigitalOceanVPC() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanVPCRead,
+		ReadContext: dataSourceDigitalOceanVPCRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:         schema.TypeString,
@@ -58,7 +58,7 @@ func dataSourceDigitalOceanVPC() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanVPCRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	var foundVPC *godo.VPC
 

--- a/digitalocean/datasource_digitalocean_vpc.go
+++ b/digitalocean/datasource_digitalocean_vpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -58,38 +59,38 @@ func dataSourceDigitalOceanVPC() *schema.Resource {
 	}
 }
 
-func dataSourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	var foundVPC *godo.VPC
 
 	if id, ok := d.GetOk("id"); ok {
 		vpc, _, err := client.VPCs.Get(context.Background(), id.(string))
 		if err != nil {
-			return fmt.Errorf("Error retrieving VPC: %s", err)
+			return diag.Errorf("Error retrieving VPC: %s", err)
 		}
 
 		foundVPC = vpc
 	} else if slug, ok := d.GetOk("region"); ok {
 		vpcs, err := listVPCs(client)
 		if err != nil {
-			return fmt.Errorf("Error retrieving VPC: %s", err)
+			return diag.Errorf("Error retrieving VPC: %s", err)
 		}
 
 		vpc, err := findRegionDefaultVPC(vpcs, slug.(string))
 		if err != nil {
-			return fmt.Errorf("Error retrieving VPC: %s", err)
+			return diag.Errorf("Error retrieving VPC: %s", err)
 		}
 
 		foundVPC = vpc
 	} else if name, ok := d.GetOk("name"); ok {
 		vpcs, err := listVPCs(client)
 		if err != nil {
-			return fmt.Errorf("Error retrieving VPC: %s", err)
+			return diag.Errorf("Error retrieving VPC: %s", err)
 		}
 
 		vpc, err := findVPCByName(vpcs, name.(string))
 		if err != nil {
-			return fmt.Errorf("Error retrieving VPC: %s", err)
+			return diag.Errorf("Error retrieving VPC: %s", err)
 		}
 
 		foundVPC = vpc

--- a/digitalocean/resource_digitalocean_app.go
+++ b/digitalocean/resource_digitalocean_app.go
@@ -12,10 +12,10 @@ import (
 
 func resourceDigitalOceanApp() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanAppCreate,
-		Read:   resourceDigitalOceanAppRead,
-		Update: resourceDigitalOceanAppUpdate,
-		Delete: resourceDigitalOceanAppDelete,
+		CreateContext: resourceDigitalOceanAppCreate,
+		ReadContext:   resourceDigitalOceanAppRead,
+		UpdateContext: resourceDigitalOceanAppUpdate,
+		DeleteContext: resourceDigitalOceanAppDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -66,7 +66,7 @@ func resourceDigitalOceanApp() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanAppCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	appCreateRequest := &godo.AppCreateRequest{}
 	appCreateRequest.Spec = expandAppSpec(d.Get("spec").([]interface{}))
@@ -90,7 +90,7 @@ func resourceDigitalOceanAppCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanAppRead(d, meta)
 }
 
-func resourceDigitalOceanAppRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	app, resp, err := client.Apps.Get(context.Background(), d.Id())
@@ -117,7 +117,7 @@ func resourceDigitalOceanAppRead(d *schema.ResourceData, meta interface{}) error
 	return err
 }
 
-func resourceDigitalOceanAppUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("spec") {
@@ -141,7 +141,7 @@ func resourceDigitalOceanAppUpdate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanAppRead(d, meta)
 }
 
-func resourceDigitalOceanAppDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting App: %s", d.Id())

--- a/digitalocean/resource_digitalocean_app.go
+++ b/digitalocean/resource_digitalocean_app.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
 
@@ -66,7 +67,7 @@ func resourceDigitalOceanApp() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	appCreateRequest := &godo.AppCreateRequest{}
 	appCreateRequest.Spec = expandAppSpec(d.Get("spec").([]interface{}))
@@ -74,7 +75,7 @@ func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] App create request: %#v", appCreateRequest)
 	app, _, err := client.Apps.Create(context.Background(), appCreateRequest)
 	if err != nil {
-		return fmt.Errorf("Error creating App: %s", err)
+		return diag.Errorf("Error creating App: %s", err)
 	}
 
 	d.SetId(app.ID)
@@ -82,15 +83,15 @@ func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = waitForAppDeployment(client, app.ID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[INFO] App created, ID: %s", d.Id())
 
-	return resourceDigitalOceanAppRead(d, meta)
+	return resourceDigitalOceanAppRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	app, resp, err := client.Apps.Get(context.Background(), d.Id())
@@ -100,7 +101,7 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading App: %s", err)
+		return diag.Errorf("Error reading App: %s", err)
 	}
 
 	d.SetId(app.ID)
@@ -111,13 +112,13 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("created_at", app.CreatedAt.UTC().String())
 
 	if err := d.Set("spec", flattenAppSpec(app.Spec)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting app spec: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting app spec: %#v", err)
 	}
 
-	return err
+	return diag.FromErr(err)
 }
 
-func resourceDigitalOceanAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("spec") {
@@ -126,28 +127,28 @@ func resourceDigitalOceanAppUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		app, _, err := client.Apps.Update(context.Background(), d.Id(), appUpdateRequest)
 		if err != nil {
-			return fmt.Errorf("Error updating app (%s): %s", d.Id(), err)
+			return diag.Errorf("Error updating app (%s): %s", d.Id(), err)
 		}
 
 		log.Printf("[DEBUG] Waiting for app (%s) deployment to become active", app.ID)
 		err = waitForAppDeployment(client, app.ID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		log.Printf("[INFO] Updated app (%s)", app.ID)
 	}
 
-	return resourceDigitalOceanAppRead(d, meta)
+	return resourceDigitalOceanAppRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanAppDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanAppDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting App: %s", d.Id())
 	_, err := client.Apps.Delete(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deletingApp: %s", err)
+		return diag.Errorf("Error deletingApp: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_cdn.go
+++ b/digitalocean/resource_digitalocean_cdn.go
@@ -2,11 +2,11 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -118,7 +118,7 @@ func migrateCDNStateV0toV1(ctx context.Context, rawState map[string]interface{},
 	return rawState, nil
 }
 
-func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	cdnRequest := &godo.CDNCreateRequest{
@@ -138,7 +138,7 @@ func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, 
 		if certName != "" {
 			cert, err := findCertificateByName(client, certName)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 
 			cdnRequest.CertificateID = cert.ID
@@ -157,10 +157,10 @@ func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, 
 					log.Println("[DEBUG] Certificate not found looking up by name. Falling back to lookup by ID.")
 					cert, _, err = client.Certificates.Get(context.Background(), certName)
 					if err != nil {
-						return err
+						return diag.FromErr(err)
 					}
 				} else {
-					return err
+					return diag.FromErr(err)
 				}
 			}
 
@@ -171,16 +171,16 @@ func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] CDN create request: %#v", cdnRequest)
 	cdn, _, err := client.CDNs.Create(context.Background(), cdnRequest)
 	if err != nil {
-		return fmt.Errorf("Error creating CDN: %s", err)
+		return diag.Errorf("Error creating CDN: %s", err)
 	}
 
 	d.SetId(cdn.ID)
 	log.Printf("[INFO] CDN created, ID: %s", d.Id())
 
-	return resourceDigitalOceanCDNRead(d, meta)
+	return resourceDigitalOceanCDNRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	cdn, resp, err := client.CDNs.Get(context.Background(), d.Id())
@@ -190,7 +190,7 @@ func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, me
 			log.Printf("[DEBUG] CDN  (%s) was not found - removing from state", d.Id())
 			d.SetId("")
 		}
-		return fmt.Errorf("Error reading CDN: %s", err)
+		return diag.Errorf("Error reading CDN: %s", err)
 	}
 
 	d.SetId(cdn.ID)
@@ -206,16 +206,16 @@ func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, me
 		// certificate name as the primary identifier instead.
 		cert, _, err := client.Certificates.Get(context.Background(), cdn.CertificateID)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		d.Set("certificate_id", cert.Name)
 		d.Set("certificate_name", cert.Name)
 	}
 
-	return err
+	return diag.FromErr(err)
 }
 
-func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	d.Partial(true)
@@ -227,7 +227,7 @@ func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, _, err := client.CDNs.UpdateTTL(context.Background(), d.Id(), ttlUpdateRequest)
 
 		if err != nil {
-			return fmt.Errorf("Error updating CDN TTL: %s", err)
+			return diag.Errorf("Error updating CDN TTL: %s", err)
 		}
 		log.Printf("[INFO] Updated TTL on CDN")
 	}
@@ -241,22 +241,22 @@ func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, _, err := client.CDNs.UpdateCustomDomain(context.Background(), d.Id(), cdnUpdateRequest)
 
 		if err != nil {
-			return fmt.Errorf("Error updating CDN custom domain: %s", err)
+			return diag.Errorf("Error updating CDN custom domain: %s", err)
 		}
 		log.Printf("[INFO] Updated custom domain/certificate on CDN")
 	}
 
 	d.Partial(false)
-	return resourceDigitalOceanCDNRead(d, meta)
+	return resourceDigitalOceanCDNRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanCDNDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	resourceId := d.Id()
 
 	_, err := client.CDNs.Delete(context.Background(), resourceId)
 	if err != nil {
-		return fmt.Errorf("Error deleting CDN: %s", err)
+		return diag.Errorf("Error deleting CDN: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_cdn.go
+++ b/digitalocean/resource_digitalocean_cdn.go
@@ -13,10 +13,10 @@ import (
 
 func resourceDigitalOceanCDN() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanCDNCreate,
-		Read:   resourceDigitalOceanCDNRead,
-		Update: resourceDigitalOceanCDNUpdate,
-		Delete: resourceDigitalOceanCDNDelete,
+		CreateContext: resourceDigitalOceanCDNCreate,
+		ReadContext:   resourceDigitalOceanCDNRead,
+		UpdateContext: resourceDigitalOceanCDNUpdate,
+		DeleteContext: resourceDigitalOceanCDNDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -118,7 +118,7 @@ func migrateCDNStateV0toV1(ctx context.Context, rawState map[string]interface{},
 	return rawState, nil
 }
 
-func resourceDigitalOceanCDNCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	cdnRequest := &godo.CDNCreateRequest{
@@ -180,7 +180,7 @@ func resourceDigitalOceanCDNCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanCDNRead(d, meta)
 }
 
-func resourceDigitalOceanCDNRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	cdn, resp, err := client.CDNs.Get(context.Background(), d.Id())
@@ -215,7 +215,7 @@ func resourceDigitalOceanCDNRead(d *schema.ResourceData, meta interface{}) error
 	return err
 }
 
-func resourceDigitalOceanCDNUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	d.Partial(true)
@@ -250,7 +250,7 @@ func resourceDigitalOceanCDNUpdate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanCDNRead(d, meta)
 }
 
-func resourceDigitalOceanCDNDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCDNDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	resourceId := d.Id()
 

--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -181,22 +182,22 @@ func buildCertificateRequest(d *schema.ResourceData) (*godo.CertificateRequest, 
 	return req, nil
 }
 
-func resourceDigitalOceanCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	certificateType := d.Get("type").(string)
 	if certificateType == "custom" {
 		if _, ok := d.GetOk("private_key"); !ok {
-			return fmt.Errorf("`private_key` is required for when type is `custom` or empty")
+			return diag.Errorf("`private_key` is required for when type is `custom` or empty")
 		}
 
 		if _, ok := d.GetOk("leaf_certificate"); !ok {
-			return fmt.Errorf("`leaf_certificate` is required for when type is `custom` or empty")
+			return diag.Errorf("`leaf_certificate` is required for when type is `custom` or empty")
 		}
 	} else if certificateType == "lets_encrypt" {
 
 		if _, ok := d.GetOk("domains"); !ok {
-			return fmt.Errorf("`domains` is required for when type is `lets_encrypt`")
+			return diag.Errorf("`domains` is required for when type is `lets_encrypt`")
 		}
 	}
 
@@ -204,13 +205,13 @@ func resourceDigitalOceanCertificateCreate(ctx context.Context, d *schema.Resour
 
 	certReq, err := buildCertificateRequest(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Certificate Create: %#v", certReq)
 	cert, _, err := client.Certificates.Create(context.Background(), certReq)
 	if err != nil {
-		return fmt.Errorf("Error creating Certificate: %s", err)
+		return diag.Errorf("Error creating Certificate: %s", err)
 	}
 
 	// When the certificate type is lets_encrypt, the certificate
@@ -233,13 +234,13 @@ func resourceDigitalOceanCertificateCreate(ctx context.Context, d *schema.Resour
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for certificate (%s) to become active: %s", d.Get("name"), err)
+		return diag.Errorf("Error waiting for certificate (%s) to become active: %s", d.Get("name"), err)
 	}
 
-	return resourceDigitalOceanCertificateRead(d, meta)
+	return resourceDigitalOceanCertificateRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// When the certificate type is lets_encrypt, the certificate
@@ -248,7 +249,7 @@ func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resource
 	log.Printf("[INFO] Reading the details of the Certificate %s", d.Id())
 	cert, err := findCertificateByName(client, d.Id())
 	if err != nil {
-		return fmt.Errorf("Error retrieving Certificate: %s", err)
+		return diag.Errorf("Error retrieving Certificate: %s", err)
 	}
 
 	// check if the certificate no longer exists.
@@ -266,20 +267,20 @@ func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resource
 	d.Set("sha1_fingerprint", cert.SHA1Fingerprint)
 
 	if err := d.Set("domains", flattenDigitalOceanCertificateDomains(cert.DNSNames)); err != nil {
-		return fmt.Errorf("Error setting `domains`: %+v", err)
+		return diag.Errorf("Error setting `domains`: %+v", err)
 	}
 
 	return nil
 
 }
 
-func resourceDigitalOceanCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting Certificate: %s", d.Id())
 	cert, err := findCertificateByName(client, d.Id())
 	if err != nil {
-		return fmt.Errorf("Error retrieving Certificate: %s", err)
+		return diag.Errorf("Error retrieving Certificate: %s", err)
 	}
 	if cert == nil {
 		return nil
@@ -287,7 +288,7 @@ func resourceDigitalOceanCertificateDelete(ctx context.Context, d *schema.Resour
 
 	_, err = client.Certificates.Delete(context.Background(), cert.ID)
 	if err != nil {
-		return fmt.Errorf("Error deleting Certificate: %s", err)
+		return diag.Errorf("Error deleting Certificate: %s", err)
 	}
 
 	return nil

--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -14,9 +14,9 @@ import (
 
 func resourceDigitalOceanCertificate() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanCertificateCreate,
-		Read:   resourceDigitalOceanCertificateRead,
-		Delete: resourceDigitalOceanCertificateDelete,
+		CreateContext: resourceDigitalOceanCertificateCreate,
+		ReadContext:   resourceDigitalOceanCertificateRead,
+		DeleteContext: resourceDigitalOceanCertificateDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -181,7 +181,7 @@ func buildCertificateRequest(d *schema.ResourceData) (*godo.CertificateRequest, 
 	return req, nil
 }
 
-func resourceDigitalOceanCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	certificateType := d.Get("type").(string)
@@ -239,7 +239,7 @@ func resourceDigitalOceanCertificateCreate(d *schema.ResourceData, meta interfac
 	return resourceDigitalOceanCertificateRead(d, meta)
 }
 
-func resourceDigitalOceanCertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// When the certificate type is lets_encrypt, the certificate
@@ -273,7 +273,7 @@ func resourceDigitalOceanCertificateRead(d *schema.ResourceData, meta interface{
 
 }
 
-func resourceDigitalOceanCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting Certificate: %s", d.Id())

--- a/digitalocean/resource_digitalocean_container_registry.go
+++ b/digitalocean/resource_digitalocean_container_registry.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -38,7 +39,7 @@ func resourceDigitalOceanContainerRegistry() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanContainerRegistryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -49,16 +50,16 @@ func resourceDigitalOceanContainerRegistryCreate(ctx context.Context, d *schema.
 	log.Printf("[DEBUG] Container Registry create configuration: %#v", opts)
 	reg, _, err := client.Registry.Create(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating container registry: %s", err)
+		return diag.Errorf("Error creating container registry: %s", err)
 	}
 
 	d.SetId(reg.Name)
 	log.Printf("[INFO] Container Registry: %s", reg.Name)
 
-	return resourceDigitalOceanContainerRegistryRead(d, meta)
+	return resourceDigitalOceanContainerRegistryRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	reg, resp, err := client.Registry.Get(context.Background())
@@ -70,7 +71,7 @@ func resourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.Re
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving container registry: %s", err)
+		return diag.Errorf("Error retrieving container registry: %s", err)
 	}
 
 	d.SetId(reg.Name)
@@ -81,13 +82,13 @@ func resourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func resourceDigitalOceanContainerRegistryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting container registry: %s", d.Id())
 	_, err := client.Registry.Delete(context.Background())
 	if err != nil {
-		return fmt.Errorf("Error deleting container registry: %s", err)
+		return diag.Errorf("Error deleting container registry: %s", err)
 	}
 	d.SetId("")
 	return nil

--- a/digitalocean/resource_digitalocean_container_registry.go
+++ b/digitalocean/resource_digitalocean_container_registry.go
@@ -12,9 +12,9 @@ import (
 
 func resourceDigitalOceanContainerRegistry() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanContainerRegistryCreate,
-		Read:   resourceDigitalOceanContainerRegistryRead,
-		Delete: resourceDigitalOceanContainerRegistryDelete,
+		CreateContext: resourceDigitalOceanContainerRegistryCreate,
+		ReadContext:   resourceDigitalOceanContainerRegistryRead,
+		DeleteContext: resourceDigitalOceanContainerRegistryDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -38,7 +38,7 @@ func resourceDigitalOceanContainerRegistry() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanContainerRegistryCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -58,7 +58,7 @@ func resourceDigitalOceanContainerRegistryCreate(d *schema.ResourceData, meta in
 	return resourceDigitalOceanContainerRegistryRead(d, meta)
 }
 
-func resourceDigitalOceanContainerRegistryRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	reg, resp, err := client.Registry.Get(context.Background())
@@ -81,7 +81,7 @@ func resourceDigitalOceanContainerRegistryRead(d *schema.ResourceData, meta inte
 	return nil
 }
 
-func resourceDigitalOceanContainerRegistryDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting container registry: %s", d.Id())

--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -52,20 +53,20 @@ func resourceDigitalOceanContainerRegistryDockerCredentials() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
-	return resourceDigitalOceanContainerRegistryDockerCredentialsRead(d, meta)
+func resourceDigitalOceanContainerRegistryDockerCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceDigitalOceanContainerRegistryDockerCredentialsRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	reg, response, err := client.Registry.Get(context.Background())
 
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
-			return fmt.Errorf("registry not found: %s", err)
+			return diag.Errorf("registry not found: %s", err)
 		}
-		return fmt.Errorf("Error retrieving registry: %s", err)
+		return diag.Errorf("Error retrieving registry: %s", err)
 	}
 
 	write := d.Get("write").(bool)
@@ -75,13 +76,13 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsRead(ctx context.Cont
 
 	err = updateExpiredDockerCredentials(d, write, client)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	if d.HasChange("expiry_seconds") {
 		write := d.Get("write").(bool)
 		expirySeconds := d.Get("expiry_seconds").(int)
@@ -91,7 +92,7 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(ctx context.Co
 		d.Set("credential_expiration_time", expirationTime.Format(time.RFC3339))
 		dockerConfigJSON, err := generateDockerCredentials(write, expirySeconds, client)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		d.Set("write", write)
 		d.Set("docker_credentials", dockerConfigJSON)
@@ -102,7 +103,7 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(ctx context.Co
 			client := meta.(*CombinedConfig).godoClient()
 			dockerConfigJSON, err := generateDockerCredentials(write, expirySeconds, client)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 			d.Set("write", write)
 			d.Set("docker_credentials", dockerConfigJSON)
@@ -112,7 +113,7 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(ctx context.Co
 	return nil
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	d.SetId("")
 	return nil
 }

--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
@@ -14,10 +14,10 @@ const expirySecondsDefault = 1576800000 // Max allowed by the API, roughly 50 ye
 
 func resourceDigitalOceanContainerRegistryDockerCredentials() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanContainerRegistryDockerCredentialsCreate,
-		Read:   resourceDigitalOceanContainerRegistryDockerCredentialsRead,
-		Update: resourceDigitalOceanContainerRegistryDockerCredentialsUpdate,
-		Delete: resourceDigitalOceanContainerRegistryDockerCredentialsDelete,
+		CreateContext: resourceDigitalOceanContainerRegistryDockerCredentialsCreate,
+		ReadContext:   resourceDigitalOceanContainerRegistryDockerCredentialsRead,
+		UpdateContext: resourceDigitalOceanContainerRegistryDockerCredentialsUpdate,
+		DeleteContext: resourceDigitalOceanContainerRegistryDockerCredentialsDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -52,11 +52,11 @@ func resourceDigitalOceanContainerRegistryDockerCredentials() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	return resourceDigitalOceanContainerRegistryDockerCredentialsRead(d, meta)
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	reg, response, err := client.Registry.Get(context.Background())
@@ -81,7 +81,7 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsRead(d *schema.Resour
 	return nil
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("expiry_seconds") {
 		write := d.Get("write").(bool)
 		expirySeconds := d.Get("expiry_seconds").(int)
@@ -112,7 +112,7 @@ func resourceDigitalOceanContainerRegistryDockerCredentialsUpdate(d *schema.Reso
 	return nil
 }
 
-func resourceDigitalOceanContainerRegistryDockerCredentialsDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanContainerRegistryDockerCredentialsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 	return nil
 }

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -15,10 +15,10 @@ import (
 
 func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDatabaseClusterCreate,
-		Read:   resourceDigitalOceanDatabaseClusterRead,
-		Update: resourceDigitalOceanDatabaseClusterUpdate,
-		Delete: resourceDigitalOceanDatabaseClusterDelete,
+		CreateContext: resourceDigitalOceanDatabaseClusterCreate,
+		ReadContext:   resourceDigitalOceanDatabaseClusterRead,
+		UpdateContext: resourceDigitalOceanDatabaseClusterUpdate,
+		DeleteContext: resourceDigitalOceanDatabaseClusterDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -201,7 +201,7 @@ func validateExclusiveAttributes() schema.CustomizeDiffFunc {
 	})
 }
 
-func resourceDigitalOceanDatabaseClusterCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.DatabaseCreateRequest{
@@ -265,7 +265,7 @@ func resourceDigitalOceanDatabaseClusterCreate(d *schema.ResourceData, meta inte
 	return resourceDigitalOceanDatabaseClusterRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("size") || d.HasChange("node_count") {
@@ -363,7 +363,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta inte
 	return resourceDigitalOceanDatabaseClusterRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	database, resp, err := client.Databases.Get(context.Background(), d.Id())
@@ -425,7 +425,7 @@ func resourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func resourceDigitalOceanDatabaseClusterDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting DatabaseCluster: %s", d.Id())

--- a/digitalocean/resource_digitalocean_database_connection_pool.go
+++ b/digitalocean/resource_digitalocean_database_connection_pool.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -102,7 +103,7 @@ func resourceDigitalOceanDatabaseConnectionPool() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseConnectionPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseConnectionPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	clusterID := d.Get("cluster_id").(string)
@@ -117,16 +118,16 @@ func resourceDigitalOceanDatabaseConnectionPoolCreate(ctx context.Context, d *sc
 	log.Printf("[DEBUG] DatabaseConnectionPool create configuration: %#v", opts)
 	pool, _, err := client.Databases.CreatePool(context.Background(), clusterID, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating DatabaseConnectionPool: %s", err)
+		return diag.Errorf("Error creating DatabaseConnectionPool: %s", err)
 	}
 
 	d.SetId(createConnectionPoolID(clusterID, pool.Name))
 	log.Printf("[INFO] DatabaseConnectionPool Name: %s", pool.Name)
 
-	return resourceDigitalOceanDatabaseConnectionPoolRead(d, meta)
+	return resourceDigitalOceanDatabaseConnectionPoolRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanDatabaseConnectionPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseConnectionPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID, poolName := splitConnectionPoolID(d.Id())
 
@@ -139,7 +140,7 @@ func resourceDigitalOceanDatabaseConnectionPoolRead(ctx context.Context, d *sche
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving DatabaseConnectionPool: %s", err)
+		return diag.Errorf("Error retrieving DatabaseConnectionPool: %s", err)
 	}
 
 	d.SetId(createConnectionPoolID(clusterID, pool.Name))
@@ -172,14 +173,14 @@ func resourceDigitalOceanDatabaseConnectionPoolImport(d *schema.ResourceData, me
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDigitalOceanDatabaseConnectionPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseConnectionPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID, poolName := splitConnectionPoolID(d.Id())
 
 	log.Printf("[INFO] Deleting DatabaseConnectionPool: %s", poolName)
 	_, err := client.Databases.DeletePool(context.Background(), clusterID, poolName)
 	if err != nil {
-		return fmt.Errorf("Error deleting DatabaseConnectionPool: %s", err)
+		return diag.Errorf("Error deleting DatabaseConnectionPool: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_database_connection_pool.go
+++ b/digitalocean/resource_digitalocean_database_connection_pool.go
@@ -13,9 +13,9 @@ import (
 
 func resourceDigitalOceanDatabaseConnectionPool() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDatabaseConnectionPoolCreate,
-		Read:   resourceDigitalOceanDatabaseConnectionPoolRead,
-		Delete: resourceDigitalOceanDatabaseConnectionPoolDelete,
+		CreateContext: resourceDigitalOceanDatabaseConnectionPoolCreate,
+		ReadContext:   resourceDigitalOceanDatabaseConnectionPoolRead,
+		DeleteContext: resourceDigitalOceanDatabaseConnectionPoolDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDatabaseConnectionPoolImport,
 		},
@@ -102,7 +102,7 @@ func resourceDigitalOceanDatabaseConnectionPool() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseConnectionPoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseConnectionPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	clusterID := d.Get("cluster_id").(string)
@@ -126,7 +126,7 @@ func resourceDigitalOceanDatabaseConnectionPoolCreate(d *schema.ResourceData, me
 	return resourceDigitalOceanDatabaseConnectionPoolRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseConnectionPoolRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseConnectionPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID, poolName := splitConnectionPoolID(d.Id())
 
@@ -172,7 +172,7 @@ func resourceDigitalOceanDatabaseConnectionPoolImport(d *schema.ResourceData, me
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDigitalOceanDatabaseConnectionPoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseConnectionPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID, poolName := splitConnectionPoolID(d.Id())
 

--- a/digitalocean/resource_digitalocean_database_db.go
+++ b/digitalocean/resource_digitalocean_database_db.go
@@ -13,9 +13,9 @@ import (
 
 func resourceDigitalOceanDatabaseDB() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDatabaseDBCreate,
-		Read:   resourceDigitalOceanDatabaseDBRead,
-		Delete: resourceDigitalOceanDatabaseDBDelete,
+		CreateContext: resourceDigitalOceanDatabaseDBCreate,
+		ReadContext:   resourceDigitalOceanDatabaseDBRead,
+		DeleteContext: resourceDigitalOceanDatabaseDBDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDatabaseDBImport,
 		},
@@ -37,7 +37,7 @@ func resourceDigitalOceanDatabaseDB() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseDBCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseDBCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
@@ -57,7 +57,7 @@ func resourceDigitalOceanDatabaseDBCreate(d *schema.ResourceData, meta interface
 	return resourceDigitalOceanDatabaseDBRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseDBRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseDBRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
@@ -78,7 +78,7 @@ func resourceDigitalOceanDatabaseDBRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceDigitalOceanDatabaseDBDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseDBDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)

--- a/digitalocean/resource_digitalocean_database_db.go
+++ b/digitalocean/resource_digitalocean_database_db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -37,7 +38,7 @@ func resourceDigitalOceanDatabaseDB() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseDBCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseDBCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
@@ -48,16 +49,16 @@ func resourceDigitalOceanDatabaseDBCreate(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Database DB create configuration: %#v", opts)
 	db, _, err := client.Databases.CreateDB(context.Background(), clusterID, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating Database DB: %s", err)
+		return diag.Errorf("Error creating Database DB: %s", err)
 	}
 
 	d.SetId(makeDatabaseDBID(clusterID, db.Name))
 	log.Printf("[INFO] Database DB Name: %s", db.Name)
 
-	return resourceDigitalOceanDatabaseDBRead(d, meta)
+	return resourceDigitalOceanDatabaseDBRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanDatabaseDBRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseDBRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
@@ -72,13 +73,13 @@ func resourceDigitalOceanDatabaseDBRead(ctx context.Context, d *schema.ResourceD
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Database DB: %s", err)
+		return diag.Errorf("Error retrieving Database DB: %s", err)
 	}
 
 	return nil
 }
 
-func resourceDigitalOceanDatabaseDBDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseDBDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
@@ -86,7 +87,7 @@ func resourceDigitalOceanDatabaseDBDelete(ctx context.Context, d *schema.Resourc
 	log.Printf("[INFO] Deleting Database DB: %s", d.Id())
 	_, err := client.Databases.DeleteDB(context.Background(), clusterID, name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Database DB: %s", err)
+		return diag.Errorf("Error deleting Database DB: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_database_firewall.go
+++ b/digitalocean/resource_digitalocean_database_firewall.go
@@ -14,10 +14,10 @@ import (
 
 func resourceDigitalOceanDatabaseFirewall() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDatabaseFirewallCreate,
-		Read:   resourceDigitalOceanDatabaseFirewallRead,
-		Update: resourceDigitalOceanDatabaseFirewallUpdate,
-		Delete: resourceDigitalOceanDatabaseFirewallDelete,
+		CreateContext: resourceDigitalOceanDatabaseFirewallCreate,
+		ReadContext:   resourceDigitalOceanDatabaseFirewallRead,
+		UpdateContext: resourceDigitalOceanDatabaseFirewallUpdate,
+		DeleteContext: resourceDigitalOceanDatabaseFirewallDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDatabaseFirewallImport,
 		},
@@ -68,7 +68,7 @@ func resourceDigitalOceanDatabaseFirewall() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
@@ -84,7 +84,7 @@ func resourceDigitalOceanDatabaseFirewallCreate(d *schema.ResourceData, meta int
 	return resourceDigitalOceanDatabaseFirewallRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseFirewallRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
@@ -96,7 +96,7 @@ func resourceDigitalOceanDatabaseFirewallRead(d *schema.ResourceData, meta inter
 	return d.Set("rule", flattenDatabaseFirewallRules(rules))
 }
 
-func resourceDigitalOceanDatabaseFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
@@ -110,7 +110,7 @@ func resourceDigitalOceanDatabaseFirewallUpdate(d *schema.ResourceData, meta int
 	return resourceDigitalOceanDatabaseFirewallRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 

--- a/digitalocean/resource_digitalocean_database_replica.go
+++ b/digitalocean/resource_digitalocean_database_replica.go
@@ -14,9 +14,9 @@ import (
 
 func resourceDigitalOceanDatabaseReplica() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDatabaseReplicaCreate,
-		Read:   resourceDigitalOceanDatabaseReplicaRead,
-		Delete: resourceDigitalOceanDatabaseReplicaDelete,
+		CreateContext: resourceDigitalOceanDatabaseReplicaCreate,
+		ReadContext:   resourceDigitalOceanDatabaseReplicaRead,
+		DeleteContext: resourceDigitalOceanDatabaseReplicaDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDatabaseReplicaImport,
 		},
@@ -113,7 +113,7 @@ func resourceDigitalOceanDatabaseReplica() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseReplicaCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseReplicaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterId := d.Get("cluster_id").(string)
 
@@ -145,7 +145,7 @@ func resourceDigitalOceanDatabaseReplicaCreate(d *schema.ResourceData, meta inte
 	return resourceDigitalOceanDatabaseReplicaRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseReplicaRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseReplicaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterId := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
@@ -189,7 +189,7 @@ func resourceDigitalOceanDatabaseReplicaImport(d *schema.ResourceData, meta inte
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDigitalOceanDatabaseReplicaDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseReplicaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterId := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)

--- a/digitalocean/resource_digitalocean_database_user.go
+++ b/digitalocean/resource_digitalocean_database_user.go
@@ -13,10 +13,10 @@ import (
 
 func resourceDigitalOceanDatabaseUser() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDatabaseUserCreate,
-		Read:   resourceDigitalOceanDatabaseUserRead,
-		Update: resourceDigitalOceanDatabaseUserUpdate,
-		Delete: resourceDigitalOceanDatabaseUserDelete,
+		CreateContext: resourceDigitalOceanDatabaseUserCreate,
+		ReadContext:   resourceDigitalOceanDatabaseUserRead,
+		UpdateContext: resourceDigitalOceanDatabaseUserUpdate,
+		DeleteContext: resourceDigitalOceanDatabaseUserDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDatabaseUserImport,
 		},
@@ -61,7 +61,7 @@ func resourceDigitalOceanDatabaseUser() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDatabaseUserCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
@@ -87,7 +87,7 @@ func resourceDigitalOceanDatabaseUserCreate(d *schema.ResourceData, meta interfa
 	return resourceDigitalOceanDatabaseUserRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseUserRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
@@ -114,7 +114,7 @@ func resourceDigitalOceanDatabaseUserRead(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceDigitalOceanDatabaseUserUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("mysql_auth_plugin") {
@@ -139,7 +139,7 @@ func resourceDigitalOceanDatabaseUserUpdate(d *schema.ResourceData, meta interfa
 	return resourceDigitalOceanDatabaseUserRead(d, meta)
 }
 
-func resourceDigitalOceanDatabaseUserDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDatabaseUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)

--- a/digitalocean/resource_digitalocean_domain.go
+++ b/digitalocean/resource_digitalocean_domain.go
@@ -12,9 +12,9 @@ import (
 
 func resourceDigitalOceanDomain() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDomainCreate,
-		Read:   resourceDigitalOceanDomainRead,
-		Delete: resourceDigitalOceanDomainDelete,
+		CreateContext: resourceDigitalOceanDomainCreate,
+		ReadContext:   resourceDigitalOceanDomainRead,
+		DeleteContext: resourceDigitalOceanDomainDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -40,7 +40,7 @@ func resourceDigitalOceanDomain() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDomainCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -65,7 +65,7 @@ func resourceDigitalOceanDomainCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanDomainRead(d, meta)
 }
 
-func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	domain, resp, err := client.Domains.Get(context.Background(), d.Id())
@@ -86,7 +86,7 @@ func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceDigitalOceanDomainDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting Domain: %s", d.Id())

--- a/digitalocean/resource_digitalocean_domain.go
+++ b/digitalocean/resource_digitalocean_domain.go
@@ -2,10 +2,10 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -40,7 +40,7 @@ func resourceDigitalOceanDomain() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -56,16 +56,16 @@ func resourceDigitalOceanDomainCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Domain create configuration: %#v", opts)
 	domain, _, err := client.Domains.Create(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating Domain: %s", err)
+		return diag.Errorf("Error creating Domain: %s", err)
 	}
 
 	d.SetId(domain.Name)
 	log.Printf("[INFO] Domain Name: %s", domain.Name)
 
-	return resourceDigitalOceanDomainRead(d, meta)
+	return resourceDigitalOceanDomainRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	domain, resp, err := client.Domains.Get(context.Background(), d.Id())
@@ -77,7 +77,7 @@ func resourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving domain: %s", err)
+		return diag.Errorf("Error retrieving domain: %s", err)
 	}
 
 	d.Set("name", domain.Name)
@@ -86,13 +86,13 @@ func resourceDigitalOceanDomainRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceDigitalOceanDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting Domain: %s", d.Id())
 	_, err := client.Domains.Delete(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting Domain: %s", err)
+		return diag.Errorf("Error deleting Domain: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -17,10 +17,10 @@ import (
 
 func resourceDigitalOceanDroplet() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDropletCreate,
-		Read:   resourceDigitalOceanDropletRead,
-		Update: resourceDigitalOceanDropletUpdate,
-		Delete: resourceDigitalOceanDropletDelete,
+		CreateContext: resourceDigitalOceanDropletCreate,
+		ReadContext:   resourceDigitalOceanDropletRead,
+		UpdateContext: resourceDigitalOceanDropletUpdate,
+		DeleteContext: resourceDigitalOceanDropletDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDropletImport,
 		},
@@ -194,7 +194,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDropletCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	image := d.Get("image").(string)
@@ -286,7 +286,7 @@ func resourceDigitalOceanDropletCreate(d *schema.ResourceData, meta interface{})
 	return resourceDigitalOceanDropletRead(d, meta)
 }
 
-func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
@@ -402,7 +402,7 @@ func findIPv4AddrByType(d *godo.Droplet, addrType string) string {
 	return ""
 }
 
-func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
@@ -597,7 +597,7 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 	return resourceDigitalOceanDropletRead(d, meta)
 }
 
-func resourceDigitalOceanDropletDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -194,7 +195,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	image := d.Get("image").(string)
@@ -260,7 +261,7 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 	if v, ok := d.GetOk("ssh_keys"); ok {
 		expandedSshKeys, err := expandSshKeys(v.(*schema.Set).List())
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		opts.SSHKeys = expandedSshKeys
 	}
@@ -270,7 +271,7 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 	droplet, _, err := client.Droplets.Create(context.Background(), opts)
 
 	if err != nil {
-		return fmt.Errorf("Error creating droplet: %s", err)
+		return diag.Errorf("Error creating droplet: %s", err)
 	}
 
 	// Assign the droplets id
@@ -280,18 +281,18 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 
 	_, err = waitForDropletAttribute(d, "active", []string{"new"}, "status", meta)
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error waiting for droplet (%s) to become ready: %s", d.Id(), err)
 	}
-	return resourceDigitalOceanDropletRead(d, meta)
+	return resourceDigitalOceanDropletRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid droplet id: %v", err)
+		return diag.Errorf("invalid droplet id: %v", err)
 	}
 
 	// Retrieve the droplet properties for updating the state
@@ -304,7 +305,7 @@ func resourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceData
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving droplet: %s", err)
+		return diag.Errorf("Error retrieving droplet: %s", err)
 	}
 
 	// Image can drift once the image is build if a remote drift is detected
@@ -337,11 +338,11 @@ func resourceDigitalOceanDropletRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err := d.Set("volume_ids", flattenDigitalOceanDropletVolumeIds(droplet.VolumeIDs)); err != nil {
-		return fmt.Errorf("Error setting `volume_ids`: %+v", err)
+		return diag.Errorf("Error setting `volume_ids`: %+v", err)
 	}
 
 	if err := d.Set("tags", flattenTags(droplet.Tags)); err != nil {
-		return fmt.Errorf("Error setting `tags`: %+v", err)
+		return diag.Errorf("Error setting `tags`: %+v", err)
 	}
 
 	// Initialize the connection info
@@ -402,12 +403,12 @@ func findIPv4AddrByType(d *godo.Droplet, addrType string) string {
 	return ""
 }
 
-func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid droplet id: %v", err)
+		return diag.Errorf("invalid droplet id: %v", err)
 	}
 
 	if d.HasChange("size") {
@@ -416,14 +417,14 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 
 		_, _, err = client.DropletActions.PowerOff(context.Background(), id)
 		if err != nil && !strings.Contains(err.Error(), "Droplet is already powered off") {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error powering off droplet (%s): %s", d.Id(), err)
 		}
 
 		// Wait for power off
 		_, err = waitForDropletAttribute(d, "off", []string{"active"}, "status", meta)
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for droplet (%s) to become powered off: %s", d.Id(), err)
 		}
 
@@ -433,10 +434,10 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			newErr := powerOnAndWait(d, meta)
 			if newErr != nil {
-				return fmt.Errorf(
+				return diag.Errorf(
 					"Error powering on droplet (%s) after failed resize: %s", d.Id(), err)
 			}
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error resizing droplet (%s): %s", d.Id(), err)
 		}
 
@@ -444,24 +445,24 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		if err = waitForAction(client, action); err != nil {
 			newErr := powerOnAndWait(d, meta)
 			if newErr != nil {
-				return fmt.Errorf(
+				return diag.Errorf(
 					"Error powering on droplet (%s) after waiting for resize to finish: %s", d.Id(), err)
 			}
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for resize droplet (%s) to finish: %s", d.Id(), err)
 		}
 
 		_, _, err = client.DropletActions.PowerOn(context.Background(), id)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error powering on droplet (%s) after resize: %s", d.Id(), err)
 		}
 
 		// Wait for power off
 		_, err = waitForDropletAttribute(d, "active", []string{"off"}, "status", meta)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -472,7 +473,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		_, _, err = client.DropletActions.Rename(context.Background(), id, newName.(string))
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error renaming droplet (%s): %s", d.Id(), err)
 		}
 
@@ -481,7 +482,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 			d, newName.(string), []string{"", oldName.(string)}, "name", meta)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for rename droplet (%s) to finish: %s", d.Id(), err)
 		}
 	}
@@ -491,23 +492,23 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 			// Enable backups on droplet
 			action, _, err := client.DropletActions.EnableBackups(context.Background(), id)
 			if err != nil {
-				return fmt.Errorf(
+				return diag.Errorf(
 					"Error enabling backups on droplet (%s): %s", d.Id(), err)
 			}
 
 			if err := waitForAction(client, action); err != nil {
-				return fmt.Errorf("Error waiting for backups to be enabled for droplet (%s): %s", d.Id(), err)
+				return diag.Errorf("Error waiting for backups to be enabled for droplet (%s): %s", d.Id(), err)
 			}
 		} else {
 			// Disable backups on droplet
 			action, _, err := client.DropletActions.DisableBackups(context.Background(), id)
 			if err != nil {
-				return fmt.Errorf(
+				return diag.Errorf(
 					"Error disabling backups on droplet (%s): %s", d.Id(), err)
 			}
 
 			if err := waitForAction(client, action); err != nil {
-				return fmt.Errorf("Error waiting for backups to be disabled for droplet (%s): %s", d.Id(), err)
+				return diag.Errorf("Error waiting for backups to be disabled for droplet (%s): %s", d.Id(), err)
 			}
 		}
 	}
@@ -518,7 +519,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		_, _, err = client.DropletActions.EnablePrivateNetworking(context.Background(), id)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error enabling private networking for droplet (%s): %s", d.Id(), err)
 		}
 
@@ -527,7 +528,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 			d, "true", []string{"", "false"}, "private_networking", meta)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for private networking to be enabled on for droplet (%s): %s", d.Id(), err)
 		}
 	}
@@ -537,7 +538,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		_, _, err = client.DropletActions.EnableIPv6(context.Background(), id)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error turning on ipv6 for droplet (%s): %s", d.Id(), err)
 		}
 
@@ -546,7 +547,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 			d, "true", []string{"", "false"}, "ipv6", meta)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for ipv6 to be turned on for droplet (%s): %s", d.Id(), err)
 		}
 	}
@@ -554,7 +555,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 	if d.HasChange("tags") {
 		err = setTags(client, d, godo.DropletResourceType)
 		if err != nil {
-			return fmt.Errorf("Error updating tags: %s", err)
+			return diag.Errorf("Error updating tags: %s", err)
 		}
 	}
 
@@ -582,11 +583,11 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		for volumeID := range leftDiff(newIDSet, oldIDSet) {
 			action, _, err := client.StorageActions.Attach(context.Background(), volumeID, id)
 			if err != nil {
-				return fmt.Errorf("Error attaching volume %q to droplet (%s): %s", volumeID, d.Id(), err)
+				return diag.Errorf("Error attaching volume %q to droplet (%s): %s", volumeID, d.Id(), err)
 			}
 			// can't fire >1 action at a time, so waiting for each is OK
 			if err := waitForAction(client, action); err != nil {
-				return fmt.Errorf("Error waiting for volume %q to attach to droplet (%s): %s", volumeID, d.Id(), err)
+				return diag.Errorf("Error waiting for volume %q to attach to droplet (%s): %s", volumeID, d.Id(), err)
 			}
 		}
 		for volumeID := range leftDiff(oldIDSet, newIDSet) {
@@ -594,29 +595,29 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	return resourceDigitalOceanDropletRead(d, meta)
+	return resourceDigitalOceanDropletRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanDropletDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid droplet id: %v", err)
+		return diag.Errorf("invalid droplet id: %v", err)
 	}
 
 	_, err = waitForDropletAttribute(
 		d, "false", []string{"", "true"}, "locked", meta)
 
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error waiting for droplet to be unlocked for destroy (%s): %s", d.Id(), err)
 	}
 
 	log.Printf("[INFO] Trying to Detach Storage Volumes (if any) from droplet: %s", d.Id())
 	err = detachVolumesFromDroplet(d, meta)
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error detaching the volumes from the droplet (%s): %s", d.Id(), err)
 	}
 
@@ -634,7 +635,7 @@ func resourceDigitalOceanDropletDelete(ctx context.Context, d *schema.ResourceDa
 	if err != nil && strings.Contains(err.Error(), "404") {
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("Error deleting droplet: %s", err)
+		return diag.Errorf("Error deleting droplet: %s", err)
 	}
 
 	return nil
@@ -691,8 +692,9 @@ func newDropletStateRefreshFunc(
 			return nil, "", err
 		}
 
-		err = resourceDigitalOceanDropletRead(d, meta)
-		if err != nil {
+		// TODO: See if context can potentially be passed in to this function?
+		diags := resourceDigitalOceanDropletRead(context.Background(), d, meta)
+		if diags.HasError() {
 			return nil, "", err
 		}
 

--- a/digitalocean/resource_digitalocean_droplet_snapshot.go
+++ b/digitalocean/resource_digitalocean_droplet_snapshot.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -55,47 +56,47 @@ func resourceDigitalOceanDropletSnapshot() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDropletSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	resourceId, _ := strconv.Atoi(d.Get("droplet_id").(string))
 	action, _, err := client.DropletActions.Snapshot(context.Background(), resourceId, d.Get("name").(string))
 	if err != nil {
-		return fmt.Errorf("Error creating Droplet Snapshot: %s", err)
+		return diag.Errorf("Error creating Droplet Snapshot: %s", err)
 	}
 
 	if err = waitForAction(client, action); err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error waiting for Droplet snapshot (%v) to finish: %s", resourceId, err)
 	}
 
 	snapshot, err := findSnapshotInSnapshotList(context.Background(), client, *action)
 
 	if err != nil {
-		return fmt.Errorf("Error retriving Droplet Snapshot: %s", err)
+		return diag.Errorf("Error retriving Droplet Snapshot: %s", err)
 	}
 
 	d.SetId(strconv.Itoa(snapshot.ID))
 	if err = d.Set("name", snapshot.Name); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err = d.Set("droplet_id", fmt.Sprintf("%d", snapshot.ID)); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err = d.Set("regions", snapshot.Regions); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err = d.Set("created_at", snapshot.Created); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err = d.Set("min_disk_size", snapshot.MinDiskSize); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceDigitalOceanDropletSnapshotRead(d, meta)
+	return resourceDigitalOceanDropletSnapshotRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	snapshot, resp, err := client.Snapshots.Get(context.Background(), d.Id())
@@ -106,7 +107,7 @@ func resourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Droplet snapshot: %s", err)
+		return diag.Errorf("Error retrieving Droplet snapshot: %s", err)
 	}
 
 	d.Set("name", snapshot.Name)
@@ -119,13 +120,13 @@ func resourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func resourceDigitalOceanDropletSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting snaphot: %s", d.Id())
 	_, err := client.Snapshots.Delete(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting snapshot: %s", err)
+		return diag.Errorf("Error deleting snapshot: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_droplet_snapshot.go
+++ b/digitalocean/resource_digitalocean_droplet_snapshot.go
@@ -14,9 +14,9 @@ import (
 
 func resourceDigitalOceanDropletSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanDropletSnapshotCreate,
-		Read:   resourceDigitalOceanDropletSnapshotRead,
-		Delete: resourceDigitalOceanDropletSnapshotDelete,
+		CreateContext: resourceDigitalOceanDropletSnapshotCreate,
+		ReadContext:   resourceDigitalOceanDropletSnapshotRead,
+		DeleteContext: resourceDigitalOceanDropletSnapshotDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -55,7 +55,7 @@ func resourceDigitalOceanDropletSnapshot() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanDropletSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	resourceId, _ := strconv.Atoi(d.Get("droplet_id").(string))
@@ -95,7 +95,7 @@ func resourceDigitalOceanDropletSnapshotCreate(d *schema.ResourceData, meta inte
 	return resourceDigitalOceanDropletSnapshotRead(d, meta)
 }
 
-func resourceDigitalOceanDropletSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	snapshot, resp, err := client.Snapshots.Get(context.Background(), d.Id())
@@ -119,7 +119,7 @@ func resourceDigitalOceanDropletSnapshotRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func resourceDigitalOceanDropletSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanDropletSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting snaphot: %s", d.Id())

--- a/digitalocean/resource_digitalocean_firewall.go
+++ b/digitalocean/resource_digitalocean_firewall.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -192,19 +193,19 @@ func resourceDigitalOceanFirewall() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts, err := firewallRequest(d, client)
 	if err != nil {
-		return fmt.Errorf("Error in firewall request: %s", err)
+		return diag.Errorf("Error in firewall request: %s", err)
 	}
 
 	log.Printf("[DEBUG] Firewall create configuration: %#v", opts)
 
 	firewall, _, err := client.Firewalls.Create(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating firewall: %s", err)
+		return diag.Errorf("Error creating firewall: %s", err)
 	}
 
 	// Assign the firewall id
@@ -212,10 +213,10 @@ func resourceDigitalOceanFirewallCreate(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[INFO] Firewall ID: %s", d.Id())
 
-	return resourceDigitalOceanFirewallRead(d, meta)
+	return resourceDigitalOceanFirewallRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Retrieve the firewall properties for updating the state
@@ -228,7 +229,7 @@ func resourceDigitalOceanFirewallRead(ctx context.Context, d *schema.ResourceDat
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving firewall: %s", err)
+		return diag.Errorf("Error retrieving firewall: %s", err)
 	}
 
 	d.Set("status", firewall.Status)
@@ -237,43 +238,43 @@ func resourceDigitalOceanFirewallRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("name", firewall.Name)
 
 	if err := d.Set("droplet_ids", flattenFirewallDropletIds(firewall.DropletIDs)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting `droplet_ids`: %+v", err)
+		return diag.Errorf("[DEBUG] Error setting `droplet_ids`: %+v", err)
 	}
 
 	if err := d.Set("inbound_rule", flattenFirewallInboundRules(firewall.InboundRules)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Firewall inbound_rule error: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting Firewall inbound_rule error: %#v", err)
 	}
 
 	if err := d.Set("outbound_rule", flattenFirewallOutboundRules(firewall.OutboundRules)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Firewall outbound_rule error: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting Firewall outbound_rule error: %#v", err)
 	}
 
 	if err := d.Set("tags", flattenTags(firewall.Tags)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting `tags`: %+v", err)
+		return diag.Errorf("[DEBUG] Error setting `tags`: %+v", err)
 	}
 
 	return nil
 }
 
-func resourceDigitalOceanFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts, err := firewallRequest(d, client)
 	if err != nil {
-		return fmt.Errorf("Error in firewall request: %s", err)
+		return diag.Errorf("Error in firewall request: %s", err)
 	}
 
 	log.Printf("[DEBUG] Firewall update configuration: %#v", opts)
 
 	_, _, err = client.Firewalls.Update(context.Background(), d.Id(), opts)
 	if err != nil {
-		return fmt.Errorf("Error updating firewall: %s", err)
+		return diag.Errorf("Error updating firewall: %s", err)
 	}
 
-	return resourceDigitalOceanFirewallRead(d, meta)
+	return resourceDigitalOceanFirewallRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting firewall: %s", d.Id())
@@ -287,7 +288,7 @@ func resourceDigitalOceanFirewallDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error deleting firewall: %s", err)
+		return diag.Errorf("Error deleting firewall: %s", err)
 	}
 
 	return nil

--- a/digitalocean/resource_digitalocean_firewall.go
+++ b/digitalocean/resource_digitalocean_firewall.go
@@ -13,10 +13,10 @@ import (
 
 func resourceDigitalOceanFirewall() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanFirewallCreate,
-		Read:   resourceDigitalOceanFirewallRead,
-		Update: resourceDigitalOceanFirewallUpdate,
-		Delete: resourceDigitalOceanFirewallDelete,
+		CreateContext: resourceDigitalOceanFirewallCreate,
+		ReadContext:   resourceDigitalOceanFirewallRead,
+		UpdateContext: resourceDigitalOceanFirewallUpdate,
+		DeleteContext: resourceDigitalOceanFirewallDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -192,7 +192,7 @@ func resourceDigitalOceanFirewall() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts, err := firewallRequest(d, client)
@@ -215,7 +215,7 @@ func resourceDigitalOceanFirewallCreate(d *schema.ResourceData, meta interface{}
 	return resourceDigitalOceanFirewallRead(d, meta)
 }
 
-func resourceDigitalOceanFirewallRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Retrieve the firewall properties for updating the state
@@ -255,7 +255,7 @@ func resourceDigitalOceanFirewallRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceDigitalOceanFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts, err := firewallRequest(d, client)
@@ -273,7 +273,7 @@ func resourceDigitalOceanFirewallUpdate(d *schema.ResourceData, meta interface{}
 	return resourceDigitalOceanFirewallRead(d, meta)
 }
 
-func resourceDigitalOceanFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting firewall: %s", d.Id())

--- a/digitalocean/resource_digitalocean_floating_ip.go
+++ b/digitalocean/resource_digitalocean_floating_ip.go
@@ -15,10 +15,10 @@ import (
 
 func resourceDigitalOceanFloatingIp() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanFloatingIpCreate,
-		Update: resourceDigitalOceanFloatingIpUpdate,
-		Read:   resourceDigitalOceanFloatingIpRead,
-		Delete: resourceDigitalOceanFloatingIpDelete,
+		CreateContext: resourceDigitalOceanFloatingIpCreate,
+		UpdateContext: resourceDigitalOceanFloatingIpUpdate,
+		ReadContext:   resourceDigitalOceanFloatingIpRead,
+		DeleteContext: resourceDigitalOceanFloatingIpDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanFloatingIpImport,
 		},
@@ -53,7 +53,7 @@ func resourceDigitalOceanFloatingIp() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanFloatingIpCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Create a FloatingIP In a Region")
@@ -88,7 +88,7 @@ func resourceDigitalOceanFloatingIpCreate(d *schema.ResourceData, meta interface
 	return resourceDigitalOceanFloatingIpRead(d, meta)
 }
 
-func resourceDigitalOceanFloatingIpUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("droplet_id") {
@@ -124,7 +124,7 @@ func resourceDigitalOceanFloatingIpUpdate(d *schema.ResourceData, meta interface
 	return resourceDigitalOceanFloatingIpRead(d, meta)
 }
 
-func resourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Reading the details of the FloatingIP %s", d.Id())
@@ -172,7 +172,7 @@ func resourceDigitalOceanFloatingIpImport(rs *schema.ResourceData, v interface{}
 	return []*schema.ResourceData{rs}, nil
 }
 
-func resourceDigitalOceanFloatingIpDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if _, ok := d.GetOk("droplet_id"); ok {

--- a/digitalocean/resource_digitalocean_floating_ip_assignment.go
+++ b/digitalocean/resource_digitalocean_floating_ip_assignment.go
@@ -13,9 +13,9 @@ import (
 
 func resourceDigitalOceanFloatingIpAssignment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanFloatingIpAssignmentCreate,
-		Read:   resourceDigitalOceanFloatingIpAssignmentRead,
-		Delete: resourceDigitalOceanFloatingIpAssignmentDelete,
+		CreateContext: resourceDigitalOceanFloatingIpAssignmentCreate,
+		ReadContext:   resourceDigitalOceanFloatingIpAssignmentRead,
+		DeleteContext: resourceDigitalOceanFloatingIpAssignmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -38,7 +38,7 @@ func resourceDigitalOceanFloatingIpAssignment() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanFloatingIpAssignmentCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ip_address := d.Get("ip_address").(string)
@@ -61,7 +61,7 @@ func resourceDigitalOceanFloatingIpAssignmentCreate(d *schema.ResourceData, meta
 	return resourceDigitalOceanFloatingIpAssignmentRead(d, meta)
 }
 
-func resourceDigitalOceanFloatingIpAssignmentRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ip_address := d.Get("ip_address").(string)
@@ -81,7 +81,7 @@ func resourceDigitalOceanFloatingIpAssignmentRead(d *schema.ResourceData, meta i
 	return nil
 }
 
-func resourceDigitalOceanFloatingIpAssignmentDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ip_address := d.Get("ip_address").(string)

--- a/digitalocean/resource_digitalocean_floating_ip_assignment.go
+++ b/digitalocean/resource_digitalocean_floating_ip_assignment.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -38,7 +39,7 @@ func resourceDigitalOceanFloatingIpAssignment() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanFloatingIpAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ip_address := d.Get("ip_address").(string)
@@ -47,21 +48,21 @@ func resourceDigitalOceanFloatingIpAssignmentCreate(ctx context.Context, d *sche
 	log.Printf("[INFO] Assigning the Floating IP (%s) to the Droplet %d", ip_address, droplet_id)
 	action, _, err := client.FloatingIPActions.Assign(context.Background(), ip_address, droplet_id)
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error Assigning FloatingIP (%s) to the droplet: %s", ip_address, err)
 	}
 
 	_, unassignedErr := waitForFloatingIPAssignmentReady(d, "completed", []string{"new", "in-progress"}, "status", meta, action.ID)
 	if unassignedErr != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error waiting for FloatingIP (%s) to be Assigned: %s", ip_address, unassignedErr)
 	}
 
 	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%d-%s-", droplet_id, ip_address)))
-	return resourceDigitalOceanFloatingIpAssignmentRead(d, meta)
+	return resourceDigitalOceanFloatingIpAssignmentRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanFloatingIpAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ip_address := d.Get("ip_address").(string)
@@ -70,7 +71,7 @@ func resourceDigitalOceanFloatingIpAssignmentRead(ctx context.Context, d *schema
 	log.Printf("[INFO] Reading the details of the FloatingIP %s", ip_address)
 	floatingIp, _, err := client.FloatingIPs.Get(context.Background(), ip_address)
 	if err != nil {
-		return fmt.Errorf("Error retrieving FloatingIP: %s", err)
+		return diag.Errorf("Error retrieving FloatingIP: %s", err)
 	}
 
 	if floatingIp.Droplet == nil || floatingIp.Droplet.ID != droplet_id {
@@ -81,7 +82,7 @@ func resourceDigitalOceanFloatingIpAssignmentRead(ctx context.Context, d *schema
 	return nil
 }
 
-func resourceDigitalOceanFloatingIpAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanFloatingIpAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	ip_address := d.Get("ip_address").(string)
@@ -90,19 +91,19 @@ func resourceDigitalOceanFloatingIpAssignmentDelete(ctx context.Context, d *sche
 	log.Printf("[INFO] Reading the details of the FloatingIP %s", ip_address)
 	floatingIp, _, err := client.FloatingIPs.Get(context.Background(), ip_address)
 	if err != nil {
-		return fmt.Errorf("Error retrieving FloatingIP: %s", err)
+		return diag.Errorf("Error retrieving FloatingIP: %s", err)
 	}
 
 	if floatingIp.Droplet.ID == droplet_id {
 		log.Printf("[INFO] Unassigning the Floating IP from the Droplet")
 		action, _, err := client.FloatingIPActions.Unassign(context.Background(), ip_address)
 		if err != nil {
-			return fmt.Errorf("Error unassigning FloatingIP (%s) from the droplet: %s", ip_address, err)
+			return diag.Errorf("Error unassigning FloatingIP (%s) from the droplet: %s", ip_address, err)
 		}
 
 		_, unassignedErr := waitForFloatingIPAssignmentReady(d, "completed", []string{"new", "in-progress"}, "status", meta, action.ID)
 		if unassignedErr != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for FloatingIP (%s) to be unassigned: %s", ip_address, unassignedErr)
 		}
 	} else {

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -18,10 +18,10 @@ import (
 
 func resourceDigitalOceanKubernetesCluster() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanKubernetesClusterCreate,
-		Read:   resourceDigitalOceanKubernetesClusterRead,
-		Update: resourceDigitalOceanKubernetesClusterUpdate,
-		Delete: resourceDigitalOceanKubernetesClusterDelete,
+		CreateContext: resourceDigitalOceanKubernetesClusterCreate,
+		ReadContext:   resourceDigitalOceanKubernetesClusterRead,
+		UpdateContext: resourceDigitalOceanKubernetesClusterUpdate,
+		DeleteContext: resourceDigitalOceanKubernetesClusterDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanKubernetesClusterImportState,
 		},
@@ -187,7 +187,7 @@ func kubernetesConfigSchema() *schema.Schema {
 	}
 }
 
-func resourceDigitalOceanKubernetesClusterCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	pools := expandNodePools(d.Get("node_pool").([]interface{}))
@@ -240,7 +240,7 @@ func resourceDigitalOceanKubernetesClusterCreate(d *schema.ResourceData, meta in
 	return resourceDigitalOceanKubernetesClusterRead(d, meta)
 }
 
-func resourceDigitalOceanKubernetesClusterRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	cluster, resp, err := client.Kubernetes.Get(context.Background(), d.Id())
@@ -321,7 +321,7 @@ func digitaloceanKubernetesClusterRead(client *godo.Client, cluster *godo.Kubern
 	return nil
 }
 
-func resourceDigitalOceanKubernetesClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Figure out the changes and then call the appropriate API methods
@@ -379,7 +379,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(d *schema.ResourceData, meta in
 	return resourceDigitalOceanKubernetesClusterRead(d, meta)
 }
 
-func resourceDigitalOceanKubernetesClusterDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	resp, err := client.Kubernetes.Delete(context.Background(), d.Id())

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -175,7 +176,7 @@ func nodeSchema() *schema.Schema {
 	}
 }
 
-func resourceDigitalOceanKubernetesNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	rawPool := map[string]interface{}{
@@ -191,15 +192,15 @@ func resourceDigitalOceanKubernetesNodePoolCreate(ctx context.Context, d *schema
 
 	pool, err := digitaloceanKubernetesNodePoolCreate(client, rawPool, d.Get("cluster_id").(string))
 	if err != nil {
-		return fmt.Errorf("Error creating Kubernetes node pool: %s", err)
+		return diag.Errorf("Error creating Kubernetes node pool: %s", err)
 	}
 
 	d.SetId(pool.ID)
 
-	return resourceDigitalOceanKubernetesNodePoolRead(d, meta)
+	return resourceDigitalOceanKubernetesNodePoolRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanKubernetesNodePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	pool, resp, err := client.Kubernetes.GetNodePool(context.Background(), d.Get("cluster_id").(string), d.Id())
@@ -209,7 +210,7 @@ func resourceDigitalOceanKubernetesNodePoolRead(ctx context.Context, d *schema.R
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Kubernetes node pool: %s", err)
+		return diag.Errorf("Error retrieving Kubernetes node pool: %s", err)
 	}
 
 	d.Set("name", pool.Name)
@@ -232,7 +233,7 @@ func resourceDigitalOceanKubernetesNodePoolRead(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceDigitalOceanKubernetesNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	rawPool := map[string]interface{}{
@@ -251,13 +252,13 @@ func resourceDigitalOceanKubernetesNodePoolUpdate(ctx context.Context, d *schema
 
 	_, err := digitaloceanKubernetesNodePoolUpdate(client, rawPool, d.Get("cluster_id").(string), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error updating node pool: %s", err)
+		return diag.Errorf("Error updating node pool: %s", err)
 	}
 
-	return resourceDigitalOceanKubernetesNodePoolRead(d, meta)
+	return resourceDigitalOceanKubernetesNodePoolRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanKubernetesNodePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	return digitaloceanKubernetesNodePoolDelete(client, d.Get("cluster_id").(string), d.Id())
@@ -403,16 +404,16 @@ func digitaloceanKubernetesNodePoolUpdate(client *godo.Client, pool map[string]i
 	return p, nil
 }
 
-func digitaloceanKubernetesNodePoolDelete(client *godo.Client, clusterID, poolID string) error {
+func digitaloceanKubernetesNodePoolDelete(client *godo.Client, clusterID, poolID string) diag.Diagnostics {
 	// delete the old pool
 	_, err := client.Kubernetes.DeleteNodePool(context.Background(), clusterID, poolID)
 	if err != nil {
-		return fmt.Errorf("Unable to delete node pool %s", err)
+		return diag.Errorf("Unable to delete node pool %s", err)
 	}
 
 	err = waitForKubernetesNodePoolDelete(client, clusterID, poolID)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -19,10 +19,10 @@ const digitaloceanKubernetesDefaultNodePoolTag = "terraform:default-node-pool"
 func resourceDigitalOceanKubernetesNodePool() *schema.Resource {
 
 	return &schema.Resource{
-		Create: resourceDigitalOceanKubernetesNodePoolCreate,
-		Read:   resourceDigitalOceanKubernetesNodePoolRead,
-		Update: resourceDigitalOceanKubernetesNodePoolUpdate,
-		Delete: resourceDigitalOceanKubernetesNodePoolDelete,
+		CreateContext: resourceDigitalOceanKubernetesNodePoolCreate,
+		ReadContext:   resourceDigitalOceanKubernetesNodePoolRead,
+		UpdateContext: resourceDigitalOceanKubernetesNodePoolUpdate,
+		DeleteContext: resourceDigitalOceanKubernetesNodePoolDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanKubernetesNodePoolImportState,
 		},
@@ -175,7 +175,7 @@ func nodeSchema() *schema.Schema {
 	}
 }
 
-func resourceDigitalOceanKubernetesNodePoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	rawPool := map[string]interface{}{
@@ -199,7 +199,7 @@ func resourceDigitalOceanKubernetesNodePoolCreate(d *schema.ResourceData, meta i
 	return resourceDigitalOceanKubernetesNodePoolRead(d, meta)
 }
 
-func resourceDigitalOceanKubernetesNodePoolRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	pool, resp, err := client.Kubernetes.GetNodePool(context.Background(), d.Get("cluster_id").(string), d.Id())
@@ -232,7 +232,7 @@ func resourceDigitalOceanKubernetesNodePoolRead(d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceDigitalOceanKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	rawPool := map[string]interface{}{
@@ -257,7 +257,7 @@ func resourceDigitalOceanKubernetesNodePoolUpdate(d *schema.ResourceData, meta i
 	return resourceDigitalOceanKubernetesNodePoolRead(d, meta)
 }
 
-func resourceDigitalOceanKubernetesNodePoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanKubernetesNodePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	return digitaloceanKubernetesNodePoolDelete(client, d.Get("cluster_id").(string), d.Id())

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -402,20 +403,20 @@ func buildLoadBalancerRequest(client *godo.Client, d *schema.ResourceData) (*god
 	return opts, nil
 }
 
-func resourceDigitalOceanLoadbalancerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Create a Loadbalancer Request")
 
 	lbOpts, err := buildLoadBalancerRequest(client, d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Loadbalancer Create: %#v", lbOpts)
 	loadbalancer, _, err := client.LoadBalancers.Create(context.Background(), lbOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Load Balancer: %s", err)
+		return diag.Errorf("Error creating Load Balancer: %s", err)
 	}
 
 	d.SetId(loadbalancer.ID)
@@ -429,13 +430,13 @@ func resourceDigitalOceanLoadbalancerCreate(ctx context.Context, d *schema.Resou
 		MinTimeout: 15 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Load Balancer (%s) to become active: %s", d.Get("name"), err)
+		return diag.Errorf("Error waiting for Load Balancer (%s) to become active: %s", d.Get("name"), err)
 	}
 
-	return resourceDigitalOceanLoadbalancerRead(d, meta)
+	return resourceDigitalOceanLoadbalancerRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Reading the details of the Loadbalancer %s", d.Id())
@@ -446,7 +447,7 @@ func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Loadbalancer: %s", err)
+		return diag.Errorf("Error retrieving Loadbalancer: %s", err)
 	}
 
 	d.Set("name", loadbalancer.Name)
@@ -462,54 +463,54 @@ func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resourc
 	d.Set("vpc_uuid", loadbalancer.VPCUUID)
 
 	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Load Balancer droplet_ids - error: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting Load Balancer droplet_ids - error: %#v", err)
 	}
 
 	if err := d.Set("sticky_sessions", flattenStickySessions(loadbalancer.StickySessions)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Load Balancer sticky_sessions - error: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting Load Balancer sticky_sessions - error: %#v", err)
 	}
 
 	if err := d.Set("healthcheck", flattenHealthChecks(loadbalancer.HealthCheck)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Load Balancer healthcheck - error: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting Load Balancer healthcheck - error: %#v", err)
 	}
 
 	forwardingRules, err := flattenForwardingRules(client, loadbalancer.ForwardingRules)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Error building Load Balancer forwarding rules - error: %#v", err)
+		return diag.Errorf("[DEBUG] Error building Load Balancer forwarding rules - error: %#v", err)
 	}
 
 	if err := d.Set("forwarding_rule", forwardingRules); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Load Balancer forwarding_rule - error: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting Load Balancer forwarding_rule - error: %#v", err)
 	}
 
 	return nil
 
 }
 
-func resourceDigitalOceanLoadbalancerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	lbOpts, err := buildLoadBalancerRequest(client, d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Load Balancer Update: %#v", lbOpts)
 	_, _, err = client.LoadBalancers.Update(context.Background(), d.Id(), lbOpts)
 	if err != nil {
-		return fmt.Errorf("Error updating Load Balancer: %s", err)
+		return diag.Errorf("Error updating Load Balancer: %s", err)
 	}
 
-	return resourceDigitalOceanLoadbalancerRead(d, meta)
+	return resourceDigitalOceanLoadbalancerRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanLoadbalancerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting Load Balancer: %s", d.Id())
 	_, err := client.LoadBalancers.Delete(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting Load Balancer: %s", err)
+		return diag.Errorf("Error deleting Load Balancer: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -15,10 +15,10 @@ import (
 
 func resourceDigitalOceanLoadbalancer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanLoadbalancerCreate,
-		Read:   resourceDigitalOceanLoadbalancerRead,
-		Update: resourceDigitalOceanLoadbalancerUpdate,
-		Delete: resourceDigitalOceanLoadbalancerDelete,
+		CreateContext: resourceDigitalOceanLoadbalancerCreate,
+		ReadContext:   resourceDigitalOceanLoadbalancerRead,
+		UpdateContext: resourceDigitalOceanLoadbalancerUpdate,
+		DeleteContext: resourceDigitalOceanLoadbalancerDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -402,7 +402,7 @@ func buildLoadBalancerRequest(client *godo.Client, d *schema.ResourceData) (*god
 	return opts, nil
 }
 
-func resourceDigitalOceanLoadbalancerCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Create a Loadbalancer Request")
@@ -435,7 +435,7 @@ func resourceDigitalOceanLoadbalancerCreate(d *schema.ResourceData, meta interfa
 	return resourceDigitalOceanLoadbalancerRead(d, meta)
 }
 
-func resourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Reading the details of the Loadbalancer %s", d.Id())
@@ -486,7 +486,7 @@ func resourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interface
 
 }
 
-func resourceDigitalOceanLoadbalancerUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	lbOpts, err := buildLoadBalancerRequest(client, d)
@@ -503,7 +503,7 @@ func resourceDigitalOceanLoadbalancerUpdate(d *schema.ResourceData, meta interfa
 	return resourceDigitalOceanLoadbalancerRead(d, meta)
 }
 
-func resourceDigitalOceanLoadbalancerDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanLoadbalancerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting Load Balancer: %s", d.Id())

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -13,10 +13,10 @@ import (
 
 func resourceDigitalOceanProject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanProjectCreate,
-		Read:   resourceDigitalOceanProjectRead,
-		Update: resourceDigitalOceanProjectUpdate,
-		Delete: resourceDigitalOceanProjectDelete,
+		CreateContext: resourceDigitalOceanProjectCreate,
+		ReadContext:   resourceDigitalOceanProjectRead,
+		UpdateContext: resourceDigitalOceanProjectUpdate,
+		DeleteContext: resourceDigitalOceanProjectDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -90,7 +90,7 @@ func resourceDigitalOceanProject() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanProjectCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	projectRequest := &godo.CreateProjectRequest{
@@ -129,7 +129,7 @@ func resourceDigitalOceanProjectCreate(d *schema.ResourceData, meta interface{})
 	return resourceDigitalOceanProjectRead(d, meta)
 }
 
-func resourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	project, resp, err := client.Projects.Get(context.Background(), d.Id())
@@ -184,7 +184,7 @@ func resourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceDigitalOceanProjectUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	projectId := d.Id()
 
@@ -229,7 +229,7 @@ func resourceDigitalOceanProjectUpdate(d *schema.ResourceData, meta interface{})
 	return resourceDigitalOceanProjectRead(d, meta)
 }
 
-func resourceDigitalOceanProjectDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	projectId := d.Id()

--- a/digitalocean/resource_digitalocean_project_resources.go
+++ b/digitalocean/resource_digitalocean_project_resources.go
@@ -10,10 +10,10 @@ import (
 
 func resourceDigitalOceanProjectResources() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanProjectResourcesUpdate,
-		Update: resourceDigitalOceanProjectResourcesUpdate,
-		Read:   resourceDigitalOceanProjectResourcesRead,
-		Delete: resourceDigitalOceanProjectResourcesDelete,
+		CreateContext: resourceDigitalOceanProjectResourcesUpdate,
+		UpdateContext: resourceDigitalOceanProjectResourcesUpdate,
+		ReadContext:   resourceDigitalOceanProjectResourcesRead,
+		DeleteContext: resourceDigitalOceanProjectResourcesDelete,
 
 		Schema: map[string]*schema.Schema{
 			"project": {
@@ -33,7 +33,7 @@ func resourceDigitalOceanProjectResources() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanProjectResourcesUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectResourcesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	projectId := d.Get("project").(string)
@@ -78,7 +78,7 @@ func resourceDigitalOceanProjectResourcesUpdate(d *schema.ResourceData, meta int
 	return resourceDigitalOceanProjectResourcesRead(d, meta)
 }
 
-func resourceDigitalOceanProjectResourcesRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectResourcesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	projectId := d.Id()
@@ -123,7 +123,7 @@ func resourceDigitalOceanProjectResourcesRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceDigitalOceanProjectResourcesDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanProjectResourcesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	projectId := d.Get("project").(string)

--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -14,10 +14,10 @@ import (
 
 func resourceDigitalOceanRecord() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanRecordCreate,
-		Read:   resourceDigitalOceanRecordRead,
-		Update: resourceDigitalOceanRecordUpdate,
-		Delete: resourceDigitalOceanRecordDelete,
+		CreateContext: resourceDigitalOceanRecordCreate,
+		ReadContext:   resourceDigitalOceanRecordRead,
+		UpdateContext: resourceDigitalOceanRecordUpdate,
+		DeleteContext: resourceDigitalOceanRecordDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanRecordImport,
 		},
@@ -154,7 +154,7 @@ func resourceDigitalOceanRecord() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	newRecord, err := expandDigitalOceanRecordResource(d)
@@ -176,7 +176,7 @@ func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanRecordRead(d, meta)
 }
 
-func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	domain := d.Get("domain").(string)
 	id, err := strconv.Atoi(d.Id())
@@ -235,7 +235,7 @@ func resourceDigitalOceanRecordImport(d *schema.ResourceData, meta interface{}) 
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDigitalOceanRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	domain := d.Get("domain").(string)
@@ -258,7 +258,7 @@ func resourceDigitalOceanRecordUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanRecordRead(d, meta)
 }
 
-func resourceDigitalOceanRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	domain := d.Get("domain").(string)

--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -154,12 +155,12 @@ func resourceDigitalOceanRecord() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	newRecord, err := expandDigitalOceanRecordResource(d)
 	if err != nil {
-		return fmt.Errorf("Error in constructing record request: %s", err)
+		return diag.Errorf("Error in constructing record request: %s", err)
 	}
 
 	newRecord.Type = d.Get("type").(string)
@@ -167,21 +168,21 @@ func resourceDigitalOceanRecordCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] record create configuration: %#v", newRecord)
 	rec, _, err := client.Domains.CreateRecord(context.Background(), d.Get("domain").(string), newRecord)
 	if err != nil {
-		return fmt.Errorf("Failed to create record: %s", err)
+		return diag.Errorf("Failed to create record: %s", err)
 	}
 
 	d.SetId(strconv.Itoa(rec.ID))
 	log.Printf("[INFO] Record ID: %s", d.Id())
 
-	return resourceDigitalOceanRecordRead(d, meta)
+	return resourceDigitalOceanRecordRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	domain := d.Get("domain").(string)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid record ID: %v", err)
+		return diag.Errorf("invalid record ID: %v", err)
 	}
 
 	rec, resp, err := client.Domains.Record(context.Background(), domain, id)
@@ -193,7 +194,7 @@ func resourceDigitalOceanRecordRead(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 
-		return err
+		return diag.FromErr(err)
 	}
 
 	if t := rec.Type; t == "CNAME" || t == "MX" || t == "NS" || t == "SRV" || t == "CAA" {
@@ -235,36 +236,36 @@ func resourceDigitalOceanRecordImport(d *schema.ResourceData, meta interface{}) 
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDigitalOceanRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	domain := d.Get("domain").(string)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid record ID: %v", err)
+		return diag.Errorf("invalid record ID: %v", err)
 	}
 
 	editRecord, err := expandDigitalOceanRecordResource(d)
 	if err != nil {
-		return fmt.Errorf("Error in constructing record request: %s", err)
+		return diag.Errorf("Error in constructing record request: %s", err)
 	}
 
 	log.Printf("[DEBUG] record update configuration: %#v", editRecord)
 	_, _, err = client.Domains.EditRecord(context.Background(), domain, id, editRecord)
 	if err != nil {
-		return fmt.Errorf("Failed to update record: %s", err)
+		return diag.Errorf("Failed to update record: %s", err)
 	}
 
-	return resourceDigitalOceanRecordRead(d, meta)
+	return resourceDigitalOceanRecordRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	domain := d.Get("domain").(string)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid record ID: %v", err)
+		return diag.Errorf("invalid record ID: %v", err)
 	}
 
 	log.Printf("[INFO] Deleting record: %s, %d", domain, id)
@@ -277,7 +278,7 @@ func resourceDigitalOceanRecordDelete(ctx context.Context, d *schema.ResourceDat
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting record: %s", delErr)
+		return diag.Errorf("Error deleting record: %s", delErr)
 	}
 
 	return nil

--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -18,10 +19,10 @@ import (
 
 func resourceDigitalOceanBucket() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanBucketCreate,
-		Read:   resourceDigitalOceanBucketRead,
-		Update: resourceDigitalOceanBucketUpdate,
-		Delete: resourceDigitalOceanBucketDelete,
+		CreateContext: resourceDigitalOceanBucketCreate,
+		ReadContext:   resourceDigitalOceanBucketRead,
+		UpdateContext: resourceDigitalOceanBucketUpdate,
+		DeleteContext: resourceDigitalOceanBucketDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanBucketImport,
 		},
@@ -193,7 +194,7 @@ func resourceDigitalOceanBucket() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanBucketCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 
@@ -235,7 +236,7 @@ func resourceDigitalOceanBucketCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanBucketUpdate(d, meta)
 }
 
-func resourceDigitalOceanBucketUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 
@@ -272,7 +273,7 @@ func resourceDigitalOceanBucketUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanBucketRead(d, meta)
 }
 
-func resourceDigitalOceanBucketRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 
@@ -448,7 +449,7 @@ func resourceDigitalOceanBucketRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceDigitalOceanBucketDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 

--- a/digitalocean/resource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_object.go
@@ -20,10 +20,10 @@ import (
 
 func resourceDigitalOceanSpacesBucketObject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanSpacesBucketObjectCreate,
-		Read:   resourceDigitalOceanSpacesBucketObjectRead,
-		Update: resourceDigitalOceanSpacesBucketObjectUpdate,
-		Delete: resourceDigitalOceanSpacesBucketObjectDelete,
+		CreateContext: resourceDigitalOceanSpacesBucketObjectCreate,
+		ReadContext:   resourceDigitalOceanSpacesBucketObjectRead,
+		UpdateContext: resourceDigitalOceanSpacesBucketObjectUpdate,
+		DeleteContext: resourceDigitalOceanSpacesBucketObjectDelete,
 
 		CustomizeDiff: resourceDigitalOceanSpacesBucketObjectCustomizeDiff,
 
@@ -233,11 +233,11 @@ func resourceDigitalOceanSpacesBucketObjectPut(d *schema.ResourceData, meta inte
 	return resourceDigitalOceanSpacesBucketObjectRead(d, meta)
 }
 
-func resourceDigitalOceanSpacesBucketObjectCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	return resourceDigitalOceanSpacesBucketObjectPut(d, meta)
 }
 
-func resourceDigitalOceanSpacesBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	s3conn, err := s3connFromResourceData(d, meta)
 	if err != nil {
 		return err
@@ -288,7 +288,7 @@ func resourceDigitalOceanSpacesBucketObjectRead(d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceDigitalOceanSpacesBucketObjectUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	// Changes to any of these attributes requires creation of a new object version (if bucket is versioned):
 	for _, key := range []string{
 		"cache_control",
@@ -330,7 +330,7 @@ func resourceDigitalOceanSpacesBucketObjectUpdate(d *schema.ResourceData, meta i
 	return resourceDigitalOceanSpacesBucketObjectRead(d, meta)
 }
 
-func resourceDigitalOceanSpacesBucketObjectDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	s3conn, err := s3connFromResourceData(d, meta)
 	if err != nil {
 		return err

--- a/digitalocean/resource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_object.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/go-homedir"
@@ -147,10 +148,10 @@ func s3connFromResourceData(d *schema.ResourceData, meta interface{}) (*s3.S3, e
 	return svc, nil
 }
 
-func resourceDigitalOceanSpacesBucketObjectPut(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	s3conn, err := s3connFromResourceData(d, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var body io.ReadSeeker
@@ -159,11 +160,11 @@ func resourceDigitalOceanSpacesBucketObjectPut(d *schema.ResourceData, meta inte
 		source := v.(string)
 		path, err := homedir.Expand(source)
 		if err != nil {
-			return fmt.Errorf("Error expanding homedir in source (%s): %s", source, err)
+			return diag.Errorf("Error expanding homedir in source (%s): %s", source, err)
 		}
 		file, err := os.Open(path)
 		if err != nil {
-			return fmt.Errorf("Error opening Spaces bucket object source (%s): %s", path, err)
+			return diag.Errorf("Error opening Spaces bucket object source (%s): %s", path, err)
 		}
 
 		body = file
@@ -182,7 +183,7 @@ func resourceDigitalOceanSpacesBucketObjectPut(d *schema.ResourceData, meta inte
 		// the AWS SDK requires an io.ReadSeeker but a base64 decoder can't seek.
 		contentRaw, err := base64.StdEncoding.DecodeString(content)
 		if err != nil {
-			return fmt.Errorf("error decoding content_base64: %s", err)
+			return diag.Errorf("error decoding content_base64: %s", err)
 		}
 		body = bytes.NewReader(contentRaw)
 	}
@@ -226,21 +227,21 @@ func resourceDigitalOceanSpacesBucketObjectPut(d *schema.ResourceData, meta inte
 	}
 
 	if _, err := s3conn.PutObject(putInput); err != nil {
-		return fmt.Errorf("Error putting object in Spaces bucket (%s): %s", bucket, err)
+		return diag.Errorf("Error putting object in Spaces bucket (%s): %s", bucket, err)
 	}
 
 	d.SetId(key)
-	return resourceDigitalOceanSpacesBucketObjectRead(d, meta)
+	return resourceDigitalOceanSpacesBucketObjectRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanSpacesBucketObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
-	return resourceDigitalOceanSpacesBucketObjectPut(d, meta)
+func resourceDigitalOceanSpacesBucketObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceDigitalOceanSpacesBucketObjectPut(ctx, d, meta)
 }
 
-func resourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	s3conn, err := s3connFromResourceData(d, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -259,7 +260,7 @@ func resourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.R
 			log.Printf("[WARN] Error Reading Object (%s), object not found (HTTP status 404)", key)
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 	log.Printf("[DEBUG] Reading Spaces Bucket Object meta: %s", resp)
 
@@ -277,7 +278,7 @@ func resourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.R
 	}
 
 	if err := d.Set("metadata", metadata); err != nil {
-		return fmt.Errorf("error setting metadata: %s", err)
+		return diag.Errorf("error setting metadata: %s", err)
 	}
 	d.Set("version_id", resp.VersionId)
 	d.Set("website_redirect", resp.WebsiteRedirectLocation)
@@ -288,7 +289,7 @@ func resourceDigitalOceanSpacesBucketObjectRead(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceDigitalOceanSpacesBucketObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Changes to any of these attributes requires creation of a new object version (if bucket is versioned):
 	for _, key := range []string{
 		"cache_control",
@@ -304,13 +305,13 @@ func resourceDigitalOceanSpacesBucketObjectUpdate(ctx context.Context, d *schema
 		"website_redirect",
 	} {
 		if d.HasChange(key) {
-			return resourceDigitalOceanSpacesBucketObjectPut(d, meta)
+			return resourceDigitalOceanSpacesBucketObjectPut(ctx, d, meta)
 		}
 	}
 
 	conn, err := s3connFromResourceData(d, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -323,17 +324,17 @@ func resourceDigitalOceanSpacesBucketObjectUpdate(ctx context.Context, d *schema
 			ACL:    aws.String(d.Get("acl").(string)),
 		})
 		if err != nil {
-			return fmt.Errorf("error putting Spaces object ACL: %s", err)
+			return diag.Errorf("error putting Spaces object ACL: %s", err)
 		}
 	}
 
-	return resourceDigitalOceanSpacesBucketObjectRead(d, meta)
+	return resourceDigitalOceanSpacesBucketObjectRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanSpacesBucketObjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSpacesBucketObjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	s3conn, err := s3connFromResourceData(d, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -348,7 +349,7 @@ func resourceDigitalOceanSpacesBucketObjectDelete(ctx context.Context, d *schema
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Spaces Bucket (%s) Object (%s): %s", bucket, key, err)
+		return diag.Errorf("error deleting Spaces Bucket (%s) Object (%s): %s", bucket, key, err)
 	}
 
 	return nil

--- a/digitalocean/resource_digitalocean_ssh_key.go
+++ b/digitalocean/resource_digitalocean_ssh_key.go
@@ -2,12 +2,12 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strconv"
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -49,7 +49,7 @@ func resourceDigitalOceanSSHKeyPublicKeyDiffSuppress(k, old, new string, d *sche
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 
-func resourceDigitalOceanSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -61,21 +61,21 @@ func resourceDigitalOceanSSHKeyCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] SSH Key create configuration: %#v", opts)
 	key, _, err := client.Keys.Create(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating SSH Key: %s", err)
+		return diag.Errorf("Error creating SSH Key: %s", err)
 	}
 
 	d.SetId(strconv.Itoa(key.ID))
 	log.Printf("[INFO] SSH Key: %d", key.ID)
 
-	return resourceDigitalOceanSSHKeyRead(d, meta)
+	return resourceDigitalOceanSSHKeyRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid SSH key id: %v", err)
+		return diag.Errorf("invalid SSH key id: %v", err)
 	}
 
 	key, resp, err := client.Keys.GetByID(context.Background(), id)
@@ -87,7 +87,7 @@ func resourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving SSH key: %s", err)
+		return diag.Errorf("Error retrieving SSH key: %s", err)
 	}
 
 	d.Set("name", key.Name)
@@ -97,12 +97,12 @@ func resourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceDigitalOceanSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid SSH key id: %v", err)
+		return diag.Errorf("invalid SSH key id: %v", err)
 	}
 
 	var newName string
@@ -116,24 +116,24 @@ func resourceDigitalOceanSSHKeyUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 	_, _, err = client.Keys.UpdateByID(context.Background(), id, opts)
 	if err != nil {
-		return fmt.Errorf("Failed to update SSH key: %s", err)
+		return diag.Errorf("Failed to update SSH key: %s", err)
 	}
 
-	return resourceDigitalOceanSSHKeyRead(d, meta)
+	return resourceDigitalOceanSSHKeyRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("invalid SSH key id: %v", err)
+		return diag.Errorf("invalid SSH key id: %v", err)
 	}
 
 	log.Printf("[INFO] Deleting SSH key: %d", id)
 	_, err = client.Keys.DeleteByID(context.Background(), id)
 	if err != nil {
-		return fmt.Errorf("Error deleting SSH key: %s", err)
+		return diag.Errorf("Error deleting SSH key: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_ssh_key.go
+++ b/digitalocean/resource_digitalocean_ssh_key.go
@@ -14,10 +14,10 @@ import (
 
 func resourceDigitalOceanSSHKey() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanSSHKeyCreate,
-		Read:   resourceDigitalOceanSSHKeyRead,
-		Update: resourceDigitalOceanSSHKeyUpdate,
-		Delete: resourceDigitalOceanSSHKeyDelete,
+		CreateContext: resourceDigitalOceanSSHKeyCreate,
+		ReadContext:   resourceDigitalOceanSSHKeyRead,
+		UpdateContext: resourceDigitalOceanSSHKeyUpdate,
+		DeleteContext: resourceDigitalOceanSSHKeyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -49,7 +49,7 @@ func resourceDigitalOceanSSHKeyPublicKeyDiffSuppress(k, old, new string, d *sche
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 
-func resourceDigitalOceanSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -70,7 +70,7 @@ func resourceDigitalOceanSSHKeyCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanSSHKeyRead(d, meta)
 }
 
-func resourceDigitalOceanSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
@@ -97,7 +97,7 @@ func resourceDigitalOceanSSHKeyRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceDigitalOceanSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())
@@ -122,7 +122,7 @@ func resourceDigitalOceanSSHKeyUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanSSHKeyRead(d, meta)
 }
 
-func resourceDigitalOceanSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id, err := strconv.Atoi(d.Id())

--- a/digitalocean/resource_digitalocean_tag.go
+++ b/digitalocean/resource_digitalocean_tag.go
@@ -11,9 +11,9 @@ import (
 
 func resourceDigitalOceanTag() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanTagCreate,
-		Read:   resourceDigitalOceanTagRead,
-		Delete: resourceDigitalOceanTagDelete,
+		CreateContext: resourceDigitalOceanTagCreate,
+		ReadContext:   resourceDigitalOceanTagRead,
+		DeleteContext: resourceDigitalOceanTagDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -53,7 +53,7 @@ func resourceDigitalOceanTag() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanTagCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -73,7 +73,7 @@ func resourceDigitalOceanTagCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanTagRead(d, meta)
 }
 
-func resourceDigitalOceanTagRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	tag, resp, err := client.Tags.Get(context.Background(), d.Id())
@@ -99,7 +99,7 @@ func resourceDigitalOceanTagRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceDigitalOceanTagDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting tag: %s", d.Id())

--- a/digitalocean/resource_digitalocean_tag.go
+++ b/digitalocean/resource_digitalocean_tag.go
@@ -2,10 +2,10 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -53,7 +53,7 @@ func resourceDigitalOceanTag() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	// Build up our creation options
@@ -64,16 +64,16 @@ func resourceDigitalOceanTagCreate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] Tag create configuration: %#v", opts)
 	tag, _, err := client.Tags.Create(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating tag: %s", err)
+		return diag.Errorf("Error creating tag: %s", err)
 	}
 
 	d.SetId(tag.Name)
 	log.Printf("[INFO] Tag: %s", tag.Name)
 
-	return resourceDigitalOceanTagRead(d, meta)
+	return resourceDigitalOceanTagRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	tag, resp, err := client.Tags.Get(context.Background(), d.Id())
@@ -85,7 +85,7 @@ func resourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, me
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving tag: %s", err)
+		return diag.Errorf("Error retrieving tag: %s", err)
 	}
 
 	d.Set("name", tag.Name)
@@ -99,13 +99,13 @@ func resourceDigitalOceanTagRead(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDigitalOceanTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting tag: %s", d.Id())
 	_, err := client.Tags.Delete(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting tag: %s", err)
+		return diag.Errorf("Error deleting tag: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -13,10 +13,10 @@ import (
 
 func resourceDigitalOceanVolume() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanVolumeCreate,
-		Read:   resourceDigitalOceanVolumeRead,
-		Update: resourceDigitalOceanVolumeUpdate,
-		Delete: resourceDigitalOceanVolumeDelete,
+		CreateContext: resourceDigitalOceanVolumeCreate,
+		ReadContext:   resourceDigitalOceanVolumeRead,
+		UpdateContext: resourceDigitalOceanVolumeUpdate,
+		DeleteContext: resourceDigitalOceanVolumeDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -120,7 +120,7 @@ func resourceDigitalOceanVolume() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVolumeCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.VolumeCreateRequest{
@@ -160,7 +160,7 @@ func resourceDigitalOceanVolumeCreate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanVolumeRead(d, meta)
 }
 
-func resourceDigitalOceanVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id := d.Id()
@@ -192,7 +192,7 @@ func resourceDigitalOceanVolumeUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceDigitalOceanVolumeRead(d, meta)
 }
 
-func resourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	volume, resp, err := client.Storage.GetVolume(context.Background(), d.Id())
@@ -230,7 +230,7 @@ func resourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceDigitalOceanVolumeDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting volume: %s", d.Id())

--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -120,7 +121,7 @@ func resourceDigitalOceanVolume() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.VolumeCreateRequest{
@@ -151,16 +152,16 @@ func resourceDigitalOceanVolumeCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] Volume create configuration: %#v", opts)
 	volume, _, err := client.Storage.CreateVolume(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating Volume: %s", err)
+		return diag.Errorf("Error creating Volume: %s", err)
 	}
 
 	d.SetId(volume.ID)
 	log.Printf("[INFO] Volume name: %s", volume.Name)
 
-	return resourceDigitalOceanVolumeRead(d, meta)
+	return resourceDigitalOceanVolumeRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	id := d.Id()
@@ -172,12 +173,12 @@ func resourceDigitalOceanVolumeUpdate(ctx context.Context, d *schema.ResourceDat
 		log.Printf("[DEBUG] Volume resize configuration: %v", size)
 		action, _, err := client.StorageActions.Resize(context.Background(), id, size, region)
 		if err != nil {
-			return fmt.Errorf("Error resizing volume (%s): %s", id, err)
+			return diag.Errorf("Error resizing volume (%s): %s", id, err)
 		}
 
 		log.Printf("[DEBUG] Volume resize action id: %d", action.ID)
 		if err = waitForAction(client, action); err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error waiting for resize volume (%s) to finish: %s", id, err)
 		}
 	}
@@ -185,14 +186,14 @@ func resourceDigitalOceanVolumeUpdate(ctx context.Context, d *schema.ResourceDat
 	if d.HasChange("tags") {
 		err := setTags(client, d, godo.VolumeResourceType)
 		if err != nil {
-			return fmt.Errorf("Error updating tags: %s", err)
+			return diag.Errorf("Error updating tags: %s", err)
 		}
 	}
 
-	return resourceDigitalOceanVolumeRead(d, meta)
+	return resourceDigitalOceanVolumeRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	volume, resp, err := client.Storage.GetVolume(context.Background(), d.Id())
@@ -204,7 +205,7 @@ func resourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving volume: %s", err)
+		return diag.Errorf("Error retrieving volume: %s", err)
 	}
 
 	d.Set("name", volume.Name)
@@ -224,19 +225,19 @@ func resourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err = d.Set("droplet_ids", flattenDigitalOceanVolumeDropletIds(volume.DropletIDs)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting droplet_ids: %#v", err)
+		return diag.Errorf("[DEBUG] Error setting droplet_ids: %#v", err)
 	}
 
 	return nil
 }
 
-func resourceDigitalOceanVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting volume: %s", d.Id())
 	_, err := client.Storage.DeleteVolume(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting volume: %s", err)
+		return diag.Errorf("Error deleting volume: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_volume_attachment.go
+++ b/digitalocean/resource_digitalocean_volume_attachment.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,7 +36,7 @@ func resourceDigitalOceanVolumeAttachment() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	dropletId := d.Get("droplet_id").(int)
@@ -43,7 +44,7 @@ func resourceDigitalOceanVolumeAttachmentCreate(ctx context.Context, d *schema.R
 
 	volume, _, err := client.Storage.GetVolume(context.Background(), volumeId)
 	if err != nil {
-		return fmt.Errorf("Error retrieving volume: %s", err)
+		return diag.Errorf("Error retrieving volume: %s", err)
 	}
 
 	if volume.DropletIDs == nil || len(volume.DropletIDs) == 0 || volume.DropletIDs[0] != dropletId {
@@ -73,7 +74,7 @@ func resourceDigitalOceanVolumeAttachmentCreate(ctx context.Context, d *schema.R
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error attaching volume to droplet after retry timeout: %s", err)
+			return diag.Errorf("Error attaching volume to droplet after retry timeout: %s", err)
 		}
 	}
 
@@ -82,7 +83,7 @@ func resourceDigitalOceanVolumeAttachmentCreate(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceDigitalOceanVolumeAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	dropletId := d.Get("droplet_id").(int)
@@ -97,7 +98,7 @@ func resourceDigitalOceanVolumeAttachmentRead(ctx context.Context, d *schema.Res
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving volume: %s", err)
+		return diag.Errorf("Error retrieving volume: %s", err)
 	}
 
 	if volume.DropletIDs == nil || len(volume.DropletIDs) == 0 || volume.DropletIDs[0] != dropletId {
@@ -108,7 +109,7 @@ func resourceDigitalOceanVolumeAttachmentRead(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceDigitalOceanVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	dropletId := d.Get("droplet_id").(int)
@@ -139,7 +140,7 @@ func resourceDigitalOceanVolumeAttachmentDelete(ctx context.Context, d *schema.R
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error detaching volume from droplet after retry timeout: %s", err)
+		return diag.Errorf("Error detaching volume from droplet after retry timeout: %s", err)
 	}
 
 	return nil

--- a/digitalocean/resource_digitalocean_volume_attachment.go
+++ b/digitalocean/resource_digitalocean_volume_attachment.go
@@ -13,9 +13,9 @@ import (
 
 func resourceDigitalOceanVolumeAttachment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanVolumeAttachmentCreate,
-		Read:   resourceDigitalOceanVolumeAttachmentRead,
-		Delete: resourceDigitalOceanVolumeAttachmentDelete,
+		CreateContext: resourceDigitalOceanVolumeAttachmentCreate,
+		ReadContext:   resourceDigitalOceanVolumeAttachmentRead,
+		DeleteContext: resourceDigitalOceanVolumeAttachmentDelete,
 
 		Schema: map[string]*schema.Schema{
 			"droplet_id": {
@@ -35,7 +35,7 @@ func resourceDigitalOceanVolumeAttachment() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVolumeAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	dropletId := d.Get("droplet_id").(int)
@@ -82,7 +82,7 @@ func resourceDigitalOceanVolumeAttachmentCreate(d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceDigitalOceanVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	dropletId := d.Get("droplet_id").(int)
@@ -108,7 +108,7 @@ func resourceDigitalOceanVolumeAttachmentRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceDigitalOceanVolumeAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	dropletId := d.Get("droplet_id").(int)

--- a/digitalocean/resource_digitalocean_volume_snapshot.go
+++ b/digitalocean/resource_digitalocean_volume_snapshot.go
@@ -12,10 +12,10 @@ import (
 
 func resourceDigitalOceanVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanVolumeSnapshotCreate,
-		Read:   resourceDigitalOceanVolumeSnapshotRead,
-		Update: resourceDigitalOceanVolumeSnapshotUpdate,
-		Delete: resourceDigitalOceanVolumeSnapshotDelete,
+		CreateContext: resourceDigitalOceanVolumeSnapshotCreate,
+		ReadContext:   resourceDigitalOceanVolumeSnapshotRead,
+		UpdateContext: resourceDigitalOceanVolumeSnapshotUpdate,
+		DeleteContext: resourceDigitalOceanVolumeSnapshotDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -61,7 +61,7 @@ func resourceDigitalOceanVolumeSnapshot() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVolumeSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.SnapshotCreateRequest{
@@ -82,7 +82,7 @@ func resourceDigitalOceanVolumeSnapshotCreate(d *schema.ResourceData, meta inter
 	return resourceDigitalOceanVolumeSnapshotRead(d, meta)
 }
 
-func resourceDigitalOceanVolumeSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("tags") {
@@ -95,7 +95,7 @@ func resourceDigitalOceanVolumeSnapshotUpdate(d *schema.ResourceData, meta inter
 	return resourceDigitalOceanVolumeSnapshotRead(d, meta)
 }
 
-func resourceDigitalOceanVolumeSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	snapshot, resp, err := client.Snapshots.Get(context.Background(), d.Id())
@@ -121,7 +121,7 @@ func resourceDigitalOceanVolumeSnapshotRead(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func resourceDigitalOceanVolumeSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting snaphot: %s", d.Id())

--- a/digitalocean/resource_digitalocean_volume_snapshot.go
+++ b/digitalocean/resource_digitalocean_volume_snapshot.go
@@ -2,10 +2,10 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -61,7 +61,7 @@ func resourceDigitalOceanVolumeSnapshot() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVolumeSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	opts := &godo.SnapshotCreateRequest{
@@ -73,29 +73,29 @@ func resourceDigitalOceanVolumeSnapshotCreate(ctx context.Context, d *schema.Res
 	log.Printf("[DEBUG] Volume Snapshot create configuration: %#v", opts)
 	snapshot, _, err := client.Storage.CreateSnapshot(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("Error creating Volume Snapshot: %s", err)
+		return diag.Errorf("Error creating Volume Snapshot: %s", err)
 	}
 
 	d.SetId(snapshot.ID)
 	log.Printf("[INFO] Volume Snapshot name: %s", snapshot.Name)
 
-	return resourceDigitalOceanVolumeSnapshotRead(d, meta)
+	return resourceDigitalOceanVolumeSnapshotRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanVolumeSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("tags") {
 		err := setTags(client, d, godo.VolumeSnapshotResourceType)
 		if err != nil {
-			return fmt.Errorf("Error updating tags: %s", err)
+			return diag.Errorf("Error updating tags: %s", err)
 		}
 	}
 
-	return resourceDigitalOceanVolumeSnapshotRead(d, meta)
+	return resourceDigitalOceanVolumeSnapshotRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	snapshot, resp, err := client.Snapshots.Get(context.Background(), d.Id())
@@ -107,7 +107,7 @@ func resourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Resou
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving volume snapshot: %s", err)
+		return diag.Errorf("Error retrieving volume snapshot: %s", err)
 	}
 
 	d.Set("name", snapshot.Name)
@@ -121,13 +121,13 @@ func resourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceDigitalOceanVolumeSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVolumeSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	log.Printf("[INFO] Deleting snaphot: %s", d.Id())
 	_, err := client.Snapshots.Delete(context.Background(), d.Id())
 	if err != nil {
-		return fmt.Errorf("Error deleting snapshot: %s", err)
+		return diag.Errorf("Error deleting snapshot: %s", err)
 	}
 
 	d.SetId("")

--- a/digitalocean/resource_digitalocean_vpc.go
+++ b/digitalocean/resource_digitalocean_vpc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -75,7 +76,7 @@ func resourceDigitalOceanVPC() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVPCCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	vpcRequest := &godo.VPCCreateRequest{
@@ -94,16 +95,16 @@ func resourceDigitalOceanVPCCreate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] VPC create request: %#v", vpcRequest)
 	vpc, _, err := client.VPCs.Create(context.Background(), vpcRequest)
 	if err != nil {
-		return fmt.Errorf("Error creating VPC: %s", err)
+		return diag.Errorf("Error creating VPC: %s", err)
 	}
 
 	d.SetId(vpc.ID)
 	log.Printf("[INFO] VPC created, ID: %s", d.Id())
 
-	return resourceDigitalOceanVPCRead(d, meta)
+	return resourceDigitalOceanVPCRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	vpc, resp, err := client.VPCs.Get(context.Background(), d.Id())
@@ -114,7 +115,7 @@ func resourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, me
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading VPC: %s", err)
+		return diag.Errorf("Error reading VPC: %s", err)
 	}
 
 	d.SetId(vpc.ID)
@@ -126,10 +127,10 @@ func resourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("default", vpc.Default)
 	d.Set("created_at", vpc.CreatedAt.UTC().String())
 
-	return err
+	return nil
 }
 
-func resourceDigitalOceanVPCUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("name") || d.HasChange("description") {
@@ -140,19 +141,19 @@ func resourceDigitalOceanVPCUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, _, err := client.VPCs.Update(context.Background(), d.Id(), vpcUpdateRequest)
 
 		if err != nil {
-			return fmt.Errorf("Error updating VPC : %s", err)
+			return diag.Errorf("Error updating VPC : %s", err)
 		}
 		log.Printf("[INFO] Updated VPC")
 	}
 
-	return resourceDigitalOceanVPCRead(d, meta)
+	return resourceDigitalOceanVPCRead(ctx, d, meta)
 }
 
-func resourceDigitalOceanVPCDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 	vpcID := d.Id()
 
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		resp, err := client.VPCs.Delete(context.Background(), vpcID)
 		if err != nil {
 			// Retry if VPC still contains member resources to prevent race condition
@@ -169,4 +170,10 @@ func resourceDigitalOceanVPCDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	})
+
+	if err != nil {
+		return diag.FromErr(err)
+	} else {
+		return nil
+	}
 }

--- a/digitalocean/resource_digitalocean_vpc.go
+++ b/digitalocean/resource_digitalocean_vpc.go
@@ -14,10 +14,10 @@ import (
 
 func resourceDigitalOceanVPC() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDigitalOceanVPCCreate,
-		Read:   resourceDigitalOceanVPCRead,
-		Update: resourceDigitalOceanVPCUpdate,
-		Delete: resourceDigitalOceanVPCDelete,
+		CreateContext: resourceDigitalOceanVPCCreate,
+		ReadContext:   resourceDigitalOceanVPCRead,
+		UpdateContext: resourceDigitalOceanVPCUpdate,
+		DeleteContext: resourceDigitalOceanVPCDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -75,7 +75,7 @@ func resourceDigitalOceanVPC() *schema.Resource {
 	}
 }
 
-func resourceDigitalOceanVPCCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	vpcRequest := &godo.VPCCreateRequest{
@@ -103,7 +103,7 @@ func resourceDigitalOceanVPCCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanVPCRead(d, meta)
 }
 
-func resourceDigitalOceanVPCRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	vpc, resp, err := client.VPCs.Get(context.Background(), d.Id())
@@ -129,7 +129,7 @@ func resourceDigitalOceanVPCRead(d *schema.ResourceData, meta interface{}) error
 	return err
 }
 
-func resourceDigitalOceanVPCUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
 	if d.HasChange("name") || d.HasChange("description") {
@@ -148,7 +148,7 @@ func resourceDigitalOceanVPCUpdate(d *schema.ResourceData, meta interface{}) err
 	return resourceDigitalOceanVPCRead(d, meta)
 }
 
-func resourceDigitalOceanVPCDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDigitalOceanVPCDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 	vpcID := d.Id()
 


### PR DESCRIPTION
Port all of the data sources, resources, and `datalist` package to use the context-related resource functions (e.g., `ReadContext` etc.). The previous Read/Create/Update/Delete functions have been deprecated in SDK v2.