### PR TITLE
fix docs for digitalocean_domains and digitalocean_records data sources

### DIFF
--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -2,7 +2,7 @@
 page_title: "DigitalOcean: digitalocean_domains"
 ---
 
-# digitalocean_droplets
+# digitalocean_domains
 
 Get information on domains for use in other resources, with the ability to filter and sort the results.
 If no filters are specified, all domains will be returned.
@@ -15,13 +15,15 @@ about a single domain if you already know the `name`.
 
 ## Example Usage
 
-Use the `filter` block with a `key` string and `values` list to filter domains.
+Use the `filter` block with a `key` string and `values` list to filter domains. (This example
+also uses the regular expression `match_by` mode in order to match domains by suffix.)
 
 ```hcl
-data "digitalocean_domains" "ttl300" {
+data "digitalocean_domains" "examples" {
   filter {
-    key    = "ttl"
-    values = ["300"]
+    key    = "name"
+    values = ["example\\.com$"]
+    match_by = "re"
   }
 }
 ```

--- a/docs/data-sources/records.md
+++ b/docs/data-sources/records.md
@@ -2,7 +2,7 @@
 page_title: "DigitalOcean: digitalocean_records"
 ---
 
-# digitalocean_record
+# digitalocean_records
 
 Retrieve information about all DNS records within a domain, with the ability to filter and sort the results.
 If no filters are specified, all records will be returned.
@@ -21,7 +21,7 @@ data "digitalocean_records" "example" {
 }
 
 output "mail_servers" {
-  value = join(",", data.digitalocean_records.example.records)
+  value = join(",", data.digitalocean_records.example.records[*].value)
 }
 ```
 
@@ -39,10 +39,10 @@ The following arguments are supported:
 
 `filter` supports the following arguments:
 
-* `key` - (Required) Filter the projects by this key. This may be one of `domain`, `flags`, `name`, `port`,
+* `key` - (Required) Filter the DNS records by this key. This may be one of `domain`, `flags`, `name`, `port`,
   `priority`, `tag`, `ttl`, `type`, `value`, or `weight`.
   
-* `values` - (Required) A list of values to match against the `key` field. Only retrieves projects
+* `values` - (Required) A list of values to match against the `key` field. Only retrieves DNS records
   where the `key` field takes on one or more of the values provided here.
 
 * `match_by` - (Optional) One of `exact` (default), `re`, or `substring`. For string-typed fields, specify `re` to
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 `sort` supports the following arguments:
 
-* `key` - (Required) Sort the projects by this key. This may be one of `domain`, `flags`, `name`, `port`,
+* `key` - (Required) Sort the DNS records by this key. This may be one of `domain`, `flags`, `name`, `port`,
   `priority`, `tag`, `ttl`, `type`, `value`, or `weight`.
 * `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
 


### PR DESCRIPTION
Fix copy/paste leftovers in the `digitalocean_domains` and `digitalocean_records` data sources. Also corrects the example in `digitalocean_records` to use a "list splat" correctly, and demonstrates using a regular expression match in the `digitalocean_domains` example.