### PR TITLE
custom_image: Surface a better error to users if image import fails.

### DIFF
--- a/digitalocean/resource_digitalocean_image.go
+++ b/digitalocean/resource_digitalocean_image.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -246,6 +247,11 @@ func imageStateRefreshFunc(ctx context.Context, d *schema.ResourceData, state st
 		if err != nil {
 			return nil, "", err
 		}
+
+		if imageResponse.Status == imageDeletedStatus {
+			return nil, "", fmt.Errorf(imageResponse.ErrorMessage)
+		}
+
 		return imageResponse, imageResponse.Status, nil
 	}
 }


### PR DESCRIPTION
When we initiate an import of a custom image, we poll until it becomes `available`. If there is a problem with the image its status moves to `deleted` and an `error_message` is populated.  We do not currently surface that error message to users. It's only visible in the debug logging for the API requests.

After this PR, error message should be more helpful. E.g.

> Error: Error waiting for image (81502973) to become ready: We had a problem decompressing your file. This typically happens if the archive is corrupt or contains multiple files. Please try decompressing the file locally and uploading the uncompressed image, or recompressing using gzip or bzip2.