### PR TITLE
database cluster: Handle MongoDB password differences.

### DIFF
--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -176,20 +176,10 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 				}
 			}
 
-			if db.Connection != nil {
-				d.Set("host", db.Connection.Host)
-				d.Set("port", db.Connection.Port)
-				d.Set("uri", db.Connection.URI)
-				d.Set("database", db.Connection.Database)
-				d.Set("user", db.Connection.User)
-				d.Set("password", db.Connection.Password)
+			err := setDatabaseConnectionInfo(&db, d)
+			if err != nil {
+				return diag.Errorf("Error setting connection info for database cluster: %s", err)
 			}
-
-			if db.PrivateConnection != nil {
-				d.Set("private_host", db.PrivateConnection.Host)
-				d.Set("private_uri", db.PrivateConnection.URI)
-			}
-
 			d.Set("urn", db.URN())
 			d.Set("private_network_uuid", db.PrivateNetworkUUID)
 

--- a/digitalocean/datasource_digitalocean_database_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_database_cluster_test.go
@@ -43,6 +43,10 @@ func TestAccDataSourceDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 						"data.digitalocean_database_cluster.foobar", "password"),
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_cluster.foobar", "private_network_uuid"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "uri"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "private_uri"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -231,10 +231,10 @@ func resourceDigitalOceanDatabaseClusterCreate(ctx context.Context, d *schema.Re
 		opts.PrivateNetworkUUID = v.(string)
 	}
 
-	log.Printf("[DEBUG] DatabaseCluster create configuration: %#v", opts)
+	log.Printf("[DEBUG] database cluster create configuration: %#v", opts)
 	database, _, err := client.Databases.Create(context.Background(), opts)
 	if err != nil {
-		return diag.Errorf("Error creating DatabaseCluster: %s", err)
+		return diag.Errorf("Error creating database cluster: %s", err)
 	}
 
 	// MongoDB clusters only return the password in response to the initial POST.
@@ -242,17 +242,17 @@ func resourceDigitalOceanDatabaseClusterCreate(ctx context.Context, d *schema.Re
 	if database.EngineSlug == mongoDBEngineSlug {
 		err = setDatabaseConnectionInfo(database, d)
 		if err != nil {
-			return diag.Errorf("Error setting connection info for DatabaseCluster: %s", err)
+			return diag.Errorf("Error setting connection info for database cluster: %s", err)
 		}
 	}
 
 	database, err = waitForDatabaseCluster(client, database.ID, "online")
 	if err != nil {
-		return diag.Errorf("Error creating DatabaseCluster: %s", err)
+		return diag.Errorf("Error creating database cluster: %s", err)
 	}
 
 	d.SetId(database.ID)
-	log.Printf("[INFO] DatabaseCluster Name: %s", database.Name)
+	log.Printf("[INFO] database cluster Name: %s", database.Name)
 
 	if v, ok := d.GetOk("maintenance_window"); ok {
 		opts := expandMaintWindowOpts(v.([]interface{}))
@@ -266,21 +266,21 @@ func resourceDigitalOceanDatabaseClusterCreate(ctx context.Context, d *schema.Re
 				return nil
 			}
 
-			return diag.Errorf("Error adding maintenance window for DatabaseCluster: %s", err)
+			return diag.Errorf("Error adding maintenance window for database cluster: %s", err)
 		}
 	}
 
 	if policy, ok := d.GetOk("eviction_policy"); ok {
 		_, err := client.Databases.SetEvictionPolicy(context.Background(), d.Id(), policy.(string))
 		if err != nil {
-			return diag.Errorf("Error adding eviction policy for DatabaseCluster: %s", err)
+			return diag.Errorf("Error adding eviction policy for database cluster: %s", err)
 		}
 	}
 
 	if mode, ok := d.GetOk("sql_mode"); ok {
 		_, err := client.Databases.SetSQLMode(context.Background(), d.Id(), mode.(string))
 		if err != nil {
-			return diag.Errorf("Error adding SQL mode for DatabaseCluster: %s", err)
+			return diag.Errorf("Error adding SQL mode for database cluster: %s", err)
 		}
 	}
 
@@ -305,12 +305,12 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 				return nil
 			}
 
-			return diag.Errorf("Error resizing DatabaseCluster: %s", err)
+			return diag.Errorf("Error resizing database cluster: %s", err)
 		}
 
 		_, err = waitForDatabaseCluster(client, d.Id(), "online")
 		if err != nil {
-			return diag.Errorf("Error resizing DatabaseCluster: %s", err)
+			return diag.Errorf("Error resizing database cluster: %s", err)
 		}
 	}
 
@@ -328,12 +328,12 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 				return nil
 			}
 
-			return diag.Errorf("Error migrating DatabaseCluster: %s", err)
+			return diag.Errorf("Error migrating database cluster: %s", err)
 		}
 
 		_, err = waitForDatabaseCluster(client, d.Id(), "online")
 		if err != nil {
-			return diag.Errorf("Error migrating DatabaseCluster: %s", err)
+			return diag.Errorf("Error migrating database cluster: %s", err)
 		}
 	}
 
@@ -349,7 +349,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 				return nil
 			}
 
-			return diag.Errorf("Error updating maintenance window for DatabaseCluster: %s", err)
+			return diag.Errorf("Error updating maintenance window for database cluster: %s", err)
 		}
 	}
 
@@ -357,13 +357,13 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 		if policy, ok := d.GetOk("eviction_policy"); ok {
 			_, err := client.Databases.SetEvictionPolicy(context.Background(), d.Id(), policy.(string))
 			if err != nil {
-				return diag.Errorf("Error updating eviction policy for DatabaseCluster: %s", err)
+				return diag.Errorf("Error updating eviction policy for database cluster: %s", err)
 			}
 		} else {
 			// If the eviction policy is completely removed from the config, set to noeviction
 			_, err := client.Databases.SetEvictionPolicy(context.Background(), d.Id(), godo.EvictionPolicyNoEviction)
 			if err != nil {
-				return diag.Errorf("Error updating eviction policy for DatabaseCluster: %s", err)
+				return diag.Errorf("Error updating eviction policy for database cluster: %s", err)
 			}
 		}
 	}
@@ -371,7 +371,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 	if d.HasChange("sql_mode") {
 		_, err := client.Databases.SetSQLMode(context.Background(), d.Id(), d.Get("sql_mode").(string))
 		if err != nil {
-			return diag.Errorf("Error updating SQL mode for DatabaseCluster: %s", err)
+			return diag.Errorf("Error updating SQL mode for database cluster: %s", err)
 		}
 	}
 
@@ -397,7 +397,7 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 			return nil
 		}
 
-		return diag.Errorf("Error retrieving DatabaseCluster: %s", err)
+		return diag.Errorf("Error retrieving database cluster: %s", err)
 	}
 
 	d.Set("name", database.Name)
@@ -417,7 +417,7 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 	if _, ok := d.GetOk("eviction_policy"); ok {
 		policy, _, err := client.Databases.GetEvictionPolicy(context.Background(), d.Id())
 		if err != nil {
-			return diag.Errorf("Error retrieving eviction policy for DatabaseCluster: %s", err)
+			return diag.Errorf("Error retrieving eviction policy for database cluster: %s", err)
 		}
 
 		d.Set("eviction_policy", policy)
@@ -426,7 +426,7 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 	if _, ok := d.GetOk("sql_mode"); ok {
 		mode, _, err := client.Databases.GetSQLMode(context.Background(), d.Id())
 		if err != nil {
-			return diag.Errorf("Error retrieving SQL mode for DatabaseCluster: %s", err)
+			return diag.Errorf("Error retrieving SQL mode for database cluster: %s", err)
 		}
 
 		d.Set("sql_mode", mode)
@@ -435,7 +435,7 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 	// Computed values
 	err = setDatabaseConnectionInfo(database, d)
 	if err != nil {
-		return diag.Errorf("Error setting connection info for DatabaseCluster: %s", err)
+		return diag.Errorf("Error setting connection info for database cluster: %s", err)
 	}
 	d.Set("urn", database.URN())
 	d.Set("private_network_uuid", database.PrivateNetworkUUID)
@@ -446,10 +446,10 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 func resourceDigitalOceanDatabaseClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
-	log.Printf("[INFO] Deleting DatabaseCluster: %s", d.Id())
+	log.Printf("[INFO] Deleting database cluster: %s", d.Id())
 	_, err := client.Databases.Delete(context.Background(), d.Id())
 	if err != nil {
-		return diag.Errorf("Error deleting DatabaseCluster: %s", err)
+		return diag.Errorf("Error deleting database cluster: %s", err)
 	}
 
 	d.SetId("")
@@ -465,7 +465,7 @@ func waitForDatabaseCluster(client *godo.Client, id string, status string) (*god
 		database, _, err := client.Databases.Get(context.Background(), id)
 		if err != nil {
 			ticker.Stop()
-			return nil, fmt.Errorf("Error trying to read DatabaseCluster state: %s", err)
+			return nil, fmt.Errorf("Error trying to read database cluster state: %s", err)
 		}
 
 		if database.Status == status {
@@ -481,7 +481,7 @@ func waitForDatabaseCluster(client *godo.Client, id string, status string) (*god
 		n++
 	}
 
-	return nil, fmt.Errorf("Timeout waiting to DatabaseCluster to become %s", status)
+	return nil, fmt.Errorf("Timeout waiting to database cluster to become %s", status)
 }
 
 func expandMaintWindowOpts(config []interface{}) *godo.DatabaseUpdateMaintenanceRequest {

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -87,6 +87,10 @@ func TestAccDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 						"digitalocean_database_cluster.foobar", "tags.#", "1"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "private_network_uuid"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "uri"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "private_uri"),
 				),
 			},
 		},
@@ -246,6 +250,10 @@ func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
 						"digitalocean_database_cluster.foobar", "name", databaseName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_cluster.foobar", "engine", "redis"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "uri"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "private_uri"),
 				),
 				ExpectError: regexp.MustCompile(`The argument "version" is required, but no definition was found.`),
 			},
@@ -406,10 +414,14 @@ func TestAccDigitalOceanDatabaseCluster_MongoDBPassword(t *testing.T) {
 			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigMongoDB, databaseName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
-					resource.TestCheckResourceAttrSet("digitalocean_database_cluster.foobar", "password"),
-					testAccCheckDigitalOceanDatabaseClusterURIPassword("digitalocean_database_cluster.foobar", "uri"),
-					testAccCheckDigitalOceanDatabaseClusterURIPassword("digitalocean_database_cluster.foobar", "private_uri"),
+					testAccCheckDigitalOceanDatabaseClusterExists(
+						"digitalocean_database_cluster.foobar", &database),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "password"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "uri"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword(
+						"digitalocean_database_cluster.foobar", "private_uri"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -76,6 +77,10 @@ func TestAccDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 						"digitalocean_database_cluster.foobar", "user"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "password"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "uri"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "private_uri"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "urn"),
 					resource.TestCheckResourceAttr(
@@ -389,6 +394,28 @@ func TestAccDigitalOceanDatabaseCluster_WithVPC(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseCluster_MongoDBPassword(t *testing.T) {
+	var database godo.Database
+	databaseName := randomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigMongoDB, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					resource.TestCheckResourceAttrSet("digitalocean_database_cluster.foobar", "password"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword("digitalocean_database_cluster.foobar", "uri"),
+					testAccCheckDigitalOceanDatabaseClusterURIPassword("digitalocean_database_cluster.foobar", "private_uri"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanDatabaseClusterDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 
@@ -446,6 +473,35 @@ func testAccCheckDigitalOceanDatabaseClusterExists(n string, database *godo.Data
 		*database = *foundDatabaseCluster
 
 		return nil
+	}
+}
+
+// testAccCheckDigitalOceanDatabaseClusterURIPassword checks that the password in
+// a database cluster's URI or private URI matches the password value stored in
+// its password attribute.
+func testAccCheckDigitalOceanDatabaseClusterURIPassword(name string, attributeName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		uri, ok := rs.Primary.Attributes[attributeName]
+		if !ok {
+			return fmt.Errorf("%s not set", attributeName)
+		}
+
+		u, err := url.Parse(uri)
+		if err != nil {
+			return err
+		}
+
+		password, ok := u.User.Password()
+		if !ok || password == "" {
+			return fmt.Errorf("password not set in %s: %s", attributeName, uri)
+		}
+
+		return resource.TestCheckResourceAttr(name, "password", password)(s)
 	}
 }
 
@@ -615,4 +671,14 @@ resource "digitalocean_database_cluster" "foobar" {
 	node_count           = 1
 	tags                 = ["production"]
 	private_network_uuid = digitalocean_vpc.foobar.id
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigMongoDB = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "mongodb"
+	version    = "4"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+    node_count = 1
 }`


### PR DESCRIPTION
Support for the MongoDB beta.

MongoDB clusters only return their password in response to the initial POST. This means they need to be handled differently than other database clusters:

- We need to set the password to state directly in the create function before doing any polling for status.
- As the host for the cluster is not known until it becomes available, we must save the password and then add it to the URL returned latter to build a usable connection URI.