### PR TITLE
Update the statement below the autoscaling example

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -46,7 +46,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 }
 ```
 
-Note that, while individual node pools may scale to 0, a cluster must always include at least one node.
+Note that, each node pool must always have at least one node and when using autoscaling the min_nodes must be greater than or equal to 1.
 
 ### Auto Upgrade Example
 


### PR DESCRIPTION
The existing statement is not accurate as specifying a node pool
min_nodes to 0 will result in the following error.

```
422 validation error: worker_node_pool_spec.min nodes must be greater than or equal to 1
```
For clarity sake I got this error when adding a 2nd node pool with autoscaling to an existing cluster.  So the cluster itself had other nodes.