### PR TITLE
Fix broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ make build
 Using the provider
 ----------------------
 
-See the [DigitalOcean Provider documentation](https://www.terraform.io/docs/providers/do/index.html) to get started using the DigitalOcean provider.
+See the [DigitalOcean Provider documentation](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs) to get started using the DigitalOcean provider.
 
 Developing the Provider
 ---------------------------

--- a/docs/data-sources/loadbalancer.md
+++ b/docs/data-sources/loadbalancer.md
@@ -34,5 +34,5 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-See the [Load Balancer Resource](/docs/providers/do/r/loadbalancer.html) for details on the
+See the [Load Balancer Resource](/providers/digitalocean/digitalocean/latest/docs/resources/loadbalancer) for details on the
 returned attributes - they are identical.

--- a/docs/resources/droplet.md
+++ b/docs/resources/droplet.md
@@ -6,7 +6,7 @@ page_title: "DigitalOcean: digitalocean_droplet"
 
 Provides a DigitalOcean Droplet resource. This can be used to create,
 modify, and delete Droplets. Droplets also support
-[provisioning](/docs/provisioners/index.html).
+[provisioning](https://www.terraform.io/docs/language/resources/provisioners/syntax.html).
 
 ## Example Usage
 
@@ -48,7 +48,7 @@ The following arguments are supported:
    size is a permanent change**. Increasing only RAM and CPU is reversible.
 * `tags` - (Optional) A list of the tags to be applied to this Droplet.
 * `user_data` (Optional) - A string of the desired User Data for the Droplet.
-* `volume_ids` (Optional) - A list of the IDs of each [block storage volume](/docs/providers/do/r/volume.html) to be attached to the Droplet.
+* `volume_ids` (Optional) - A list of the IDs of each [block storage volume](/providers/digitalocean/digitalocean/latest/docs/resources/volume) to be attached to the Droplet.
 
 ~> **NOTE:** If you use `volume_ids` on a Droplet, Terraform will assume management over the full set volumes for the instance, and treat additional volumes as a drift. For this reason, `volume_ids` must not be mixed with external `digitalocean_volume_attachment` resources for a given instance.
 

--- a/examples/droplet/README.md
+++ b/examples/droplet/README.md
@@ -2,7 +2,7 @@
 
 The example launches an Ubuntu 16.04, runs apt-get update and installs nginx. Also demonstrates how to create DNS records under Domains at DigitalOcean. 
 
-To run, configure your Digital Ocean provider as described in https://www.terraform.io/docs/providers/do/index.html
+To run, configure your Digital Ocean provider as described in https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs
 
 ## Prerequisites
 You need to export you DigitalOcean API Token as an environment variable


### PR DESCRIPTION
Several broken links remain after the docs restructuring in PR #501.
This commit serves to update those links to point to the correct pages.