### PR TITLE
cdn: Handle certificate name updates.

### DIFF
--- a/digitalocean/resource_digitalocean_cdn.go
+++ b/digitalocean/resource_digitalocean_cdn.go
@@ -232,10 +232,19 @@ func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, 
 		log.Printf("[INFO] Updated TTL on CDN")
 	}
 
-	if d.HasChange("certificate_id") || d.HasChange("custom_domain") {
+	if d.HasChange("certificate_id") || d.HasChange("custom_domain") || d.HasChange("certificate_name") {
 		cdnUpdateRequest := &godo.CDNUpdateCustomDomainRequest{
-			CustomDomain:  d.Get("custom_domain").(string),
-			CertificateID: d.Get("certificate_id").(string),
+			CustomDomain: d.Get("custom_domain").(string),
+		}
+
+		certName := d.Get("certificate_name").(string)
+		if certName != "" {
+			cert, err := findCertificateByName(client, certName)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			cdnUpdateRequest.CertificateID = cert.ID
 		}
 
 		_, _, err := client.CDNs.UpdateCustomDomain(context.Background(), d.Id(), cdnUpdateRequest)


### PR DESCRIPTION
This resolves a bug introduced in https://github.com/digitalocean/terraform-provider-digitalocean/pull/500. We made changes to use certificate names as primary identifier instead of IDs. This included the CDN resource, but I missed the update flow for CDNs. We did not have an acceptance test excercising using CDNs with custom domains/certificates.

The new test fails before the code changes are appiled:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanCDN_CustomDomain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanCDN_CustomDomain -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanCDN_CustomDomain
=== PAUSE TestAccDigitalOceanCDN_CustomDomain
=== CONT  TestAccDigitalOceanCDN_CustomDomain
    resource_digitalocean_cdn_test.go:114: Step 2/2 error: Error running apply: 
        Error: Error deleting Certificate: DELETE https://api.digitalocean.com/v2/certificates/a25f53d6-fdc7-4230-bf25-c6266d48d81a: 422 (request "559bc985-3360-4c4d-a124-71ba0bd83538") This certificate is being used by an active Load Balancer. You must make sure no Load Balancer is using it before deleting.
        
        
--- FAIL: TestAccDigitalOceanCDN_CustomDomain (54.61s)
FAIL
FAIL    github.com/digitalocean/terraform-provider-digitalocean/digitalocean    54.623s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
FAIL
make: *** [GNUmakefile:16: testacc] Error 1
```

When the changes are applied, the test now passes:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanCDN_CustomDomain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanCDN_CustomDomain -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanCDN_CustomDomain
=== PAUSE TestAccDigitalOceanCDN_CustomDomain
=== CONT  TestAccDigitalOceanCDN_CustomDomain
--- PASS: TestAccDigitalOceanCDN_CustomDomain (95.23s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    95.238s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/setutil        (cached) [no tests to run]
```