### PR TITLE
Updating Provider Doc for Dummies like me

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,84 @@ resource "digitalocean_droplet" "web" {
 }
 ```
 
+## Module Example
+
+The provider is also not maintained by hashicorp, so you will need to explicitly define the required provider in every module so that terraform knows where to find the provider and version. Provider Inheritance does not work with Digital Ocean like it does for hashicorp maintained providers like AWS, Azure, and GCP.
+
+Albeit against DRY programming principles, you will need to repeat this block at the top of _each of your modules_ because the inheritance from the parent terraform file that calls the module will not trickle down properly.
+
+```hcl
+#Set the required providers block to define the proper routing to digitalocean.
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = ">= 2.8.0"
+    }
+  }
+}
+#Just like in the example above, pass your `DIGITALOCEAN_TOKEN` to the module
+provider "digitalocean" {
+  token = var.do_token
+}
+```
+
+For Example, if you had a tree of modules, you would need to include this provider code in the main.tf of each module. `Dedicated-Server`, `Network`, and `Security-Groups`
+```
+├── main.tf
+├── modules
+│   ├── dedicated-server
+│   │   ├── main.tf
+│   │   ├── output.tf
+│   │   └── vars.tf
+│   ├── network
+│   │   ├── main.tf
+│   │   ├── output.tf
+│   │   └── vars.tf
+│   ├── security-groups
+│   │   ├── main.tf
+│   │   ├── output.tf
+│   │   └── vars.tf
+```
+
+For the Network Module, we call it in main.tf like so:
+
+```hcl
+# BUILD NETWORK
+module "network" {
+    source  = "./modules/network"
+    vpcname = "examplevpc"
+    ip_range = "10.10.10.0/24"
+    region  = var.region
+    token   = var.token
+}
+```
+
+Passing the parameters to the module, but making sure we explicitly define the provider again so the module knows where to look for the resource since it defaults to looking into hashicorp maintained providers.
+
+```hcl
+#NETWORK MODULE: main.tf
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = ">= 2.8.0"
+    }
+  }
+}
+provider "digitalocean" {
+  token = var.token
+}
+
+#RANGE 10.10.10.x VPC NETWORK
+resource "digitalocean_vpc" "examplevpc" {
+  name     = var.vpcname
+  region   = var.region
+  ip_range = var.ip_range
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
Updated the Docs/Index.md file to add detail about utilizing digitalocean provider for dummies like me who came from AWS, Azure, and GCP. 

I added a module example with a more explicit declaration for the digital ocean provider.

Thank you @tdyas and @andrewsomething for helping me understand this in more depth. I've taken for granted hashicorp maintained providers in the past and appreciate you both clearing this up for me. 