### PR TITLE
vpcs: Protect against race conditions in IP range assignment.

### DIFF
--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -2,7 +2,12 @@ package digitalocean
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv"
 )
+
+// Global MutexKV
+var mutexKV = mutexkv.NewMutexKV()
 
 // Provider returns a schema.Provider for DigitalOcean.
 func Provider() *schema.Provider {

--- a/internal/mutexkv/mutexkv.go
+++ b/internal/mutexkv/mutexkv.go
@@ -1,0 +1,53 @@
+package mutexkv
+
+import (
+	"log"
+	"sync"
+)
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+// The initial use case is to let aws_security_group_rule resources serialize
+// their access to individual security groups based on SG ID.
+//
+// Originally from: https://github.com/hashicorp/terraform-plugin-sdk/blob/v1.12.0/helper/mutexkv/mutexkv.go
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initalized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/internal/mutexkv/mutexkv_test.go
+++ b/internal/mutexkv/mutexkv_test.go
@@ -1,0 +1,67 @@
+package mutexkv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMutexKVLock(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("foo")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		t.Fatal("Second lock was able to be taken. This shouldn't happen.")
+	case <-time.After(50 * time.Millisecond):
+		// pass
+	}
+}
+
+func TestMutexKVUnlock(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+	mkv.Unlock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("foo")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// pass
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock blocked after unlock. This shouldn't happen.")
+	}
+}
+
+func TestMutexKVDifferentKeys(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("bar")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// pass
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock on a different key blocked. This shouldn't happen.")
+	}
+}


### PR DESCRIPTION
This prevents parallel creation of VPCs in the same region to protect against race conditions in IP range assignment. Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/551

It creates an internal copy of the mutexkv package that had previously been part of the Terraform SDK. This is the same strategy employed by other providers.

https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#removal-of-helper-mutexkv-package

> Providers that need the functionality provided by the `helper/mutexkv` package are encouraged to copy the types and functions it provided into their own codebase, provided here under a public domain license

Before change, the new test fails with:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanVPC_IPRangeRace'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanVPC_IPRangeRace -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanVPC_IPRangeRace
=== PAUSE TestAccDigitalOceanVPC_IPRangeRace
=== CONT  TestAccDigitalOceanVPC_IPRangeRace
    resource_digitalocean_vpc_test.go:87: Step 1/1 error: Error running apply: 
        Error: Error creating VPC: POST https://api.digitalocean.com/v2/vpcs: 422 (request "beeb46fc-d4ba-4223-bffd-462e21fe4f23") This range/size overlaps with another VPC network in your account: tf-acc-test-rk10vpxzml 10.108.0.0/20.
        
        
--- FAIL: TestAccDigitalOceanVPC_IPRangeRace (2.72s)
FAIL
FAIL    github.com/digitalocean/terraform-provider-digitalocean/digitalocean    2.730s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
FAIL
make: *** [GNUmakefile:16: testacc] Error 1
```

Post-change it passes:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanVPC_IPRangeRace'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanVPC_IPRangeRace -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanVPC_IPRangeRace
=== PAUSE TestAccDigitalOceanVPC_IPRangeRace
=== CONT  TestAccDigitalOceanVPC_IPRangeRace
--- PASS: TestAccDigitalOceanVPC_IPRangeRace (8.24s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    8.245s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
```