### PR TITLE
Fix docs and validation for expiry_seconds on registry docker credentials resource.

### DIFF
--- a/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
+++ b/digitalocean/resource_digitalocean_container_registry_docker_credentials.go
@@ -36,9 +36,10 @@ func resourceDigitalOceanContainerRegistryDockerCredentials() *schema.Resource {
 				Default:  false,
 			},
 			"expiry_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  expirySecondsDefault,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      expirySecondsDefault,
+				ValidateFunc: validation.IntBetween(0, expirySecondsDefault),
 			},
 			"docker_credentials": {
 				Type:      schema.TypeString,
@@ -133,11 +134,6 @@ func generateDockerCredentials(readWrite bool, expirySeconds int, client *godo.C
 func updateExpiredDockerCredentials(d *schema.ResourceData, readWrite bool, client *godo.Client) error {
 	expirySeconds := d.Get("expiry_seconds").(int)
 	expirationTime := d.Get("credential_expiration_time").(string)
-
-	if (expirySeconds > expirySecondsDefault) || (expirySeconds <= 0) {
-		return fmt.Errorf("expiry_seconds outside acceptable range")
-	}
-
 	d.Set("expiry_seconds", expirySeconds)
 
 	currentTime := time.Now().UTC()

--- a/docs/resources/container_registry_docker_credentials.md
+++ b/docs/resources/container_registry_docker_credentials.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `registry_name` - (Required) The name of the container registry.
 * `write` - (Optional) Allow for write access to the container registry. Defaults to false.
-* `expiry_seconds` - (Optional) The amount of time to pass before the Docker credentials expire in seconds. Defaults to 2147483647, or roughly 68 years. Must be greater than 0 and less than 2147483647.
+* `expiry_seconds` - (Optional) The amount of time to pass before the Docker credentials expire in seconds. Defaults to 1576800000, or roughly 50 years. Must be greater than 0 and less than 1576800000.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The `updateExpiredDockerCredentials` function gets called when the state is being refreshed, but the change to the configuration is not available at refresh. So you can encounter a situation like #581 where a bad value has been set in state but the validation prevents the value from being corrected. We should prevent the bad value from ever being entered in the first place.

Fixes: #581

