### PR TITLE
kubernetes - enable surge upgrades by default during cluster creation

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -26,7 +26,7 @@ func resourceDigitalOceanKubernetesCluster() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanKubernetesClusterImportState,
 		},
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -49,6 +49,7 @@ func resourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"surge_upgrade": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default: true,
 			},
 
 			"version": {


### PR DESCRIPTION
Description: Now that surge upgrades is stable, enable surge upgrades by default as it is a better user experience during upgrades.

cc @adamwg

