### PR TITLE
Assign and remove project resources without unnecessary churn (Fixes: #585).

### DIFF
--- a/digitalocean/datasource_digitalocean_projects_test.go
+++ b/digitalocean/datasource_digitalocean_projects_test.go
@@ -57,7 +57,7 @@ data "digitalocean_projects" "both" {
     }
 }
 `, stagingProjectName, stagingProjectName)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckDigitalOceanProjectDestroy,

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -210,9 +210,14 @@ func resourceDigitalOceanProjectUpdate(ctx context.Context, d *schema.ResourceDa
 		oldURNs, newURNs := d.GetChange("resources")
 		remove, add := getSetChanges(oldURNs.(*schema.Set), newURNs.(*schema.Set))
 
-		assignResourcesToDefaultProject(client, remove)
+		if remove.Len() > 0 {
+			_, err = assignResourcesToDefaultProject(client, remove)
+			if err != nil {
+				return diag.Errorf("Error assigning resources to default project: %s", err)
+			}
+		}
 
-		if newURNs.(*schema.Set).Len() != 0 {
+		if add.Len() > 0 {
 			_, err = assignResourcesToProject(client, projectId, add)
 			if err != nil {
 				return diag.Errorf("Error Updating project: %s", err)

--- a/digitalocean/resource_digitalocean_project_resources.go
+++ b/digitalocean/resource_digitalocean_project_resources.go
@@ -53,14 +53,14 @@ func resourceDigitalOceanProjectResourcesUpdate(ctx context.Context, d *schema.R
 		oldURNs, newURNs := d.GetChange("resources")
 		remove, add := getSetChanges(oldURNs.(*schema.Set), newURNs.(*schema.Set))
 
-		if oldURNs.(*schema.Set).Len() > 0 {
+		if remove.Len() > 0 {
 			_, err = assignResourcesToDefaultProject(client, remove)
 			if err != nil {
 				return diag.Errorf("Error assigning resources to default project: %s", err)
 			}
 		}
 
-		if newURNs.(*schema.Set).Len() > 0 {
+		if add.Len() > 0 {
 			_, err = assignResourcesToProject(client, projectId, add)
 			if err != nil {
 				return diag.Errorf("Error assigning resources to project %s: %s", projectId, err)

--- a/digitalocean/resource_digitalocean_project_resources.go
+++ b/digitalocean/resource_digitalocean_project_resources.go
@@ -51,24 +51,23 @@ func resourceDigitalOceanProjectResourcesUpdate(ctx context.Context, d *schema.R
 
 	if d.HasChange("resources") {
 		oldURNs, newURNs := d.GetChange("resources")
+		remove, add := getSetChanges(oldURNs.(*schema.Set), newURNs.(*schema.Set))
 
 		if oldURNs.(*schema.Set).Len() > 0 {
-			_, err = assignResourcesToDefaultProject(client, oldURNs.(*schema.Set))
+			_, err = assignResourcesToDefaultProject(client, remove)
 			if err != nil {
 				return diag.Errorf("Error assigning resources to default project: %s", err)
 			}
 		}
 
-		var urns *[]interface{}
-
 		if newURNs.(*schema.Set).Len() > 0 {
-			urns, err = assignResourcesToProject(client, projectId, newURNs.(*schema.Set))
+			_, err = assignResourcesToProject(client, projectId, add)
 			if err != nil {
 				return diag.Errorf("Error assigning resources to project %s: %s", projectId, err)
 			}
 		}
 
-		if err = d.Set("resources", urns); err != nil {
+		if err = d.Set("resources", newURNs); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/digitalocean/set.go
+++ b/digitalocean/set.go
@@ -2,9 +2,34 @@ package digitalocean
 
 import (
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Helper function for sets of strings that are case insensitive
 func HashStringIgnoreCase(v interface{}) int {
 	return SDKHashString(strings.ToLower(v.(string)))
+}
+
+// getSetChanges compares two *schema.Set, "old" and "new." It returns one
+// *schema.Set only containing items not found in the "new" set and another
+// containing items not found in the "old" set.
+//
+// Originally written to update the resources in a project.
+func getSetChanges(old *schema.Set, new *schema.Set) (remove *schema.Set, add *schema.Set) {
+	remove = schema.NewSet(old.F, []interface{}{})
+	for _, x := range old.List() {
+		if !new.Contains(x) {
+			remove.Add(x)
+		}
+	}
+
+	add = schema.NewSet(new.F, []interface{}{})
+	for _, x := range new.List() {
+		if !old.Contains(x) {
+			add.Add(x)
+		}
+	}
+
+	return remove, add
 }

--- a/digitalocean/set_test.go
+++ b/digitalocean/set_test.go
@@ -1,0 +1,118 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestGetSetChanges(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		old    *schema.Set
+		new    *schema.Set
+		add    *schema.Set
+		remove *schema.Set
+	}{
+		{
+			old: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar", "baz",
+			}),
+			new: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar",
+			}),
+			add: schema.NewSet(schema.HashString, []interface{}{}),
+			remove: schema.NewSet(schema.HashString, []interface{}{
+				"baz",
+			}),
+		},
+		{
+			old: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar",
+			}),
+			new: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar", "baz",
+			}),
+			add: schema.NewSet(schema.HashString, []interface{}{
+				"baz",
+			}),
+			remove: schema.NewSet(schema.HashString, []interface{}{}),
+		},
+		{
+			old: schema.NewSet(schema.HashString, []interface{}{
+				"foo",
+			}),
+			new: schema.NewSet(schema.HashString, []interface{}{
+				"bar",
+			}),
+			add: schema.NewSet(schema.HashString, []interface{}{
+				"bar",
+			}),
+			remove: schema.NewSet(schema.HashString, []interface{}{
+				"foo",
+			}),
+		},
+		{
+			old: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar",
+			}),
+			new: schema.NewSet(schema.HashString, []interface{}{
+				"baz", "qux",
+			}),
+			add: schema.NewSet(schema.HashString, []interface{}{
+				"baz", "qux",
+			}),
+			remove: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar",
+			}),
+		},
+		{
+			old: schema.NewSet(schema.HashString, []interface{}{
+				"foo", "bar", "baz",
+			}),
+			new: schema.NewSet(schema.HashString, []interface{}{
+				"bar", "baz", "qux",
+			}),
+			add: schema.NewSet(schema.HashString, []interface{}{
+				"qux",
+			}),
+			remove: schema.NewSet(schema.HashString, []interface{}{
+				"foo",
+			}),
+		},
+		{
+			old: schema.NewSet(schema.HashInt, []interface{}{
+				1, 2, 3,
+			}),
+			new: schema.NewSet(schema.HashInt, []interface{}{
+				1, 2,
+			}),
+			add: schema.NewSet(schema.HashInt, []interface{}{}),
+			remove: schema.NewSet(schema.HashInt, []interface{}{
+				3,
+			}),
+		},
+		{
+			old: schema.NewSet(schema.HashInt, []interface{}{
+				1,
+			}),
+			new: schema.NewSet(schema.HashInt, []interface{}{
+				2,
+			}),
+			add: schema.NewSet(schema.HashInt, []interface{}{
+				2,
+			}),
+			remove: schema.NewSet(schema.HashInt, []interface{}{
+				1,
+			}),
+		},
+	}
+
+	for _, item := range tt {
+		remove, add := getSetChanges(item.old, item.new)
+		if !remove.Equal(item.remove) || !add.Equal(item.add) {
+			t.Errorf("expected add: %#v, remove: %#v; got add: %#v, remove: %#v", add, remove, item.add, item.remove)
+		}
+	}
+}


### PR DESCRIPTION
The current implementation moves all resources in the old config to the default project and then adds the resources in the new config to the Terraform-managed project. This creates a lot of unnecessary churn.

https://github.com/digitalocean/terraform-provider-digitalocean/blob/2c4bf56fe1da163346f8bfa98ec9dbb996355b3b/digitalocean/resource_digitalocean_project.go#L208-L209

This PR adds a helper function to compares two `*schema.Set`s, producing lists of which should be added and which should be removed. Resources that were in both the old and new configs will no longer be touched.

Fixes: #585