### PR TITLE
Fix container registry creation and support updating subscription plans.

### DIFF
--- a/digitalocean/datasource_digitalocean_container_registry.go
+++ b/digitalocean/datasource_digitalocean_container_registry.go
@@ -2,14 +2,11 @@ package digitalocean
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
-
-const RegistryHostname = "registry.digitalocean.com"
 
 func dataSourceDigitalOceanContainerRegistry() *schema.Resource {
 	return &schema.Resource{
@@ -20,6 +17,10 @@ func dataSourceDigitalOceanContainerRegistry() *schema.Resource {
 				Required:     true,
 				Description:  "name of the container registry",
 				ValidateFunc: validation.NoZeroValues,
+			},
+			"subscription_tier_slug": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -34,20 +35,5 @@ func dataSourceDigitalOceanContainerRegistry() *schema.Resource {
 }
 
 func dataSourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*CombinedConfig).godoClient()
-
-	reg, response, err := client.Registry.Get(context.Background())
-
-	if err != nil {
-		if response != nil && response.StatusCode == 404 {
-			return diag.Errorf("registry not found: %s", err)
-		}
-		return diag.Errorf("Error retrieving registry: %s", err)
-	}
-
-	d.SetId(reg.Name)
-	d.Set("name", reg.Name)
-	d.Set("endpoint", fmt.Sprintf("%s/%s", RegistryHostname, reg.Name))
-	d.Set("server_url", RegistryHostname)
-	return nil
+	return resourceDigitalOceanContainerRegistryRead(ctx, d, meta)
 }

--- a/digitalocean/datasource_digitalocean_container_registry_test.go
+++ b/digitalocean/datasource_digitalocean_container_registry_test.go
@@ -6,18 +6,18 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceDigitalOceanContainerRegistry_Basic(t *testing.T) {
 	var reg godo.Registry
-	regName := fmt.Sprintf("foo-%s", acctest.RandString(10))
+	regName := randomTestName()
 
 	resourceConfig := fmt.Sprintf(`
 resource "digitalocean_container_registry" "foo" {
-  name = "%s"
+  name                   = "%s"
+  subscription_tier_slug = "basic"
 }
 `, regName)
 
@@ -40,6 +40,8 @@ data "digitalocean_container_registry" "foobar" {
 					testAccCheckDataSourceDigitalOceanContainerRegistryExists("data.digitalocean_container_registry.foobar", &reg),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_container_registry.foobar", "name", regName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_container_registry.foobar", "subscription_tier_slug", "basic"),
 				),
 			},
 		},

--- a/digitalocean/import_digitalocean_container_registry_test.go
+++ b/digitalocean/import_digitalocean_container_registry_test.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,7 +16,7 @@ func TestAccDigitalOceanContainerRegistry_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanContainerRegistryConfig_basic,
+				Config: fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, "basic"),
 			},
 
 			{

--- a/digitalocean/import_digitalocean_container_registry_test.go
+++ b/digitalocean/import_digitalocean_container_registry_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestAccDigitalOceanContainerRegistry_importBasic(t *testing.T) {
 	resourceName := "digitalocean_container_registry.foobar"
+	name := randomTestName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -16,7 +17,7 @@ func TestAccDigitalOceanContainerRegistry_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, "basic"),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, name, "basic"),
 			},
 
 			{

--- a/digitalocean/resource_digitalocean_container_registry.go
+++ b/digitalocean/resource_digitalocean_container_registry.go
@@ -11,10 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+const RegistryHostname = "registry.digitalocean.com"
+
 func resourceDigitalOceanContainerRegistry() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDigitalOceanContainerRegistryCreate,
 		ReadContext:   resourceDigitalOceanContainerRegistryRead,
+		UpdateContext: resourceDigitalOceanContainerRegistryUpdate,
 		DeleteContext: resourceDigitalOceanContainerRegistryDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -26,6 +29,15 @@ func resourceDigitalOceanContainerRegistry() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
+			},
+			"subscription_tier_slug": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"starter",
+					"basic",
+					"professional",
+				}, false),
 			},
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -44,7 +56,8 @@ func resourceDigitalOceanContainerRegistryCreate(ctx context.Context, d *schema.
 
 	// Build up our creation options
 	opts := &godo.RegistryCreateRequest{
-		Name: d.Get("name").(string),
+		Name:                 d.Get("name").(string),
+		SubscriptionTierSlug: d.Get("subscription_tier_slug").(string),
 	}
 
 	log.Printf("[DEBUG] Container Registry create configuration: %#v", opts)
@@ -79,7 +92,28 @@ func resourceDigitalOceanContainerRegistryRead(ctx context.Context, d *schema.Re
 	d.Set("endpoint", fmt.Sprintf("%s/%s", RegistryHostname, reg.Name))
 	d.Set("server_url", RegistryHostname)
 
+	sub, _, err := client.Registry.GetSubscription(context.Background())
+	if err != nil {
+		return diag.Errorf("Error retrieving container registry subscription: %s", err)
+	}
+	d.Set("subscription_tier_slug", sub.Tier.Slug)
+
 	return nil
+}
+
+func resourceDigitalOceanContainerRegistryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*CombinedConfig).godoClient()
+	if d.HasChange("subscription_tier_slug") {
+		req := &godo.RegistrySubscriptionUpdateRequest{
+			TierSlug: d.Get("subscription_tier_slug").(string),
+		}
+
+		_, _, err := client.Registry.UpdateSubscription(ctx, req)
+		if err != nil {
+			return diag.Errorf("Error updating container registry subscription: %s", err)
+		}
+	}
+	return resourceDigitalOceanContainerRegistryRead(ctx, d, meta)
 }
 
 func resourceDigitalOceanContainerRegistryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials_test.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials_test.go
@@ -125,7 +125,8 @@ func testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists(n string, 
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_basic = `
 resource "digitalocean_container_registry" "foobar" {
-	name = "foobar"
+	name                   = "foobar"
+	subscription_tier_slug = "basic"
 }
 
 resource "digitalocean_container_registry_docker_credentials" "foobar" {
@@ -135,7 +136,8 @@ resource "digitalocean_container_registry_docker_credentials" "foobar" {
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry = `
 resource "digitalocean_container_registry" "foobar" {
-	name = "foobar"
+	name                   = "foobar"
+	subscription_tier_slug = "basic"
 }
 
 resource "digitalocean_container_registry_docker_credentials" "foobar" {

--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials_test.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccDigitalOceanContainerRegistryDockerCredentials_Basic(t *testing.T) {
 	var reg godo.Registry
+	name := randomTestName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -19,12 +20,12 @@ func TestAccDigitalOceanContainerRegistryDockerCredentials_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanContainerRegistryDockerCredentialsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_basic,
+				Config: fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_basic, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists("digitalocean_container_registry.foobar", &reg),
-					testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(&reg),
+					testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(&reg, name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_container_registry_docker_credentials.foobar", "registry_name", "foobar"),
+						"digitalocean_container_registry_docker_credentials.foobar", "registry_name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry_docker_credentials.foobar", "write", "true"),
 					resource.TestCheckResourceAttrSet(
@@ -39,6 +40,7 @@ func TestAccDigitalOceanContainerRegistryDockerCredentials_Basic(t *testing.T) {
 
 func TestAccDigitalOceanContainerRegistryDockerCredentials_withExpiry(t *testing.T) {
 	var reg godo.Registry
+	name := randomTestName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -46,12 +48,12 @@ func TestAccDigitalOceanContainerRegistryDockerCredentials_withExpiry(t *testing
 		CheckDestroy:      testAccCheckDigitalOceanContainerRegistryDockerCredentialsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry,
+				Config: fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists("digitalocean_container_registry.foobar", &reg),
-					testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(&reg),
+					testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(&reg, name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_container_registry_docker_credentials.foobar", "registry_name", "foobar"),
+						"digitalocean_container_registry_docker_credentials.foobar", "registry_name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry_docker_credentials.foobar", "write", "true"),
 					resource.TestCheckResourceAttr(
@@ -85,10 +87,10 @@ func testAccCheckDigitalOceanContainerRegistryDockerCredentialsDestroy(s *terraf
 	return nil
 }
 
-func testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(reg *godo.Registry) resource.TestCheckFunc {
+func testAccCheckDigitalOceanContainerRegistryDockerCredentialsAttributes(reg *godo.Registry, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if reg.Name != "foobar" {
+		if reg.Name != name {
 			return fmt.Errorf("Bad name: %s", reg.Name)
 		}
 
@@ -125,7 +127,7 @@ func testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists(n string, 
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_basic = `
 resource "digitalocean_container_registry" "foobar" {
-	name                   = "foobar"
+	name                   = "%s"
 	subscription_tier_slug = "basic"
 }
 
@@ -136,7 +138,7 @@ resource "digitalocean_container_registry_docker_credentials" "foobar" {
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry = `
 resource "digitalocean_container_registry" "foobar" {
-	name                   = "foobar"
+	name                   = "%s"
 	subscription_tier_slug = "basic"
 }
 

--- a/digitalocean/resource_digitalocean_container_registry_test.go
+++ b/digitalocean/resource_digitalocean_container_registry_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestAccDigitalOceanContainerRegistry_Basic(t *testing.T) {
 	var reg godo.Registry
-	starterConfig := fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, "starter")
-	basicConfig := fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, "basic")
+	name := randomTestName()
+	starterConfig := fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, name, "starter")
+	basicConfig := fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, name, "basic")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -24,11 +25,11 @@ func TestAccDigitalOceanContainerRegistry_Basic(t *testing.T) {
 				Config: starterConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanContainerRegistryExists("digitalocean_container_registry.foobar", &reg),
-					testAccCheckDigitalOceanContainerRegistryAttributes(&reg),
+					testAccCheckDigitalOceanContainerRegistryAttributes(&reg, name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_container_registry.foobar", "name", "foobar"),
+						"digitalocean_container_registry.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_container_registry.foobar", "endpoint", "registry.digitalocean.com/foobar"),
+						"digitalocean_container_registry.foobar", "endpoint", "registry.digitalocean.com/"+name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry.foobar", "server_url", "registry.digitalocean.com"),
 					resource.TestCheckResourceAttr(
@@ -39,11 +40,11 @@ func TestAccDigitalOceanContainerRegistry_Basic(t *testing.T) {
 				Config: basicConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanContainerRegistryExists("digitalocean_container_registry.foobar", &reg),
-					testAccCheckDigitalOceanContainerRegistryAttributes(&reg),
+					testAccCheckDigitalOceanContainerRegistryAttributes(&reg, name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_container_registry.foobar", "name", "foobar"),
+						"digitalocean_container_registry.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_container_registry.foobar", "endpoint", "registry.digitalocean.com/foobar"),
+						"digitalocean_container_registry.foobar", "endpoint", "registry.digitalocean.com/"+name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry.foobar", "server_url", "registry.digitalocean.com"),
 					resource.TestCheckResourceAttr(
@@ -73,10 +74,10 @@ func testAccCheckDigitalOceanContainerRegistryDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testAccCheckDigitalOceanContainerRegistryAttributes(reg *godo.Registry) resource.TestCheckFunc {
+func testAccCheckDigitalOceanContainerRegistryAttributes(reg *godo.Registry, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if reg.Name != "foobar" {
+		if reg.Name != name {
 			return fmt.Errorf("Bad name: %s", reg.Name)
 		}
 
@@ -113,6 +114,6 @@ func testAccCheckDigitalOceanContainerRegistryExists(n string, reg *godo.Registr
 
 var testAccCheckDigitalOceanContainerRegistryConfig_basic = `
 resource "digitalocean_container_registry" "foobar" {
-  name                   = "foobar"
+  name                   = "%s"
   subscription_tier_slug = "%s"
 }`

--- a/digitalocean/resource_digitalocean_container_registry_test.go
+++ b/digitalocean/resource_digitalocean_container_registry_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestAccDigitalOceanContainerRegistry_Basic(t *testing.T) {
 	var reg godo.Registry
+	starterConfig := fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, "starter")
+	basicConfig := fmt.Sprintf(testAccCheckDigitalOceanContainerRegistryConfig_basic, "basic")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -19,7 +21,7 @@ func TestAccDigitalOceanContainerRegistry_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanContainerRegistryConfig_basic,
+				Config: starterConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanContainerRegistryExists("digitalocean_container_registry.foobar", &reg),
 					testAccCheckDigitalOceanContainerRegistryAttributes(&reg),
@@ -29,6 +31,23 @@ func TestAccDigitalOceanContainerRegistry_Basic(t *testing.T) {
 						"digitalocean_container_registry.foobar", "endpoint", "registry.digitalocean.com/foobar"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_container_registry.foobar", "server_url", "registry.digitalocean.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry.foobar", "subscription_tier_slug", "starter"),
+				),
+			},
+			{
+				Config: basicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanContainerRegistryExists("digitalocean_container_registry.foobar", &reg),
+					testAccCheckDigitalOceanContainerRegistryAttributes(&reg),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry.foobar", "name", "foobar"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry.foobar", "endpoint", "registry.digitalocean.com/foobar"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry.foobar", "server_url", "registry.digitalocean.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_container_registry.foobar", "subscription_tier_slug", "basic"),
 				),
 			},
 		},
@@ -94,5 +113,6 @@ func testAccCheckDigitalOceanContainerRegistryExists(n string, reg *godo.Registr
 
 var testAccCheckDigitalOceanContainerRegistryConfig_basic = `
 resource "digitalocean_container_registry" "foobar" {
-    name = "foobar"
+  name                   = "foobar"
+  subscription_tier_slug = "%s"
 }`

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.25.4
-	github.com/digitalocean/godo v1.45.0
+	github.com/digitalocean/godo v1.52.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.3
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.45.0 h1:Hg4Q216Xr0AJjnAxK4bkP/qacj4svGaapWRfC8z9URc=
-github.com/digitalocean/godo v1.45.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
+github.com/digitalocean/godo v1.52.0 h1:1QSUC0w5T1wS1d/1uvPtG8GLeD0p/4zhx1Q+Fxtna+k=
+github.com/digitalocean/godo v1.52.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Change Log
 
+## [v1.52.0] - 2020-11-05
+
+- #411 - @nicktate - apps: add unspecified type to image source registry types
+- #409 - @andrewsomething - registry: Add support for updating a subscription.
+- #408 - @nicktate - apps: update spec to include image source
+- #407 - @kamaln7 - apps: add the option to force build a new deployment
+
+## [v1.51.0] - 2020-11-02
+
+- #405 - @adamwg - registry: Support subscription options
+- #398 - @reeseconor - Add support for caching dependencies between GitHub Action runs
+- #404 - @andrewsomething - CONTRIBUTING.md: Suggest using github-changelog-generator.
+
+## [v1.50.0] - 2020-10-26
+
+- #400 - @waynr - registry: add garbage collection support
+- #402 - @snormore - apps: add catchall_document static site spec field and failed-deploy job type
+- #401 - @andrewlouis93 - VPC: adds option to set a VPC as the regional default
+
+## [v1.49.0] - 2020-10-21
+
+- #383 - @kamaln7 - apps: add ListRegions, Get/ListTiers, Get/ListInstanceSizes
+- #390 - @snormore - apps: add service spec internal_ports
+
+## [v1.48.0] - 2020-10-16
+
+- #388 - @varshavaradarajan - kubernetes - change docr integration api routes
+- #386 - @snormore - apps: pull in recent updates to jobs and domains
+
+## [v1.47.0] - 2020-10-14
+
+- #384 kubernetes - add registry related doks apis - @varshavaradarajan
+- #385 Fixed some typo in apps.gen.go and databases.go file - @devil-cyber
+- #382 Add GetKubeConfigWithExpiry (#334) - @ivanlemeshev
+- #381 Fix golint issues #377 - @sidsbrmnn
+- #380 refactor: Cyclomatic complexity issue - @DonRenando
+- #379 Run gofmt to fix some issues in codebase - @mycodeself
+
+## [v1.46.0] - 2020-10-05
+
+- #373 load balancers: add LB size field, currently in closed beta - @anitgandhi
+
 ## [v1.45.0] - 2020-09-25
 
 **Note**: This release contains breaking changes to App Platform features currently in closed beta.

--- a/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
+++ b/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
@@ -29,7 +29,7 @@ version number. Any code merged to main is subject to release.
 
 ## Releasing
 
-Releasing a new version of godo is currently a manual process. 
+Releasing a new version of godo is currently a manual process.
 
 Submit a separate pull request for the version change from the pull
 request with your changes.
@@ -38,17 +38,32 @@ request with your changes.
    for the next (unreleased) version does not exist, create one.
    Include one bullet point for each piece of new functionality in the
    release, including the pull request ID, description, and author(s).
+   For example:
 
 ```
 ## [v1.8.0] - 2019-03-13
 
-- #210 Expose tags on storage volume create/list/get. - @jcodybaker
-- #123 Update test dependencies - @digitalocean
+- #210 - @jcodybaker - Expose tags on storage volume create/list/get.
+- #123 - @digitalocean - Update test dependencies
+```
+
+   To generate a list of changes since the previous release in the correct
+   format, you can use [github-changelog-generator](https://github.com/digitalocean/github-changelog-generator).
+   It can be installed from source by running:
+
+```
+go get -u github.com/digitalocean/github-changelog-generator
+```
+
+   Next, list the changes by running:
+
+```
+github-changelog-generator -org digitalocean -repo godo
 ```
 
 2. Update the `libraryVersion` number in `godo.go`.
 3. Make a pull request with these changes.  This PR should be separate from the PR containing the godo changes.
-4. Once the pull request has been merged, [draft a new release](https://github.com/digitalocean/godo/releases/new).  
-5. Update the `Tag version` and `Release title` field with the new godo version.  Be sure the version has a `v` prefixed in both places. Ex `v1.8.0`.  
+4. Once the pull request has been merged, [draft a new release](https://github.com/digitalocean/godo/releases/new).
+5. Update the `Tag version` and `Release title` field with the new godo version.  Be sure the version has a `v` prefixed in both places. Ex `v1.8.0`.
 6. Copy the changelog bullet points to the description field.
 7. Publish the release.

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -33,9 +33,17 @@ type AppsService interface {
 
 	GetDeployment(ctx context.Context, appID, deploymentID string) (*Deployment, *Response, error)
 	ListDeployments(ctx context.Context, appID string, opts *ListOptions) ([]*Deployment, *Response, error)
-	CreateDeployment(ctx context.Context, appID string) (*Deployment, *Response, error)
+	CreateDeployment(ctx context.Context, appID string, create ...*DeploymentCreateRequest) (*Deployment, *Response, error)
 
 	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error)
+
+	ListRegions(ctx context.Context) ([]*AppRegion, *Response, error)
+
+	ListTiers(ctx context.Context) ([]*AppTier, *Response, error)
+	GetTier(ctx context.Context, slug string) (*AppTier, *Response, error)
+
+	ListInstanceSizes(ctx context.Context) ([]*AppInstanceSize, *Response, error)
+	GetInstanceSize(ctx context.Context, slug string) (*AppInstanceSize, *Response, error)
 }
 
 // AppLogs represent app logs.
@@ -54,6 +62,11 @@ type AppUpdateRequest struct {
 	Spec *AppSpec `json:"spec"`
 }
 
+// DeploymentCreateRequest represents a request to create a deployment.
+type DeploymentCreateRequest struct {
+	ForceBuild bool `json:"force_build"`
+}
+
 type appRoot struct {
 	App *App `json:"app"`
 }
@@ -68,6 +81,26 @@ type deploymentRoot struct {
 
 type deploymentsRoot struct {
 	Deployments []*Deployment `json:"deployments"`
+}
+
+type appTierRoot struct {
+	Tier *AppTier `json:"tier"`
+}
+
+type appTiersRoot struct {
+	Tiers []*AppTier `json:"tiers"`
+}
+
+type instanceSizeRoot struct {
+	InstanceSize *AppInstanceSize `json:"instance_size"`
+}
+
+type instanceSizesRoot struct {
+	InstanceSizes []*AppInstanceSize `json:"instance_sizes"`
+}
+
+type appRegionsRoot struct {
+	Regions []*AppRegion `json:"regions"`
 }
 
 // AppsServiceOp handles communication with Apps methods of the DigitalOcean API.
@@ -182,9 +215,15 @@ func (s *AppsServiceOp) ListDeployments(ctx context.Context, appID string, opts 
 }
 
 // CreateDeployment creates an app deployment.
-func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string) (*Deployment, *Response, error) {
+func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string, create ...*DeploymentCreateRequest) (*Deployment, *Response, error) {
 	path := fmt.Sprintf("%s/%s/deployments", appsBasePath, appID)
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+
+	var createReq *DeploymentCreateRequest
+	for _, c := range create {
+		createReq = c
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -213,4 +252,79 @@ func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, compon
 		return nil, resp, err
 	}
 	return logs, resp, nil
+}
+
+// ListRegions lists all regions supported by App Platform.
+func (s *AppsServiceOp) ListRegions(ctx context.Context) ([]*AppRegion, *Response, error) {
+	path := fmt.Sprintf("%s/regions", appsBasePath)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(appRegionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Regions, resp, nil
+}
+
+// ListTiers lists available app tiers.
+func (s *AppsServiceOp) ListTiers(ctx context.Context) ([]*AppTier, *Response, error) {
+	path := fmt.Sprintf("%s/tiers", appsBasePath)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(appTiersRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Tiers, resp, nil
+}
+
+// GetTier retrieves information about a specific app tier.
+func (s *AppsServiceOp) GetTier(ctx context.Context, slug string) (*AppTier, *Response, error) {
+	path := fmt.Sprintf("%s/tiers/%s", appsBasePath, slug)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(appTierRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Tier, resp, nil
+}
+
+// ListInstanceSizes lists available instance sizes for service, worker, and job components.
+func (s *AppsServiceOp) ListInstanceSizes(ctx context.Context) ([]*AppInstanceSize, *Response, error) {
+	path := fmt.Sprintf("%s/tiers/instance_sizes", appsBasePath)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(instanceSizesRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.InstanceSizes, resp, nil
+}
+
+// GetInstanceSize retreives information about a specific instance size for service, worker, and job components.
+func (s *AppsServiceOp) GetInstanceSize(ctx context.Context, slug string) (*AppInstanceSize, *Response, error) {
+	path := fmt.Sprintf("%s/tiers/instance_sizes/%s", appsBasePath, slug)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(instanceSizeRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.InstanceSize, resp, nil
 }

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -82,7 +82,7 @@ const (
 // The DatabasesService provides access to the DigitalOcean managed database
 // suite of products through the public API. Customers can create new database
 // clusters, migrate them  between regions, create replicas and interact with
-// their configurations. Each database service is refered to as a Database. A
+// their configurations. Each database service is referred to as a Database. A
 // SQL database service can have multiple databases residing in the system. To
 // help make these entities distinct from Databases in godo, we refer to them
 // here as DatabaseDBs.
@@ -269,7 +269,7 @@ type DatabaseCreateUserRequest struct {
 	MySQLSettings *DatabaseMySQLUserSettings `json:"mysql_settings,omitempty"`
 }
 
-// DatabaseResetUserAuth request is used to reset a users DB auth
+// DatabaseResetUserAuthRequest is used to reset a users DB auth
 type DatabaseResetUserAuthRequest struct {
 	MySQLSettings *DatabaseMySQLUserSettings `json:"mysql_settings,omitempty"`
 }
@@ -537,6 +537,7 @@ func (svc *DatabasesServiceOp) CreateUser(ctx context.Context, databaseID string
 	return root.User, resp, nil
 }
 
+// ResetUserAuth will reset user authentication
 func (svc *DatabasesServiceOp) ResetUserAuth(ctx context.Context, databaseID, userID string, resetAuth *DatabaseResetUserAuthRequest) (*DatabaseUser, *Response, error) {
 	path := fmt.Sprintf(databaseResetUserAuthPath, databaseID, userID)
 	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, resetAuth)

--- a/vendor/github.com/digitalocean/godo/domains.go
+++ b/vendor/github.com/digitalocean/godo/domains.go
@@ -101,6 +101,7 @@ func (d Domain) String() string {
 	return Stringify(d)
 }
 
+// URN returns the domain name in a valid DO API URN form.
 func (d Domain) URN() string {
 	return ToURN("Domain", d.Name)
 }

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -126,6 +126,7 @@ func (d Droplet) String() string {
 	return Stringify(d)
 }
 
+// URN returns the droplet ID in a valid DO API URN form.
 func (d Droplet) URN() string {
 	return ToURN("Droplet", d.ID)
 }

--- a/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/vendor/github.com/digitalocean/godo/firewalls.go
@@ -49,6 +49,7 @@ func (fw Firewall) String() string {
 	return Stringify(fw)
 }
 
+// URN returns the firewall name in a valid DO API URN form.
 func (fw Firewall) URN() string {
 	return ToURN("Firewall", fw.ID)
 }

--- a/vendor/github.com/digitalocean/godo/floating_ips.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips.go
@@ -37,6 +37,7 @@ func (f FloatingIP) String() string {
 	return Stringify(f)
 }
 
+// URN returns the floating IP in a valid DO API URN form.
 func (f FloatingIP) URN() string {
 	return ToURN("FloatingIP", f.IP)
 }

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.45.0"
+	libraryVersion = "1.52.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -166,10 +166,7 @@ func addOptions(s string, opt interface{}) (string, error) {
 // token.
 func NewFromToken(token string) *Client {
 	ctx := context.Background()
-
-	config := &oauth2.Config{}
-	ts := config.TokenSource(ctx, &oauth2.Token{AccessToken: token})
-
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	return NewClient(oauth2.NewClient(ctx, ts))
 }
 

--- a/vendor/github.com/digitalocean/godo/images.go
+++ b/vendor/github.com/digitalocean/godo/images.go
@@ -132,6 +132,7 @@ func (s *ImagesServiceOp) GetBySlug(ctx context.Context, slug string) (*Image, *
 	return s.get(ctx, interface{}(slug))
 }
 
+// Create a new image
 func (s *ImagesServiceOp) Create(ctx context.Context, createRequest *CustomImageCreateRequest) (*Image, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")

--- a/vendor/github.com/digitalocean/godo/invoices.go
+++ b/vendor/github.com/digitalocean/godo/invoices.go
@@ -171,7 +171,7 @@ func (s *InvoicesServiceOp) List(ctx context.Context, opt *ListOptions) (*Invoic
 	return root, resp, err
 }
 
-// Get a summary of metadata and summarized usage for an Invoice
+// GetSummary returns a summary of metadata and summarized usage for an Invoice
 func (s *InvoicesServiceOp) GetSummary(ctx context.Context, invoiceUUID string) (*InvoiceSummary, *Response, error) {
 	path := fmt.Sprintf("%s/%s/summary", invoicesBasePath, invoiceUUID)
 
@@ -189,7 +189,7 @@ func (s *InvoicesServiceOp) GetSummary(ctx context.Context, invoiceUUID string) 
 	return root, resp, err
 }
 
-// Get the pdf for an Invoice
+// GetPDF returns the pdf for an Invoice
 func (s *InvoicesServiceOp) GetPDF(ctx context.Context, invoiceUUID string) ([]byte, *Response, error) {
 	path := fmt.Sprintf("%s/%s/pdf", invoicesBasePath, invoiceUUID)
 
@@ -207,7 +207,7 @@ func (s *InvoicesServiceOp) GetPDF(ctx context.Context, invoiceUUID string) ([]b
 	return root.Bytes(), resp, err
 }
 
-// Get the csv for an Invoice
+// GetCSV returns the csv for an Invoice
 func (s *InvoicesServiceOp) GetCSV(ctx context.Context, invoiceUUID string) ([]byte, *Response, error) {
 	path := fmt.Sprintf("%s/%s/csv", invoicesBasePath, invoiceUUID)
 

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -31,6 +31,7 @@ type LoadBalancer struct {
 	ID                     string           `json:"id,omitempty"`
 	Name                   string           `json:"name,omitempty"`
 	IP                     string           `json:"ip,omitempty"`
+	SizeSlug               string           `json:"size,omitempty"`
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Status                 string           `json:"status,omitempty"`
 	Created                string           `json:"created_at,omitempty"`
@@ -52,6 +53,7 @@ func (l LoadBalancer) String() string {
 	return Stringify(l)
 }
 
+// URN returns the load balancer ID in a valid DO API URN form.
 func (l LoadBalancer) URN() string {
 	return ToURN("LoadBalancer", l.ID)
 }
@@ -62,6 +64,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	r := LoadBalancerRequest{
 		Name:                   l.Name,
 		Algorithm:              l.Algorithm,
+		SizeSlug:               l.SizeSlug,
 		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
 		DropletIDs:             append([]int(nil), l.DropletIDs...),
 		Tag:                    l.Tag,
@@ -134,6 +137,7 @@ type LoadBalancerRequest struct {
 	Name                   string           `json:"name,omitempty"`
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Region                 string           `json:"region,omitempty"`
+	SizeSlug               string           `json:"size,omitempty"`
 	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
 	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
 	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`

--- a/vendor/github.com/digitalocean/godo/projects.go
+++ b/vendor/github.com/digitalocean/godo/projects.go
@@ -117,7 +117,7 @@ type ProjectResource struct {
 	Status     string                `json:"status,omitempty"`
 }
 
-// ProjetResourceLinks specify the link for more information about the resource.
+// ProjectResourceLinks specify the link for more information about the resource.
 type ProjectResourceLinks struct {
 	Self string `json:"self"`
 }
@@ -252,7 +252,6 @@ func (p *ProjectsServiceOp) ListResources(ctx context.Context, projectID string,
 
 // AssignResources assigns one or more resources to a project. AssignResources
 // accepts resources in two possible formats:
-
 //  1. The resource type, like `&Droplet{ID: 1}` or `&FloatingIP{IP: "1.2.3.4"}`
 //  2. A valid DO URN as a string, like "do:droplet:1234"
 //

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -60,6 +60,7 @@ func (f Volume) String() string {
 	return Stringify(f)
 }
 
+// URN returns the volume ID as a valid DO API URN
 func (f Volume) URN() string {
 	return ToURN("Volume", f.ID)
 }

--- a/vendor/github.com/digitalocean/godo/strings.go
+++ b/vendor/github.com/digitalocean/godo/strings.go
@@ -10,6 +10,8 @@ import (
 
 var timestampType = reflect.TypeOf(Timestamp{})
 
+// ResourceWithURN is an interface for interfacing with the types
+// that implement the URN method.
 type ResourceWithURN interface {
 	URN() string
 }

--- a/vendor/github.com/digitalocean/godo/vpcs.go
+++ b/vendor/github.com/digitalocean/godo/vpcs.go
@@ -39,6 +39,7 @@ type VPCCreateRequest struct {
 type VPCUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
+	Default     *bool  `json:"default,omitempty"`
 }
 
 // VPCSetField allows one to set individual fields within a VPC configuration.
@@ -53,6 +54,16 @@ type VPCSetName string
 // VPCSetDescription is used when one want to set the `description` field of a VPC.
 // Ex.: VPCs.Set(..., VPCSetDescription("vpc description"))
 type VPCSetDescription string
+
+// VPCSetDefault is used when one wants to enable the `default` field of a VPC, to
+// set a VPC as the default one in the region
+// Ex.: VPCs.Set(..., VPCSetDefault())
+func VPCSetDefault() VPCSetField {
+	return &vpcSetDefault{}
+}
+
+// vpcSetDefault satisfies the VPCSetField interface
+type vpcSetDefault struct{}
 
 // VPC represents a DigitalOcean Virtual Private Cloud configuration.
 type VPC struct {
@@ -159,6 +170,10 @@ func (n VPCSetName) vpcSetField(in map[string]interface{}) {
 
 func (n VPCSetDescription) vpcSetField(in map[string]interface{}) {
 	in["description"] = n
+}
+
+func (*vpcSetDefault) vpcSetField(in map[string]interface{}) {
+	in["default"] = true
 }
 
 // Set updates specific properties of a Virtual Private Cloud.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 github.com/bgentry/go-netrc/netrc
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.45.0
+# github.com/digitalocean/godo v1.52.0
 github.com/digitalocean/godo
 # github.com/emirpasic/gods v1.12.0
 github.com/emirpasic/gods/containers


### PR DESCRIPTION
When registry support went into general availability, it added the requirement of specifying a subscription plan. This adds the `subscription_tier_slug` to both the resource and data source allowing it to be specified on create and updated.

```
$ make testacc TESTARGS=-run='ContainerRegistry'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=ContainerRegistry -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDataSourceDigitalOceanContainerRegistry_Basic
=== PAUSE TestAccDataSourceDigitalOceanContainerRegistry_Basic
=== RUN   TestAccDigitalOceanContainerRegistry_importBasic
--- PASS: TestAccDigitalOceanContainerRegistry_importBasic (19.08s)
=== RUN   TestAccDigitalOceanContainerRegistryDockerCredentials_Basic
--- PASS: TestAccDigitalOceanContainerRegistryDockerCredentials_Basic (17.92s)
=== RUN   TestAccDigitalOceanContainerRegistryDockerCredentials_withExpiry
--- PASS: TestAccDigitalOceanContainerRegistryDockerCredentials_withExpiry (17.73s)
=== RUN   TestAccDigitalOceanContainerRegistry_Basic
--- PASS: TestAccDigitalOceanContainerRegistry_Basic (20.75s)
=== CONT  TestAccDataSourceDigitalOceanContainerRegistry_Basic
--- PASS: TestAccDataSourceDigitalOceanContainerRegistry_Basic (22.86s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    98.358s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
```