### PR TITLE
dbaas replica: Add missing attributes to docs.

### DIFF
--- a/docs/resources/database_replica.md
+++ b/docs/resources/database_replica.md
@@ -35,6 +35,8 @@ The following arguments are supported:
 * `name` - (Required) The name for the database replica.
 * `size` - (Required) Database Droplet size associated with the replica (ex. `db-s-1vcpu-1gb`).
 * `region` - (Required) DigitalOcean region where the replica will reside.
+* `tags` - (Optional) A list of tag names to be applied to the database replica.
+* `private_network_uuid` - (Optional) The ID of the VPC where the database replica will be located.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Looks like we missed documenting these attributes:

`private_network_uuid`: https://github.com/digitalocean/terraform-provider-digitalocean/blob/2c4bf56fe1da163346f8bfa98ec9dbb996355b3b/digitalocean/resource_digitalocean_database_replica.go#L52

`tags`: https://github.com/digitalocean/terraform-provider-digitalocean/blob/2c4bf56fe1da163346f8bfa98ec9dbb996355b3b/digitalocean/resource_digitalocean_database_replica.go#L103