### PR TITLE
Use hashicorp/ghaction-import-gpg in release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
HashiCorp forked the action we are using to import our GPG key to sign releases. This moves to it so that it is controlled by a trusted organization, not an individual.

Context: https://github.com/hashicorp/terraform-provider-scaffolding/issues/22