### PR TITLE
apps: Deprecate domains list in favor of domain block.

### DIFF
--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -983,11 +983,6 @@ func expandAppSpecStaticSites(config []interface{}) []*godo.AppStaticSiteSpec {
 			s.Git = expandAppGitSourceSpec(git)
 		}
 
-		//		image := site["image"].([]interface{})
-		//		if len(image) > 0 {
-		//			s.Image = expandAppImageSourceSpec(image)
-		//		}
-
 		routes := site["routes"].([]interface{})
 		if len(routes) > 0 {
 			s.Routes = expandAppRoutes(routes)
@@ -1010,7 +1005,6 @@ func flattenAppSpecStaticSites(sites []*godo.AppStaticSiteSpec) []map[string]int
 		r["github"] = flattenAppGitHubSourceSpec(s.GitHub)
 		r["gitlab"] = flattenAppGitLabSourceSpec(s.GitLab)
 		r["git"] = flattenAppGitSourceSpec(s.Git)
-		// r["image"] = flattenAppImageSourceSpec(s.Image)
 		r["routes"] = flattenAppRoutes(s.Routes)
 		r["dockerfile_path"] = s.DockerfilePath
 		r["env"] = flattenAppEnvs(s.Envs)

--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -644,7 +644,7 @@ func flattenAppSpecDomains(domains []*godo.AppDomainSpec) []map[string]interface
 
 		r["name"] = d.Domain
 		r["type"] = string(d.Type)
-		r["wildcard"] = d.Zone
+		r["wildcard"] = d.Wildcard
 		r["zone"] = d.Zone
 
 		result[i] = r

--- a/digitalocean/datasource_digitalocean_app.go
+++ b/digitalocean/datasource_digitalocean_app.go
@@ -20,7 +20,7 @@ func dataSourceDigitalOceanApp() *schema.Resource {
 				Computed:    true,
 				Description: "A DigitalOcean App Platform Spec",
 				Elem: &schema.Resource{
-					Schema: appSpecSchema(),
+					Schema: appSpecSchema(false),
 				},
 			},
 			"default_ingress": {

--- a/digitalocean/resource_digitalocean_app.go
+++ b/digitalocean/resource_digitalocean_app.go
@@ -29,7 +29,7 @@ func resourceDigitalOceanApp() *schema.Resource {
 				MaxItems:    1,
 				Description: "A DigitalOcean App Platform Spec",
 				Elem: &schema.Resource{
-					Schema: appSpecSchema(),
+					Schema: appSpecSchema(true),
 				},
 			},
 
@@ -112,7 +112,7 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("updated_at", app.UpdatedAt.UTC().String())
 	d.Set("created_at", app.CreatedAt.UTC().String())
 
-	if err := d.Set("spec", flattenAppSpec(app.Spec)); err != nil {
+	if err := d.Set("spec", flattenAppSpec(d, app.Spec)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting app spec: %#v", err)
 	}
 


### PR DESCRIPTION
This builds off of the work by @acraven in https://github.com/digitalocean/terraform-provider-digitalocean/pull/544 It deprecates the `domains` array in favor of a `domain` block that supports additional features like wildcard domains. Existing users of `domains` should not see any behavior change, only a deprecation warning.

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanApp_Domain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanApp_Domain -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanApp_Domain
=== PAUSE TestAccDigitalOceanApp_Domain
=== RUN   TestAccDigitalOceanApp_DomainsDeprecation
=== PAUSE TestAccDigitalOceanApp_DomainsDeprecation
=== CONT  TestAccDigitalOceanApp_Domain
=== CONT  TestAccDigitalOceanApp_DomainsDeprecation
--- PASS: TestAccDigitalOceanApp_DomainsDeprecation (240.92s)
--- PASS: TestAccDigitalOceanApp_Domain (256.15s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    256.159s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
```

Note: This does not include docs changes. There are other apps related docs changes needed for images in #565 and jobs in #566. I'll open a separate PR for them together. 