### PR TITLE
apps: Suppress diff when env type is GENERAL.

### DIFF
--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -119,6 +119,12 @@ func appSpecEnvSchema() *schema.Resource {
 					"SECRET",
 				}, false),
 				Description: "The type of the environment variable.",
+				// The API does not always return `"type":"GENERAL"` when set.
+				// As being unset and being set to `GENERAL` are functionally,
+				// the same, we can safely ignore the diff.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new == "GENERAL" && old == ""
+				},
 			},
 		},
 	}

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -182,6 +182,7 @@ func TestAccDigitalOceanApp_Envs(t *testing.T) {
         key   = "FOO"
         value = "baz"
         scope = "RUN_TIME"
+        type  = "GENERAL"
       }
 `
 


### PR DESCRIPTION
 The API does not consistently return `"type":"GENERAL"` when set for an environment variable. This leads to changes shown on each run if an env var type is set to `GENERAL`. As being unset and being set to `GENERAL` are functionally, the same, we can safely ignore the diff.

Resolves one issue mentioned in #514

Test failure with the test change adding ` type  = "GENERAL"`:

```
$ make testacc TESTARGS="-run='TestAccDigitalOceanApp_Envs'"==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanApp_Envs' -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanApp_Envs
=== PAUSE TestAccDigitalOceanApp_Envs
=== CONT  TestAccDigitalOceanApp_Envs
    resource_digitalocean_app_test.go:189: Step 3/3 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # digitalocean_app.foobar will be updated in-place
          ~ resource "digitalocean_app" "foobar" {
                active_deployment_id = "e80ef063-1442-4ff7-84cd-c25b4e9d0e05"
                created_at           = "2020-11-05 16:34:37 +0000 UTC"
                default_ingress      = "https://tf-acc-test-tpph1rync4-ouyzo.ondigitalocean.app"
                id                   = "28767f1d-fd64-489a-9381-b6f8a17f8e4c"
                live_url             = "https://tf-acc-test-tpph1rync4-ouyzo.ondigitalocean.app"
                updated_at           = "2020-11-05 16:39:40 +0000 UTC"
        
              ~ spec {
                    domains = []
                    name    = "tf-acc-test-tpph1rync4"
                    region  = "ams"
        
                  ~ service {
                        environment_slug   = "go"
                        http_port          = 8080
                        instance_count     = 1
                        instance_size_slug = "basic-xxs"
                        name               = "go-service"
        
                      - env {
                          - key   = "FOO" -> null
                          - scope = "RUN_TIME" -> null
                          - value = "baz" -> null
                        }
                      + env {
                          + key   = "FOO"
                          + scope = "RUN_TIME"
                          + type  = "GENERAL"
                          + value = "baz"
                        }
        
                        git {
                            branch         = "main"
                            repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
                        }
        
                        routes {
                            path = "/"
                        }
                    }
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccDigitalOceanApp_Envs (310.77s)
```

All Apps tests pass after the `DiffSuppressFunc` is added:

```
$ make testacc TESTARGS="-run='TestAccDigitalOceanApp' -parallel=12"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanApp' -parallel=12 -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanApp_importBasic
=== PAUSE TestAccDigitalOceanApp_importBasic
=== RUN   TestAccDigitalOceanApp_Basic
=== PAUSE TestAccDigitalOceanApp_Basic
=== RUN   TestAccDigitalOceanApp_StaticSite
=== PAUSE TestAccDigitalOceanApp_StaticSite
=== RUN   TestAccDigitalOceanApp_Envs
=== PAUSE TestAccDigitalOceanApp_Envs
=== RUN   TestAccDigitalOceanApp_Worker
=== PAUSE TestAccDigitalOceanApp_Worker
=== CONT  TestAccDigitalOceanApp_importBasic
=== CONT  TestAccDigitalOceanApp_Envs
=== CONT  TestAccDigitalOceanApp_Basic
=== CONT  TestAccDigitalOceanApp_StaticSite
=== CONT  TestAccDigitalOceanApp_Worker
--- PASS: TestAccDigitalOceanApp_StaticSite (362.97s)
--- PASS: TestAccDigitalOceanApp_importBasic (453.35s)
--- PASS: TestAccDigitalOceanApp_Worker (654.88s)
--- PASS: TestAccDigitalOceanApp_Envs (948.30s)
--- PASS: TestAccDigitalOceanApp_Basic (1088.84s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    1088.850s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       0.021s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        0.016s [no tests to run]
```
