### PR TITLE
App: internal ports array attribute

### DIFF
--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -1011,9 +1011,9 @@ func expandAppSpecServices(config []interface{}) []*godo.AppServiceSpec {
 			s.HealthCheck = expandAppHealthCheck(checks)
 		}
 
-		internal_ports := service["internal_ports"].([]interface{})
-		if len(internal_ports) > 0 {
-			s.InternalPorts = expandAppInternalPort(internal_ports)
+		internalPorts := service["internal_ports"].([]interface{})
+		if len(internalPorts) > 0 {
+			s.InternalPorts = expandAppInternalPort(internalPorts)
 		}
 
 		appServices = append(appServices, s)

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -245,12 +245,12 @@ func appSpecRouteSchema() map[string]*schema.Schema {
 func appSpecInternalPortSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-		"port": {
-			Type:        schema.TypeInt,
-			Optional:    false,
-			Description: "A port used for internally contacting the service.",
-		},
-	}}
+			"port": {
+				Type:        schema.TypeInt,
+				Optional:    false,
+				Description: "A port used for internally contacting the service.",
+			},
+		}}
 }
 
 func appSpecHealthCheckSchema() map[string]*schema.Schema {
@@ -400,8 +400,8 @@ func appSpecServicesSchema() *schema.Resource {
 		"internal_port": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem: appSpecInternalPortSchema(),
-			Set: schema.HashResource(appSpecInternalPortSchema()),
+			Elem:     appSpecInternalPortSchema(),
+			Set:      schema.HashResource(appSpecInternalPortSchema()),
 		},
 	}
 

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -242,14 +242,15 @@ func appSpecRouteSchema() map[string]*schema.Schema {
 	}
 }
 
-func appSpecInternalPortSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+func appSpecInternalPortSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
 		"port": {
 			Type:        schema.TypeInt,
 			Optional:    false,
 			Description: "A port used for internally contacting the service.",
 		},
-	}
+	}}
 }
 
 func appSpecHealthCheckSchema() map[string]*schema.Schema {
@@ -399,9 +400,8 @@ func appSpecServicesSchema() *schema.Resource {
 		"internal_port": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem: &schema.Resource{
-				Schema: appSpecInternalPortSchema(),
-			},
+			Elem: appSpecInternalPortSchema(),
+			Set: schema.HashResource(appSpecInternalPortSchema()),
 		},
 	}
 
@@ -912,9 +912,9 @@ func expandAppInternalPort(config []interface{}) []int64 {
 	appInternalPorts := make([]int64, 0, len(config))
 
 	for _, rawinternalPort := range config {
-		internal_port := rawinternalPort.(map[string]interface{})
+		internalPort := rawinternalPort.(map[string]interface{})
 
-		appInternalPorts = append(appInternalPorts, internal_port["port"].(int64))
+		appInternalPorts = append(appInternalPorts, internalPort["port"].(int64))
 	}
 
 	return appInternalPorts

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -247,7 +247,7 @@ func appSpecInternalPortSchema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"port": {
 				Type:        schema.TypeInt,
-				Optional:    false,
+				Required:    true,
 				Description: "A port used for internally contacting the service.",
 			},
 		}}

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -242,6 +242,16 @@ func appSpecRouteSchema() map[string]*schema.Schema {
 	}
 }
 
+func appSpecInternalPortSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"port": {
+			Type:        schema.TypeInt,
+			Optional:    false,
+			Description: "A port used for internally contacting the service.",
+		},
+	}
+}
+
 func appSpecHealthCheckSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"http_path": {
@@ -384,6 +394,13 @@ func appSpecServicesSchema() *schema.Resource {
 			Computed: true,
 			Elem: &schema.Resource{
 				Schema: appSpecRouteSchema(),
+			},
+		},
+		"internal_port": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: appSpecInternalPortSchema(),
 			},
 		},
 	}
@@ -895,9 +912,9 @@ func expandAppInternalPort(config []interface{}) []int64 {
 	appInternalPorts := make([]int64, 0, len(config))
 
 	for _, rawinternalPort := range config {
-		internal_port := rawinternalPort.(int64)
+		internal_port := rawinternalPort.(map[string]interface{})
 
-		appInternalPorts = append(appInternalPorts, internal_port)
+		appInternalPorts = append(appInternalPorts, internal_port["port"].(int64))
 	}
 
 	return appInternalPorts
@@ -994,7 +1011,7 @@ func expandAppSpecServices(config []interface{}) []*godo.AppServiceSpec {
 			s.HealthCheck = expandAppHealthCheck(checks)
 		}
 
-		internal_ports := service["internal_port"].([]interface{})
+		internal_ports := service["internal_ports"].([]interface{})
 		if len(internal_ports) > 0 {
 			s.InternalPorts = expandAppInternalPort(internal_ports)
 		}

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -241,17 +241,6 @@ func appSpecRouteSchema() map[string]*schema.Schema {
 	}
 }
 
-func appSpecInternalPortSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"port": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				Description: "A port used for internally contacting the service.",
-			},
-		}}
-}
-
 func appSpecHealthCheckSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"http_path": {

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -736,7 +736,7 @@ resource "digitalocean_app" "foobar" {
         branch         = "main"
       }
 	  
-	  internal_ports = ["5000"]
+	  internal_ports = [ 5000 ]
     }
   }
 }`

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -243,8 +243,6 @@ func TestAccDigitalOceanApp_InternalPort(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.git.0.branch", "main"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.service.0.health_check.0.timeout_seconds", "10"),
-					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.#", "1"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.0", "5000"),

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -215,6 +215,49 @@ func TestAccDigitalOceanApp_StaticSite(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanApp_InternalPort(t *testing.T) {
+	var app godo.App
+	appName := randomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_addInternalPort, appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.name", appName),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "default_ingress"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "updated_at"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "created_at"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.instance_count", "1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.instance_size_slug", "basic-xxs"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.routes.0.path", "/"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.git.0.repo_clone_url",
+						"https://github.com/digitalocean/sample-golang.git"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.git.0.branch", "main"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.health_check.0.http_path", "/"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.health_check.0.timeout_seconds", "10"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.0", "5000"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanApp_Envs(t *testing.T) {
 	var app godo.App
 	appName := randomTestName()
@@ -678,6 +721,34 @@ resource "digitalocean_app" "foobar" {
       }
 
       http_port = 80
+    }
+  }
+}`
+
+var testAccCheckDigitalOceanAppConfig_addInternalPort = `
+resource "digitalocean_app" "foobar" {
+  spec {
+    name = "%s"
+    region = "ams"
+
+    service {
+      name               = "go-service"
+      environment_slug   = "go"
+      instance_count     = 1
+      instance_size_slug = "basic-xxs"
+
+      git {
+        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+        branch         = "main"
+      }
+
+      routes {
+        path = "/"
+	  }
+	  
+	  internal_port {
+		port = 5000
+	  }
     }
   }
 }`

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -243,9 +243,9 @@ func TestAccDigitalOceanApp_InternalPort(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.git.0.branch", "main"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.#", "1"),
+						"digitalocean_app.foobar", "spec.0.service.0.internal_ports.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.0", "5000"),
+						"digitalocean_app.foobar", "spec.0.service.0.internal_ports.0", "5000"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -230,8 +230,6 @@ func TestAccDigitalOceanApp_InternalPort(t *testing.T) {
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.name", appName),
-					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "default_ingress"),
-					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "updated_at"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "created_at"),
@@ -240,16 +238,14 @@ func TestAccDigitalOceanApp_InternalPort(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.instance_size_slug", "basic-xxs"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.service.0.routes.0.path", "/"),
-					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.git.0.repo_clone_url",
 						"https://github.com/digitalocean/sample-golang.git"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.git.0.branch", "main"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.service.0.health_check.0.http_path", "/"),
-					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.health_check.0.timeout_seconds", "10"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.#", "1"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.routes.0.internal_ports.0", "5000"),
 				),
@@ -741,14 +737,8 @@ resource "digitalocean_app" "foobar" {
         repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
         branch         = "main"
       }
-
-      routes {
-        path = "/"
-	  }
 	  
-	  internal_port {
-		port = 5000
-	  }
+	  internal_ports = ["5000"]
     }
   }
 }`


### PR DESCRIPTION
The digitalocean_app spec was also missing the internal_ports attribute on a service, this should fix this. Acceptance test (`TestAccDigitalOceanApp_InternalPort`) is passing
internal_ports are specified like `internal_ports = ["5000"]`, maybe an array syntax
```
internal_port {
   port = 5000
}
internal_port {
   port = 2000
}
```
would be preferred, similarly to the routes attribute. not sure.