### PR TITLE
Adding a datasource for listing all SSH Keys

### DIFF
--- a/digitalocean/datasource_digitalocean_ssh_keys.go
+++ b/digitalocean/datasource_digitalocean_ssh_keys.go
@@ -1,0 +1,17 @@
+package digitalocean
+
+import (
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/datalist"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDigitalOceanSSHKeys() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema:        sshKeySchema(),
+		ResultAttributeName: "ssh_keys",
+		GetRecords:          getDigitalOceanSshKeys,
+		FlattenRecord:       flattenDigitalOceanSshKey,
+	}
+
+	return datalist.NewResource(dataListConfig)
+}

--- a/digitalocean/datasource_digitalocean_ssh_keys_test.go
+++ b/digitalocean/datasource_digitalocean_ssh_keys_test.go
@@ -1,0 +1,65 @@
+package digitalocean
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanSSHKeys_Basic(t *testing.T) {
+	keyName1 := fmt.Sprintf("tf-acc-test1-%s", acctest.RandString(10))
+	pubKey1, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
+	if err != nil {
+		t.Fatalf("Unable to generate public key: %v", err)
+		return
+	}
+	keyName2 := fmt.Sprintf("tf-acc-test2-%s", acctest.RandString(10))
+	pubKey2, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
+	if err != nil {
+		t.Fatalf("Unable to generate public key: %v", err)
+		return
+	}
+
+	resourcesConfig := fmt.Sprintf(`
+resource "digitalocean_ssh_key" "foo" {
+  name = "%s"
+  public_key = "%s"
+}
+
+resource "digitalocean_ssh_key" "bar" {
+  name = "%s"
+  public_key = "%s"
+}
+`, keyName1, pubKey1, keyName2, pubKey2)
+
+	datasourceConfig := fmt.Sprintf(`
+data "digitalocean_ssh_keys" "result" {
+  sort {
+    key       = "name"
+    direction = "asc"
+  }
+}
+`)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesConfig,
+			},
+			{
+				Config: resourcesConfig + datasourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_ssh_keys.result", "ssh_keys.#", "2"),
+					resource.TestCheckResourceAttr("data.digitalocean_ssh_keys.result", "ssh_keys.0.name", keyName1),
+					resource.TestCheckResourceAttr("data.digitalocean_ssh_keys.result", "ssh_keys.1.name", keyName2),
+				),
+			},
+			{
+				Config: resourcesConfig,
+			},
+		},
+	})
+}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 			"digitalocean_spaces_bucket_object":  dataSourceDigitalOceanSpacesBucketObject(),
 			"digitalocean_spaces_bucket_objects": dataSourceDigitalOceanSpacesBucketObjects(),
 			"digitalocean_ssh_key":               dataSourceDigitalOceanSSHKey(),
+			"digitalocean_ssh_keys":              dataSourceDigitalOceanSSHKeys(),
 			"digitalocean_tag":                   dataSourceDigitalOceanTag(),
 			"digitalocean_tags":                  dataSourceDigitalOceanTags(),
 			"digitalocean_volume_snapshot":       dataSourceDigitalOceanVolumeSnapshot(),

--- a/digitalocean/ssh_keys.go
+++ b/digitalocean/ssh_keys.go
@@ -1,0 +1,78 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func sshKeySchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeInt,
+			Description: "id of the ssh key",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Description: "name of the ssh key",
+		},
+		"public_key": {
+			Type:        schema.TypeString,
+			Description: "public key part of the ssh key",
+		},
+		"fingerprint": {
+			Type:        schema.TypeString,
+			Description: "fingerprint of the ssh key",
+		},
+	}
+}
+
+func getDigitalOceanSshKeys(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
+	client := meta.(*CombinedConfig).godoClient()
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	var keyList []interface{}
+
+	for {
+		keys, resp, err := client.Keys.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving ssh keys: %s", err)
+		}
+
+		for _, key := range keys {
+			keyList = append(keyList, key)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving ssh keys: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return keyList, nil
+}
+
+func flattenDigitalOceanSshKey(rawSshKey, meta interface{}, extra map[string]interface{}) (map[string]interface{}, error) {
+	key := rawSshKey.(godo.Key)
+
+	flattenedSshKey := map[string]interface{}{
+		"id":          key.ID,
+		"name":        key.Name,
+		"fingerprint": key.Fingerprint,
+		"public_key":  key.PublicKey,
+	}
+
+	return flattenedSshKey, nil
+}

--- a/docs/data-sources/ssh_keys.md
+++ b/docs/data-sources/ssh_keys.md
@@ -35,7 +35,7 @@ data "digitalocean_ssh_keys" "keys" {
  
 `filter` supports the following arguments:
 
-* `key` - (Required) Filter the SSH Keys by this key. This may be one of `name`, `public_key`, or `thumbprint`.
+* `key` - (Required) Filter the SSH Keys by this key. This may be one of `name`, `public_key`, or `fingerprint`.
 
 `sort` supports the following arguments:
 

--- a/docs/data-sources/ssh_keys.md
+++ b/docs/data-sources/ssh_keys.md
@@ -1,0 +1,53 @@
+---
+page_title: "DigitalOcean: digitalocean_ssh_keys"
+---
+
+# digitalocean_ssh_keys
+
+Get information on SSH Keys for use in other resources.
+
+This data source is useful if the SSH Keys in question are not managed by Terraform or you need to
+utilize any of the SSH Keys' data.
+
+Note: You can use the [`digitalocean_ssh_key`](droplet) data source to obtain metadata
+about a single SSH Key if you already know the unique `name` to retrieve.
+
+## Example Usage
+
+For example to find all SSH Keys:
+
+```hcl
+data "digitalocean_ssh_keys" "keys" {
+  sort {
+    key       = "name"
+    direction = "asc"
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+ 
+`filter` supports the following arguments:
+
+* `key` - (Required) Filter the SSH Keys by this key. This may be one of `name`, `public_key`, or `thumbprint`.
+
+`sort` supports the following arguments:
+
+* `key` - (Required) Sort the SSH Keys by this key. This may be one of `name`, `public_key`, or `thumbprint`.
+
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
+
+## Attributes Reference
+
+* `ssh_keys` - A list of SSH Keys. Each SSH Key has the following attributes:  
+
+  * `id` - The ID of the ssh key.
+  * `name`: The name of the ssh key.
+  * `public_key`: The public key of the ssh key.
+  * `fingerprint`: The fingerprint of the public key of the ssh key.

--- a/docs/data-sources/ssh_keys.md
+++ b/docs/data-sources/ssh_keys.md
@@ -39,7 +39,7 @@ data "digitalocean_ssh_keys" "keys" {
 
 `sort` supports the following arguments:
 
-* `key` - (Required) Sort the SSH Keys by this key. This may be one of `name`, `public_key`, or `thumbprint`.
+* `key` - (Required) Sort the SSH Keys by this key. This may be one of `name`, `public_key`, or `fingerprint`.
 
 * `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
 


### PR DESCRIPTION
Fixes: #518

```
▶ TF_ACC=1 go test -v -tags=go -parallel 4 -timeout 2h --run=TestAccDataSourceDigitalOceanSSHKeys
=== RUN   TestAccDataSourceDigitalOceanSSHKeys_Basic
=== PAUSE TestAccDataSourceDigitalOceanSSHKeys_Basic
=== CONT  TestAccDataSourceDigitalOceanSSHKeys_Basic
--- PASS: TestAccDataSourceDigitalOceanSSHKeys_Basic (9.75s)
PASS
ok  	github.com/digitalocean/terraform-provider-digitalocean/digitalocean	9.766s

terraform-providers/terraform-provider-digitalocean/digitalocean  ssh_keys_datasource ✗                                                                                                                                                                                9m ⚑
▶ TF_ACC=1 go test -v -tags=go -parallel 4 -timeout 2h --run=TestAccDataSourceDigitalOceanSSHKey_
=== RUN   TestAccDataSourceDigitalOceanSSHKey_Basic
=== PAUSE TestAccDataSourceDigitalOceanSSHKey_Basic
=== CONT  TestAccDataSourceDigitalOceanSSHKey_Basic
--- PASS: TestAccDataSourceDigitalOceanSSHKey_Basic (8.88s)
PASS
ok  	github.com/digitalocean/terraform-provider-digitalocean/digitalocean	8.903s
```