### PR TITLE
bump kubernetes version to 1.19.3-do.3

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -15,7 +15,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name   = "foo"
   region = "nyc1"
   # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.5-do.1"
+  version = "1.19.3-do.3"
 
   node_pool {
     name       = "worker-pool"
@@ -34,7 +34,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name   = "foo"
   region = "nyc1"
   # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.5-do.1"
+  version = "1.19.3-do.3"
   tags    = ["staging"]
 
   node_pool {
@@ -63,7 +63,7 @@ For example:
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.15.5-do.1"
+  version = "1.19.3-do.3"
 
   node_pool {
     name       = "autoscale-worker-pool"

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -14,7 +14,7 @@ Provides a DigitalOcean Kubernetes node pool resource. While the default node po
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.15.5-do.1"
+  version = "1.19.3-do.3"
 
   node_pool {
     name       = "front-end-pool"


### PR DESCRIPTION
Thank you for creating such great documentation!

However, when I try to create a kubernetes cluster using the following as a reference, I get the error.

Referred: 
https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster
https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_node_pool

result: 
```
Error: Error creating Kubernetes cluster: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 validation error: invalid version slug
```

This is probably due to the fact that it is an older version and is not supported.
So I changed to the current latest version and it works fine now.

What do you feel about this PR?

Thanks!