### PR TITLE
database_cluster: Handle Redis version change with DiffSuppressFunc.

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -47,6 +47,11 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 				// Required: true,
 				Optional: true,
 				ForceNew: true,
+				// Redis clusters are being force upgraded from version 5 to 6.
+				// Prevent attempting to recreate clusters specifying 5 in their config.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("engine") == "redis" && old == "6" && new == "5"
+				},
 			},
 
 			"size": {

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -37,7 +37,7 @@ resource "digitalocean_database_cluster" "mysql-example" {
 resource "digitalocean_database_cluster" "redis-example" {
   name       = "example-redis-cluster"
   engine     = "redis"
-  version    = "5"
+  version    = "6"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1


### PR DESCRIPTION
Redis 5 clusters can no longer be created. For backwards compatibility the API allows for POST requests that specify "5" for the version, but a Redis 6 cluster is actually created. The response body specifies "6" for the version. This should be handled without Terraform attempting to recreate the cluster.


Acceptance test failure without change:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_oldRedisVersion'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_oldRedisVersion -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_oldRedisVersion
=== PAUSE TestAccDigitalOceanDatabaseCluster_oldRedisVersion
=== CONT  TestAccDigitalOceanDatabaseCluster_oldRedisVersion
    resource_digitalocean_database_cluster_test.go:258: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # digitalocean_database_cluster.foobar must be replaced
        -/+ resource "digitalocean_database_cluster" "foobar" {
              + database             = (known after apply)
                engine               = "redis"
              ~ host                 = "tf-acc-test-q17wtcrno3-do-user-3100395-0.b.db.ondigitalocean.com" -> (known after apply)
              ~ id                   = "c987d02d-8961-44be-8e73-f71c3b5d26f6" -> (known after apply)
                name                 = "tf-acc-test-q17wtcrno3"
                node_count           = 1
              ~ password             = (sensitive value)
              ~ port                 = 25061 -> (known after apply)
              ~ private_host         = "private-tf-acc-test-q17wtcrno3-do-user-3100395-0.b.db.ondigitalocean.com" -> (known after apply)
              ~ private_network_uuid = "b7d3832e-dc84-11e8-8650-3cfdfea9f8c8" -> (known after apply)
              ~ private_uri          = (sensitive value)
                region               = "nyc1"
                size                 = "db-s-1vcpu-1gb"
                tags                 = [
                    "production",
                ]
              ~ uri                  = (sensitive value)
              ~ urn                  = "do:dbaas:c987d02d-8961-44be-8e73-f71c3b5d26f6" -> (known after apply)
              ~ user                 = "default" -> (known after apply)
              ~ version              = "6" -> "5"
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccDigitalOceanDatabaseCluster_oldRedisVersion (274.33s)
FAIL
FAIL    github.com/digitalocean/terraform-provider-digitalocean/digitalocean    274.337s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        0.008s [no tests to run]
FAIL
make: *** [GNUmakefile:16: testacc] Error 1
```

All `database_cluster` tests passing post change:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster -parallel=10'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster -parallel=10 -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_Basic
=== PAUSE TestAccDigitalOceanDatabaseCluster_Basic
=== RUN   TestAccDigitalOceanDatabaseCluster_WithUpdate
=== PAUSE TestAccDigitalOceanDatabaseCluster_WithUpdate
=== RUN   TestAccDigitalOceanDatabaseCluster_WithMigration
=== PAUSE TestAccDigitalOceanDatabaseCluster_WithMigration
=== RUN   TestAccDigitalOceanDatabaseCluster_WithMaintWindow
=== PAUSE TestAccDigitalOceanDatabaseCluster_WithMaintWindow
=== RUN   TestAccDigitalOceanDatabaseCluster_WithSQLMode
=== PAUSE TestAccDigitalOceanDatabaseCluster_WithSQLMode
=== RUN   TestAccDigitalOceanDatabaseCluster_CheckSQLModeSupport
=== PAUSE TestAccDigitalOceanDatabaseCluster_CheckSQLModeSupport
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisNoVersion
=== PAUSE TestAccDigitalOceanDatabaseCluster_RedisNoVersion
=== RUN   TestAccDigitalOceanDatabaseCluster_oldRedisVersion
=== PAUSE TestAccDigitalOceanDatabaseCluster_oldRedisVersion
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy
=== PAUSE TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy
=== RUN   TestAccDigitalOceanDatabaseCluster_CheckEvictionPolicySupport
=== PAUSE TestAccDigitalOceanDatabaseCluster_CheckEvictionPolicySupport
=== RUN   TestAccDigitalOceanDatabaseCluster_TagUpdate
=== PAUSE TestAccDigitalOceanDatabaseCluster_TagUpdate
=== RUN   TestAccDigitalOceanDatabaseCluster_WithVPC
=== PAUSE TestAccDigitalOceanDatabaseCluster_WithVPC
=== CONT  TestAccDigitalOceanDatabaseCluster_Basic
=== CONT  TestAccDigitalOceanDatabaseCluster_TagUpdate
=== CONT  TestAccDigitalOceanDatabaseCluster_WithSQLMode
=== CONT  TestAccDigitalOceanDatabaseCluster_WithMigration
=== CONT  TestAccDigitalOceanDatabaseCluster_CheckSQLModeSupport
=== CONT  TestAccDigitalOceanDatabaseCluster_CheckEvictionPolicySupport
=== CONT  TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy
=== CONT  TestAccDigitalOceanDatabaseCluster_oldRedisVersion
=== CONT  TestAccDigitalOceanDatabaseCluster_RedisNoVersion
=== CONT  TestAccDigitalOceanDatabaseCluster_WithMaintWindow
2020/12/02 17:45:16 [INFO] DigitalOcean Client configured for URL: https://api.digitalocean.com
=== CONT  TestAccDigitalOceanDatabaseCluster_WithUpdate
--- PASS: TestAccDigitalOceanDatabaseCluster_RedisNoVersion (0.61s)
2020/12/02 17:45:16 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccDigitalOceanDatabaseCluster_CheckSQLModeSupport (0.71s)
=== CONT  TestAccDigitalOceanDatabaseCluster_WithVPC
--- PASS: TestAccDigitalOceanDatabaseCluster_CheckEvictionPolicySupport (0.71s)
2020/12/02 17:45:17 [INFO] DigitalOcean Client configured for URL: https://api.digitalocean.com
--- PASS: TestAccDigitalOceanDatabaseCluster_WithVPC (269.87s)
--- PASS: TestAccDigitalOceanDatabaseCluster_Basic (280.89s)
--- PASS: TestAccDigitalOceanDatabaseCluster_WithMaintWindow (288.34s)
--- PASS: TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy (291.95s)
--- PASS: TestAccDigitalOceanDatabaseCluster_WithSQLMode (359.44s)
--- PASS: TestAccDigitalOceanDatabaseCluster_oldRedisVersion (414.92s)
--- PASS: TestAccDigitalOceanDatabaseCluster_TagUpdate (450.55s)
--- PASS: TestAccDigitalOceanDatabaseCluster_WithUpdate (608.57s)
--- PASS: TestAccDigitalOceanDatabaseCluster_WithMigration (611.59s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    611.605s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
```