### PR TITLE
k8s: Update k8s versions used in acceptance tests.

### DIFF
--- a/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccDataSourceDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	rName := randomTestName()
 	var k8s godo.KubernetesCluster
-	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersion16, rName)
+	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersion19, rName)
 	dataSourceConfig := `
 data "digitalocean_kubernetes_cluster" "foobar" {
 	name = digitalocean_kubernetes_cluster.foo.name

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -21,7 +21,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, clusterName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, clusterName),
 				// Remove the default node pool tag so that the import code which infers
 				// the need to add the tag gets triggered.
 				Check: testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
@@ -112,7 +112,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testClusterVersion16, testName1, testName2)
+`, testClusterVersion19, testName1, testName2)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -32,7 +32,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testClusterVersion16, testName1, testName2)
+`, testClusterVersion19, testName1, testName2)
 	resourceName := "digitalocean_kubernetes_node_pool.barfoo"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	testClusterVersion16 = `data "digitalocean_kubernetes_versions" "test" {
-  version_prefix = "1.16."
+	testClusterVersion18 = `data "digitalocean_kubernetes_versions" "test" {
+  version_prefix = "1.18."
 }`
-	testClusterVersion17 = `data "digitalocean_kubernetes_versions" "test" {
-  version_prefix = "1.17."
+	testClusterVersion19 = `data "digitalocean_kubernetes_versions" "test" {
+  version_prefix = "1.19."
 }`
 )
 
@@ -71,7 +71,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -125,14 +125,14 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion17, rName+"-updated"),
+				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion19, rName+"-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName+"-updated"),
@@ -157,7 +157,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -168,7 +168,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -196,7 +196,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -207,7 +207,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -249,7 +249,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion17, rName),
+				`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -280,7 +280,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion17, rName),
+				`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -311,7 +311,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion17, rName),
+				`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -339,7 +339,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							node_count = 2
 						}
 					}
-				`, testClusterVersion17, rName),
+				`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -380,7 +380,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 						node_count = 1
 					}
 				}
-			`, testClusterVersion17, rName),
+			`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -411,7 +411,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion17, rName),
+				`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -441,7 +441,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion17, rName),
+				`, testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -474,7 +474,7 @@ func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s), resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.raw_config"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.cluster_ca_certificate"),
@@ -496,14 +496,14 @@ func TestAccDigitalOceanKubernetesCluster_UpgradeVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion18, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion17, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPtr("digitalocean_kubernetes_cluster.foobar", "id", &k8s.ID),
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -112,7 +112,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 5
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -150,7 +150,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -189,7 +189,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -225,7 +225,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 2
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -275,7 +275,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 1
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -314,7 +314,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -352,7 +352,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion16, rName, rName),
+				`, testClusterVersion19, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -395,7 +395,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 	node_count = 1
 	tags  = ["three","four"]
 }
-`, testClusterVersion16, rName, rName)
+`, testClusterVersion19, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string {
@@ -426,7 +426,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
       priority = "high"
 	}
 }
-`, testClusterVersion16, rName, rName)
+`, testClusterVersion19, rName, rName)
 }
 
 func testAccCheckDigitalOceanKubernetesNodePoolExists(n string, cluster *godo.KubernetesCluster, pool *godo.KubernetesNodePool) resource.TestCheckFunc {


### PR DESCRIPTION
This update the k8s versions used in acceptance tests as 1.16.x is no longer available for new clusters:

```
$ doctl kubernetes options versions 
Slug            Kubernetes Version
1.19.3-do.2     1.19.3
1.18.10-do.2    1.18.10
1.17.13-do.2    1.17.13
```

```
$ make testacc TESTARGS='-run=Kubernetes -count=1 -parallel=10'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=Kubernetes -count=1 -parallel=10 -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDataSourceDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDataSourceDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDataSourceDigitalOceanKubernetesVersions_Basic
=== PAUSE TestAccDataSourceDigitalOceanKubernetesVersions_Basic
=== RUN   TestAccDataSourceDigitalOceanKubernetesVersions_Filtered
=== PAUSE TestAccDataSourceDigitalOceanKubernetesVersions_Filtered
=== RUN   TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster
=== PAUSE TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportBasic
=== PAUSE TestAccDigitalOceanKubernetesCluster_ImportBasic
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
=== PAUSE TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
=== RUN   TestAccDigitalOceanKubernetesNodePool_Import
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Import
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== RUN   TestAccDigitalOceanKubernetesNodePool_Basic
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Basic
=== RUN   TestAccDigitalOceanKubernetesNodePool_Update
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Update
=== RUN   TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale
=== CONT  TestAccDataSourceDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesNodePool_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (312.21s)
=== CONT  TestAccDigitalOceanKubernetesNodePool_Import
--- PASS: TestAccDataSourceDigitalOceanKubernetesCluster_Basic (339.70s)
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
--- PASS: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (362.17s)
=== CONT  TestAccDigitalOceanKubernetesCluster_UpgradeVersion
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (412.63s)
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
--- PASS: TestAccDigitalOceanKubernetesNodePool_Basic (445.76s)
=== CONT  TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool (455.55s)
=== CONT  TestAccDigitalOceanKubernetesCluster_ImportBasic
--- PASS: TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale (557.11s)
=== CONT  TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
--- PASS: TestAccDigitalOceanKubernetesNodePool_Update (568.13s)
=== CONT  TestAccDataSourceDigitalOceanKubernetesVersions_Filtered
--- PASS: TestAccDataSourceDigitalOceanKubernetesVersions_Filtered (9.79s)
=== CONT  TestAccDataSourceDigitalOceanKubernetesVersions_Basic
--- PASS: TestAccDataSourceDigitalOceanKubernetesVersions_Basic (9.65s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale (620.45s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale (344.29s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (733.79s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpgradeVersion (392.58s)
--- PASS: TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster (310.88s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Import (455.78s)
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportBasic (352.97s)
--- PASS: TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale (512.83s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (772.37s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    1185.015s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        0.009s [no tests to run]
```