### PR TITLE
apps: Mark env var values as sensitive (Closes: #554).

### DIFF
--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -97,6 +97,7 @@ func appSpecEnvSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The value of the environment variable.",
+				Sensitive:   true,
 			},
 			"scope": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
An app env var's `type` can be `GENERAL` or `SECRET`. Unfortunately there is not a way to set an attribute on one field based on an attribute from another. So we should error on the side of safely, and treat all env var values as sensitive when it comes to logging.