### PR TITLE
Run tests on pull_request not pull_request_target.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 name: Unit Test
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
     - main

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -49,7 +49,7 @@ func resourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"surge_upgrade": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default: true,
+				Default:  true,
 			},
 
 			"version": {


### PR DESCRIPTION
Run tests on `pull_request` not `pull_request_target` to  prevent failures like this from only being found after merge into main.

https://github.com/digitalocean/terraform-provider-digitalocean/runs/1936909608?check_suite_focus=true