### PR TITLE
bump kubernetes version

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -15,7 +15,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name   = "foo"
   region = "nyc1"
   # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.19.3-do.3"
+  version = "1.20.2-do.0"
 
   node_pool {
     name       = "worker-pool"
@@ -34,7 +34,7 @@ For example:
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.19.3-do.3"
+  version = "1.20.2-do.0"
 
   node_pool {
     name       = "autoscale-worker-pool"

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -14,7 +14,7 @@ Provides a DigitalOcean Kubernetes node pool resource. While the default node po
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.19.3-do.3"
+  version = "1.20.2-do.0"
 
   node_pool {
     name       = "front-end-pool"


### PR DESCRIPTION
Hi!
Thanks for provide great documentation.

Currently, choosable latest kubernetes version is "1.20.2-do.0"  also "1.19.3-do.3" is already abolished.

```
❯ doctl kubernetes o versions                                                                                                                                              [10:27:36]
Slug            Kubernetes Version
1.20.2-do.0     1.20.2
1.19.6-do.0     1.19.6
1.18.14-do.0    1.18.14
```

Error
```
Error: Error creating Kubernetes cluster: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 validation error: invalid version slug
```

I've updated documentation content.
What do you feel about this PR?

Thanks! 