### PR TITLE
Make create timeouts configurable for DBaaS and K8s clusters.

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -467,9 +467,9 @@ func waitForDatabaseCluster(client *godo.Client, d *schema.ResourceData, status 
 		timeoutSeconds = d.Timeout(schema.TimeoutDelete).Seconds()
 		timeout        = int(timeoutSeconds / tickerInterval.Seconds())
 		n              = 0
+		ticker         = time.NewTicker(tickerInterval)
 	)
 
-	ticker := time.NewTicker(tickerInterval)
 	for range ticker.C {
 		database, _, err := client.Databases.Get(context.Background(), d.Id())
 		if err != nil {

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -171,6 +171,10 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 			"tags": tagsSchema(),
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		CustomizeDiff: customdiff.All(
 			transitionVersionToRequired(),
 			validateExclusiveAttributes(),
@@ -246,13 +250,14 @@ func resourceDigitalOceanDatabaseClusterCreate(ctx context.Context, d *schema.Re
 		}
 	}
 
-	database, err = waitForDatabaseCluster(client, database.ID, "online")
-	if err != nil {
-		return diag.Errorf("Error creating database cluster: %s", err)
-	}
-
 	d.SetId(database.ID)
 	log.Printf("[INFO] database cluster Name: %s", database.Name)
+
+	database, err = waitForDatabaseCluster(client, d, "online")
+	if err != nil {
+		d.SetId("")
+		return diag.Errorf("Error creating database cluster: %s", err)
+	}
 
 	if v, ok := d.GetOk("maintenance_window"); ok {
 		opts := expandMaintWindowOpts(v.([]interface{}))
@@ -308,7 +313,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 			return diag.Errorf("Error resizing database cluster: %s", err)
 		}
 
-		_, err = waitForDatabaseCluster(client, d.Id(), "online")
+		_, err = waitForDatabaseCluster(client, d, "online")
 		if err != nil {
 			return diag.Errorf("Error resizing database cluster: %s", err)
 		}
@@ -331,7 +336,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 			return diag.Errorf("Error migrating database cluster: %s", err)
 		}
 
-		_, err = waitForDatabaseCluster(client, d.Id(), "online")
+		_, err = waitForDatabaseCluster(client, d, "online")
 		if err != nil {
 			return diag.Errorf("Error migrating database cluster: %s", err)
 		}
@@ -456,13 +461,17 @@ func resourceDigitalOceanDatabaseClusterDelete(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func waitForDatabaseCluster(client *godo.Client, id string, status string) (*godo.Database, error) {
-	ticker := time.NewTicker(15 * time.Second)
-	timeout := 120
-	n := 0
+func waitForDatabaseCluster(client *godo.Client, d *schema.ResourceData, status string) (*godo.Database, error) {
+	var (
+		tickerInterval = 15 * time.Second
+		timeoutSeconds = d.Timeout(schema.TimeoutDelete).Seconds()
+		timeout        = int(timeoutSeconds / tickerInterval.Seconds())
+		n              = 0
+	)
 
+	ticker := time.NewTicker(tickerInterval)
 	for range ticker.C {
-		database, _, err := client.Databases.Get(context.Background(), id)
+		database, _, err := client.Databases.Get(context.Background(), d.Id())
 		if err != nil {
 			ticker.Stop()
 			return nil, fmt.Errorf("Error trying to read database cluster state: %s", err)

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -556,12 +556,12 @@ func resourceDigitalOceanKubernetesClusterImportState(d *schema.ResourceData, me
 func waitForKubernetesClusterCreate(client *godo.Client, d *schema.ResourceData) (*godo.KubernetesCluster, error) {
 	var (
 		tickerInterval = 10 * time.Second
-		timeoutSeconds = d.Timeout(schema.TimeoutDelete).Seconds()
+		timeoutSeconds = d.Timeout(schema.TimeoutCreate).Seconds()
 		timeout        = int(timeoutSeconds / tickerInterval.Seconds())
 		n              = 0
+		ticker         = time.NewTicker(tickerInterval)
 	)
 
-	ticker := time.NewTicker(tickerInterval)
 	for range ticker.C {
 		cluster, _, err := client.Kubernetes.Get(context.Background(), d.Id())
 		if err != nil {

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -112,7 +112,8 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "vpc_uuid"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "auto_upgrade"),
 					resource.TestMatchResourceAttr("digitalocean_kubernetes_cluster.foobar", "urn", expectedURNRegEx),
-					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "maintenance_policy"),
+					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.day"),
+					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.start_time"),
 				),
 			},
 			// Update: remove default node_pool taints


### PR DESCRIPTION
DBaaS and K8s clusters can take awhile to come online. This PR makes the timeouts for them user configurable. It also bumps up the default K8s create timeout to 30 minutes.

Fixes: #329