### PR TITLE
kubernetes: Expand example to show best practices for interacting with k8s provider.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ website/node_modules
 .vagrant/
 *.backup
 ./*.tfstate
+*.terraform.lock.hcl
 .terraform/
 *.log
 *.bak
@@ -34,3 +35,6 @@ website/vendor
 
 # Local release artifacts
 dist/
+
+# kubeconfig file produced by running example
+examples/kubernetes/kubeconfig

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -468,7 +468,7 @@ func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"kubernetes": {
 				Source:            "hashicorp/kubernetes",
-				VersionConstraint: "1.13.2",
+				VersionConstraint: "2.0.1",
 			},
 		},
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
@@ -637,7 +637,6 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 
 provider "kubernetes" {
   host = digitalocean_kubernetes_cluster.foobar.endpoint
-  load_config_file = false
   cluster_ca_certificate = base64decode(
     digitalocean_kubernetes_cluster.foobar.kube_config[0].cluster_ca_certificate
   )

--- a/docs/data-sources/kubernetes_cluster.md
+++ b/docs/data-sources/kubernetes_cluster.md
@@ -14,7 +14,6 @@ data "digitalocean_kubernetes_cluster" "example" {
 }
 
 provider "kubernetes" {
-  load_config_file = false
   host             = data.digitalocean_kubernetes_cluster.example.endpoint
   token            = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(

--- a/docs/resources/container_registry_docker_credentials.md
+++ b/docs/resources/container_registry_docker_credentials.md
@@ -53,25 +53,15 @@ resource "digitalocean_container_registry_docker_credentials" "example" {
   registry_name = "example"
 }
 
-resource "digitalocean_kubernetes_cluster" "example" {
-  name   = "example"
-  region = "nyc1"
-  # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.16.6-do.0"
-
-  node_pool {
-    name       = "worker-pool"
-    size       = "s-2vcpu-2gb"
-    node_count = 3
-  }
+data "digitalocean_kubernetes_cluster" "example" {
+  name = "prod-cluster-01"
 }
 
 provider "kubernetes" {
-  load_config_file = false
-  host             = digitalocean_kubernetes_cluster.example.endpoint
-  token            = digitalocean_kubernetes_cluster.example.kube_config[0].token
+  host             = data.digitalocean_kubernetes_cluster.example.endpoint
+  token            = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(
-    digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
+    data.digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
   )
 }
 

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -25,35 +25,6 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 }
 ```
 
-### Kubernetes Terraform Provider Example
-
-The cluster's kubeconfig is exported as an attribute allowing you to use it with the [Kubernetes Terraform provider](https://www.terraform.io/docs/providers/kubernetes/index.html). For example:
-
-```hcl
-resource "digitalocean_kubernetes_cluster" "foo" {
-  name   = "foo"
-  region = "nyc1"
-  # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.19.3-do.3"
-  tags    = ["staging"]
-
-  node_pool {
-    name       = "worker-pool"
-    size       = "s-2vcpu-2gb"
-    node_count = 3
-  }
-}
-
-provider "kubernetes" {
-  load_config_file = false
-  host             = digitalocean_kubernetes_cluster.foo.endpoint
-  token            = digitalocean_kubernetes_cluster.foo.kube_config[0].token
-  cluster_ca_certificate = base64decode(
-    digitalocean_kubernetes_cluster.foo.kube_config[0].cluster_ca_certificate
-  )
-}
-```
-
 ### Autoscaling Example
 
 Node pools may also be configured to [autoscale](https://www.digitalocean.com/docs/kubernetes/how-to/autoscale/).
@@ -102,6 +73,47 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 ```
 
 Note that a data source is used to supply the version. This is needed to prevent configuration diff whenever a cluster is upgraded.
+
+### Kubernetes Terraform Provider Example
+
+The cluster's kubeconfig is exported as an attribute allowing you to use it with
+the [Kubernetes Terraform provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs).
+
+~> When using interpolation to pass credentials from a `digitalocean_kubernetes_cluster`
+resource to the Kubernetes provider, the cluster resource generally should not
+be created in the same Terraform module where Kubernetes provider resources are
+also used. This can lead to unpredictable errors which are hard to debug and
+diagnose. The root issue lies with the order in which Terraform itself evaluates
+the provider blocks vs. actual resources.
+
+When using the Kubernetes provider with a cluster created in a separate Terraform
+module or configuration, use the [`digitalocean_kubernetes_cluster` data-source](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/kubernetes_cluster)
+to access the cluster's credentials. [See here for a full example](https://github.com/digitalocean/terraform-provider-digitalocean/tree/main/examples/kubernetes).
+
+```hcl
+resource "digitalocean_kubernetes_cluster" "foo" {
+  name   = "foo"
+  region = "nyc1"
+  # Grab the latest version slug from `doctl kubernetes options versions`
+  version = "1.19.3-do.3"
+  tags    = ["staging"]
+
+  node_pool {
+    name       = "worker-pool"
+    size       = "s-2vcpu-2gb"
+    node_count = 3
+  }
+}
+
+provider "kubernetes" {
+  load_config_file = false
+  host             = digitalocean_kubernetes_cluster.foo.endpoint
+  token            = digitalocean_kubernetes_cluster.foo.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    digitalocean_kubernetes_cluster.foo.kube_config[0].cluster_ca_certificate
+  )
+}
+```
 
 ## Argument Reference
 

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -91,26 +91,15 @@ module or configuration, use the [`digitalocean_kubernetes_cluster` data-source]
 to access the cluster's credentials. [See here for a full example](https://github.com/digitalocean/terraform-provider-digitalocean/tree/main/examples/kubernetes).
 
 ```hcl
-resource "digitalocean_kubernetes_cluster" "foo" {
-  name   = "foo"
-  region = "nyc1"
-  # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.19.3-do.3"
-  tags    = ["staging"]
-
-  node_pool {
-    name       = "worker-pool"
-    size       = "s-2vcpu-2gb"
-    node_count = 3
-  }
+data "digitalocean_kubernetes_cluster" "example" {
+  name = "prod-cluster-01"
 }
 
 provider "kubernetes" {
-  load_config_file = false
-  host             = digitalocean_kubernetes_cluster.foo.endpoint
-  token            = digitalocean_kubernetes_cluster.foo.kube_config[0].token
+  host             = data.digitalocean_kubernetes_cluster.example.endpoint
+  token            = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(
-    digitalocean_kubernetes_cluster.foo.kube_config[0].cluster_ca_certificate
+    data.digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
   )
 }
 ```

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -104,6 +104,29 @@ provider "kubernetes" {
 }
 ```
 
+#### Exec credential plugin
+
+Another method to ensure that the Kubernetes provider is receiving valid credentials
+is to use an exec plugin. In order to use use this approach, the DigitalOcean
+CLI (`doctl`) must be present. `doctl` will renew the token if needed before
+initializing the provider.
+
+```hcl
+provider "kubernetes" {
+  host                   = data.digitalocean_kubernetes_cluster.foo.endpoint
+  cluster_ca_certificate = base64decode(
+    data.digitalocean_kubernetes_cluster.foo.kube_config[0].cluster_ca_certificate
+  )
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "doctl"
+    args = ["kubernetes", "cluster", "kubeconfig", "exec-credential",
+    "--version=v1beta1", data.digitalocean_kubernetes_cluster.foo.id]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -4,7 +4,7 @@ This example shows how to use the Terraform Kubernetes Provider and Terraform
 Helm Provider to configure a DOKS cluster. The example config builds the DOKS
 cluster and applies the Kubernetes configurations in a single operation. This
 guide will also show you how to make changes to the underlying DOKS cluster in
-such a way that Kuberntes/Helm resources are recreated after the underlying
+such a way that Kubernetes/Helm resources are recreated after the underlying
 cluster is replaced.
 
 You will need to set the following environment variables:

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,2 +1,75 @@
+# DigitalOcean Kubernetes Service (DOKS)
+
+This example shows how to use the Terraform Kubernetes Provider and Terraform
+Helm Provider to configure a DOKS cluster. The example config builds the DOKS
+cluster and applies the Kubernetes configurations in a single operation. This
+guide will also show you how to make changes to the underlying DOKS cluster in
+such a way that Kuberntes/Helm resources are recreated after the underlying
+cluster is replaced.
+
+You will need to set the following environment variables:
+
+ - `DIGITALOCEAN_ACCESS_TOKEN`
+
+To install the DOKS cluster using default values, run terraform init and apply
+from the directory containing this README.
+
+```
+terraform init
+terraform apply
+```
+
+Optionally, the Kubernetes version, the number of worker nodes, and the instance
+type of the worker nodes can also be specified:
+
+```
+terraform apply -var=cluster_version=1.18 -var=worker_size=s-4vcpu-8gb -var=worker_count=5
+```
+
+
+## Versions
+
+Valid versions for the DOKS cluster can be found by using the doctl, the DigitalOcean CLI.
+
+```
+ doctl kubernetes options versions
+```
+
+## Kubeconfig for manual CLI access
+
+Optionally, this example can generate a kubeconfig file in the current working
+directory. However, the token in this config will expire. The token can be
+refreshed by running `terraform apply` again and setting `write_kubeconfig` to
+`true`.
+
+```
 terraform apply -var="write_kubeconfig=true"
 export KUBECONFIG=$(terraform output -raw kubeconfig_path
+kubectl get pods -n test
+```
+
+Alternatively, a longer-lived configuration can be generated using doctl. This
+command will merge the configuration into your kubeconfig at the default location
+(`$HOME/.kube/config`) or create it if the file does not exist.
+
+```
+doctl kubernetes cluster kubeconfig save $(terraform output -raw cluster_name)
+kubectl get pods -n test
+```
+
+## Replacing the DOKS cluster and re-creating the Kubernetes / Helm resources
+
+When the cluster is initially created, the Kubernetes and Helm providers will not
+be initialized until authentication details are created for the cluster. However,
+for future operations that may involve replacing the underlying cluster, the DOKS
+cluster will have to be targeted without the Kubernetes/Helm providers, as shown
+below. This is done by removing the `module.kubernetes-config` from Terraform
+State prior to replacing cluster credentials, to avoid passing outdated
+credentials into the providers.
+
+This will create the new cluster and the Kubernetes resources in a single apply.
+
+```
+terraform state rm module.kubernetes-config
+terraform apply
+```

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -44,7 +44,7 @@ refreshed by running `terraform apply` again and setting `write_kubeconfig` to
 
 ```
 terraform apply -var="write_kubeconfig=true"
-export KUBECONFIG=$(terraform output -raw kubeconfig_path
+export KUBECONFIG=$(terraform output -raw kubeconfig_path)
 kubectl get pods -n test
 ```
 

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,2 @@
+terraform apply -var="write_kubeconfig=true"
+export KUBECONFIG=$(terraform output -raw kubeconfig_path

--- a/examples/kubernetes/doks-cluster/main.tf
+++ b/examples/kubernetes/doks-cluster/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = ">= 2.4.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  # Provider is configured using environment variables:
+  # DIGITALOCEAN_TOKEN, DIGITALOCEAN_ACCESS_TOKEN
+}
+
+data "digitalocean_kubernetes_versions" "current" {
+  version_prefix = var.cluster_version
+}
+
+resource "digitalocean_kubernetes_cluster" "primary" {
+  name    = var.cluster_name
+  region  = var.cluster_region
+  version = data.digitalocean_kubernetes_versions.current.latest_version
+
+  node_pool {
+    name       = "default"
+    size       = var.worker_size
+    node_count = var.worker_count
+  }
+}

--- a/examples/kubernetes/doks-cluster/outputs.tf
+++ b/examples/kubernetes/doks-cluster/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_id" {
+  value = digitalocean_kubernetes_cluster.primary.id
+}
+
+output "cluster_name" {
+  value = digitalocean_kubernetes_cluster.primary.name
+}

--- a/examples/kubernetes/doks-cluster/variables.tf
+++ b/examples/kubernetes/doks-cluster/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_version" {
+  type = string
+}
+
+variable "worker_count" {
+  type = number
+}
+
+variable "worker_size" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "cluster_region" {
+  type = string
+}

--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -1,0 +1,147 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = ">= 2.4.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0.1"
+    }
+  }
+}
+
+data "digitalocean_kubernetes_cluster" "primary" {
+  name = var.cluster_name
+}
+
+resource "local_file" "kubeconfig" {
+  depends_on = [var.cluster_id]
+  count      = var.write_kubeconfig ? 1 : 0
+  content    = data.digitalocean_kubernetes_cluster.primary.kube_config[0].raw_config
+  filename   = "${path.root}/kubeconfig"
+}
+
+provider "kubernetes" {
+  host             = data.digitalocean_kubernetes_cluster.primary.endpoint
+  token            = data.digitalocean_kubernetes_cluster.primary.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    data.digitalocean_kubernetes_cluster.primary.kube_config[0].cluster_ca_certificate
+  )
+}
+
+provider "helm" {
+  kubernetes {
+    host  = data.digitalocean_kubernetes_cluster.primary.endpoint
+    token = data.digitalocean_kubernetes_cluster.primary.kube_config[0].token
+    cluster_ca_certificate = base64decode(
+      data.digitalocean_kubernetes_cluster.primary.kube_config[0].cluster_ca_certificate
+    )
+  }
+}
+
+resource "kubernetes_namespace" "test" {
+  metadata {
+    name = "test"
+  }
+}
+
+resource "kubernetes_deployment" "test" {
+  metadata {
+    name = "test"
+    namespace= kubernetes_namespace.test.metadata.0.name
+  }
+  spec {
+    replicas = 2
+    selector {
+      match_labels = {
+        app = "test"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app  = "test"
+        }
+      }
+      spec {
+        container {
+          image = "hashicorp/http-echo"
+          name  = "http-echo"
+          args  = ["-text=test"]
+
+          resources {
+            limits = {
+              memory = "512M"
+              cpu = "1"
+            }
+            requests = {
+              memory = "256M"
+              cpu = "50m"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "test" {
+  metadata {
+    name      = "test-service"
+    namespace = kubernetes_namespace.test.metadata.0.name
+  }
+  spec {
+    selector = {
+      app = kubernetes_deployment.test.metadata.0.name
+    }
+
+    port {
+      port = 5678
+    }
+  }
+}
+
+resource "helm_release" "nginx_ingress" {
+  name       = "nginx-ingress-controller"
+  namespace  = kubernetes_namespace.test.metadata.0.name
+
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx-ingress-controller"
+
+  set {
+    name  = "service.type"
+    value = "LoadBalancer"
+  }
+}
+
+resource "kubernetes_ingress" "test_ingress" {
+  wait_for_load_balancer = true
+  metadata {
+    name = "test-ingress"
+    namespace  = kubernetes_namespace.test.metadata.0.name
+    annotations = {
+      "kubernetes.io/ingress.class" = "nginx"
+      "ingress.kubernetes.io/rewrite-target" = "/"
+    }
+  }
+
+  spec {
+    rule {
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.test.metadata.0.name
+            service_port = 5678
+          }
+
+          path = "/test"
+        }
+      }
+    }
+  }
+}

--- a/examples/kubernetes/kubernetes-config/variables.tf
+++ b/examples/kubernetes/kubernetes-config/variables.tf
@@ -1,0 +1,12 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "cluster_id" {
+  type = string
+}
+
+variable "write_kubeconfig" {
+  type        = bool
+  default     = false
+}

--- a/examples/kubernetes/outputs.tf
+++ b/examples/kubernetes/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_name" {
+  value = module.doks-cluster.cluster_name
+}
+
+output "kubeconfig_path" {
+  value = var.write_kubeconfig ? abspath("${path.root}/kubeconfig") : "none"
+}

--- a/examples/kubernetes/variables.tf
+++ b/examples/kubernetes/variables.tf
@@ -1,0 +1,17 @@
+
+variable "cluster_version" {
+  default = "1.19"
+}
+
+variable "worker_count" {
+  default = 3
+}
+
+variable "worker_size" {
+  default = "s-2vcpu-4gb"
+}
+
+variable "write_kubeconfig" {
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
As seen in https://github.com/digitalocean/terraform-provider-digitalocean/issues/562, using interpolation to pass credentials to the Kubernetes provider from other resources can cause some issues due to the order in which Terraform evaluates the provider blocks vs. actual resources. In fact, the Kubernetes provider docs have added a warning to discourage using interpolation to pass credentials: 

https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#stacking-with-managed-kubernetes-cluster-resources

This PR expands the Kubernetes example in this repo to be more complete and better adhere to best practices for interacting with the Kubernetes provider. It also adds a notes to the Kubernetes cluster resource docs addressing the issue and linking to that example. Finally, it updates usage of the Kubernetes provider for it 2.0.x release (specifically the removal of the `load_config_file` attribute).

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/562