### PR TITLE
goreleaser: Build OpenBSD binaries.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
     - windows
     - linux
     - darwin
+    - openbsd
   goarch:
     - amd64
     - '386'
@@ -27,6 +28,10 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: openbsd
+      goarch: arm
+    - goos: openbsd
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
When HashiCorp managed the build and distribution of the module directly, they provided OpenBSD binaries. Looking back at the last release before the transition to the registry distribution model, they were provided for i386 and amd64. So I've skipped the ARM builds for OpenBSD. This also matches with the OpenBSD support for Terraform binaries provided by HashiCorp: https://www.terraform.io/downloads.html

```
curl 'https://registry.terraform.io/v1/providers/terraform-providers/digitalocean/versions' | jq '.versions[]  | select(.version=="1.20.0") | .platforms[] | select(.os=="openbsd")'

{
  "os": "openbsd",
  "arch": "386"
}
{
  "os": "openbsd",
  "arch": "amd64"
}
```

Closes: #533 