### PR TITLE
spaces: Validate input for region.

### DIFF
--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -43,7 +43,9 @@ func (c *CombinedConfig) spacesClient(region string) (*session.Session, error) {
 	}
 
 	endpointWriter := strings.Builder{}
-	err := c.spacesEndpointTemplate.Execute(&endpointWriter, map[string]string{"Region": region})
+	err := c.spacesEndpointTemplate.Execute(&endpointWriter, map[string]string{
+		"Region": strings.ToLower(region),
+	})
 	if err != nil {
 		return &session.Session{}, err
 	}

--- a/digitalocean/datasource_digitalocean_spaces_bucket.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceDigitalOceanSpacesBucket() *schema.Resource {
@@ -19,6 +20,7 @@ func dataSourceDigitalOceanSpacesBucket() *schema.Resource {
 
 	recordSchema["region"].Required = true
 	recordSchema["region"].Computed = false
+	recordSchema["region"].ValidateFunc = validation.StringInSlice(SpacesRegions, true)
 	recordSchema["name"].Required = true
 	recordSchema["name"].Computed = false
 

--- a/digitalocean/datasource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_object.go
@@ -29,7 +29,7 @@ func dataSourceDigitalOceanSpacesBucketObject() *schema.Resource {
 			"region": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringInSlice(SpacesRegions, true),
 			},
 
 			// computed attributes

--- a/digitalocean/datasource_digitalocean_spaces_bucket_object_test.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_object_test.go
@@ -221,6 +221,25 @@ func TestAccDataSourceDigitalOceanSpacesBucketObject_MultipleSlashes(t *testing.
 	})
 }
 
+func TestAccDataSourceDigitalOceanSpacesBucketObject_RegionError(t *testing.T) {
+	badRegion := "ny2"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`data "digitalocean_spaces_bucket_object" "object" {
+										region = "%s"
+										bucket = "foo.digitaloceanspaces.com"
+										key = "test-key"
+									}`, badRegion),
+				ExpectError: regexp.MustCompile(`expected region to be one of`),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanSpacesObjectDataSourceExists(n string, obj *s3.GetObjectOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/digitalocean/datasource_digitalocean_spaces_bucket_objects.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_objects.go
@@ -26,7 +26,7 @@ func dataSourceDigitalOceanSpacesBucketObjects() *schema.Resource {
 			"region": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringInSlice(SpacesRegions, true),
 			},
 
 			"prefix": {

--- a/digitalocean/datasource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_test.go
@@ -78,3 +78,22 @@ data "digitalocean_spaces_bucket" "bucket" {
 		},
 	})
 }
+
+func TestAccDataSourceDigitalOceanSpacesBucket_RegionError(t *testing.T) {
+	badRegion := "ny2"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "digitalocean_spaces_bucket" "bucket" {
+						name   = "tf-test-bucket"
+						region = "%s"
+					}`, badRegion),
+				ExpectError: regexp.MustCompile(`expected region to be one of`),
+			},
+		},
+	})
+}

--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -40,11 +40,12 @@ func resourceDigitalOceanBucket() *schema.Resource {
 				Description: "the uniform resource name for the bucket",
 			},
 			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Bucket region",
-				Default:     "nyc3",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "Bucket region",
+				Default:      "nyc3",
+				ValidateFunc: validation.StringInSlice(SpacesRegions, true),
 				StateFunc: func(val interface{}) string {
 					// DO API V2 region slug is always lowercase
 					return strings.ToLower(val.(string))

--- a/digitalocean/resource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_object.go
@@ -33,7 +33,7 @@ func resourceDigitalOceanSpacesBucketObject() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringInSlice(SpacesRegions, true),
 			},
 
 			"bucket": {

--- a/digitalocean/resource_digitalocean_spaces_bucket_object_test.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_object_test.go
@@ -382,6 +382,25 @@ func TestAccDigitalOceanSpacesBucketObject_metadata(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanSpacesBucketObject_RegionError(t *testing.T) {
+	badRegion := "ny2"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`resource "digitalocean_spaces_bucket_object" "object" {
+										region = "%s"
+										bucket = "foo.digitaloceanspaces.com"
+										key = "test-key"
+									}`, badRegion),
+				ExpectError: regexp.MustCompile(`expected region to be one of`),
+			},
+		},
+	})
+}
+
 func testAccGetS3Conn() (*s3.S3, error) {
 	client, err := testAccProvider.Meta().(*CombinedConfig).spacesClient(testAccDigitalOceanSpacesBucketObject_TestRegion)
 	if err != nil {

--- a/digitalocean/resource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/internal/setutil"
@@ -418,6 +419,25 @@ func TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanSpacesBucket_RegionError(t *testing.T) {
+	badRegion := "ny2"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "digitalocean_spaces_bucket" "bucket" {
+						name   = "tf-test-bucket"
+						region = "%s"
+					}`, badRegion),
+				ExpectError: regexp.MustCompile(`expected region to be one of`),
 			},
 		},
 	})

--- a/digitalocean/spaces_buckets.go
+++ b/digitalocean/spaces_buckets.go
@@ -7,6 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+var (
+	// SpacesRegions is a list of DigitalOcean regions that support Spaces.
+	SpacesRegions = []string{"ams3", "fra1", "nyc3", "sfo2", "sfo3", "sgp1"}
+)
+
 type bucketMetadataStruct struct {
 	name   string
 	region string
@@ -53,14 +58,9 @@ func getSpacesBucketsInRegion(meta interface{}, region string) ([]*s3.Bucket, er
 func getDigitalOceanBuckets(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	// The DigitalOcean API does not currently return what regions have Spaces available. Thus, this
 	// function hard-codes the regions in which Spaces operates.
-	//
-	// This list is current as of April 20, 2020 and is from:
-	// https://www.digitalocean.com/docs/platform/availability-matrix/#other-product-availability
-	spacesRegions := []string{"ams3", "fra1", "nyc3", "sfo2", "sgp1"}
-
 	var buckets []interface{}
 
-	for _, region := range spacesRegions {
+	for _, region := range SpacesRegions {
 		bucketsInRegion, err := getSpacesBucketsInRegion(meta, region)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Do some input validation on the region for Spaces operations as the `no such host` error message is not helpful. The new error would be:

```
Error: expected region to be one of [nyc3 sfo2 sfo3 ams3 sgp1 fra1], got ny2

  on main.tf line 21, in resource "digitalocean_spaces_bucket" "i-dont-exist":
  21:   region = "ny2"
```

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/617