### PR TITLE
apps: Allow multiple routes (Closes: #567).

### DIFF
--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -276,7 +276,6 @@ func appSpecComponentBase() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 			Optional: true,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: appSpecRouteSchema(),
 			},

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -272,14 +272,6 @@ func appSpecComponentBase() map[string]*schema.Schema {
 			Elem:     appSpecEnvSchema(),
 			Set:      schema.HashResource(appSpecEnvSchema()),
 		},
-		"routes": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: appSpecRouteSchema(),
-			},
-		},
 		"source_dir": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -334,6 +326,14 @@ func appSpecServicesSchema() *schema.Resource {
 				Schema: appSpecImageSourceSchema(),
 			},
 		},
+		"routes": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: appSpecRouteSchema(),
+			},
+		},
 	}
 
 	for k, v := range appSpecComponentBase() {
@@ -366,6 +366,14 @@ func appSpecStaticSiteSchema() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The name of the document to use as the fallback for any requests to documents that are not found when serving this static site.",
+		},
+		"routes": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: appSpecRouteSchema(),
+			},
 		},
 	}
 

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -618,6 +618,10 @@ resource "digitalocean_app" "foobar" {
       routes {
         path = "/"
       }
+
+      routes {
+        path = "/foo"
+      }
     }
   }
 }`


### PR DESCRIPTION
This PR addresses #567 by allowing multiple routes for a service or static site. As workers and jobs are not publicly rotatable, this moves the attribute out of the `appSpecComponentBase()` and directly into `appSpecServicesSchema()` and `appSpecStaticSiteSchema()`