### PR TITLE
dbaas: Protect against setting empty tags.

### DIFF
--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -168,7 +168,7 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 			d.Set("size", db.SizeSlug)
 			d.Set("region", db.RegionSlug)
 			d.Set("node_count", db.NumNodes)
-			d.Set("tags", db.Tags)
+			d.Set("tags", flattenTags(db.Tags))
 
 			if _, ok := d.GetOk("maintenance_window"); ok {
 				if err := d.Set("maintenance_window", flattenMaintWindowOpts(*db.MaintenanceWindow)); err != nil {

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -411,7 +411,7 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 	d.Set("size", database.SizeSlug)
 	d.Set("region", database.RegionSlug)
 	d.Set("node_count", database.NumNodes)
-	d.Set("tags", database.Tags)
+	d.Set("tags", flattenTags(database.Tags))
 
 	if _, ok := d.GetOk("maintenance_window"); ok {
 		if err := d.Set("maintenance_window", flattenMaintWindowOpts(*database.MaintenanceWindow)); err != nil {

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -691,6 +691,6 @@ resource "digitalocean_database_cluster" "foobar" {
 	engine     = "mongodb"
 	version    = "4"
 	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
+	region     = "nyc3"
     node_count = 1
 }`

--- a/digitalocean/resource_digitalocean_database_replica.go
+++ b/digitalocean/resource_digitalocean_database_replica.go
@@ -163,7 +163,7 @@ func resourceDigitalOceanDatabaseReplicaRead(ctx context.Context, d *schema.Reso
 	}
 
 	d.Set("region", replica.Region)
-	d.Set("tags", replica.Tags)
+	d.Set("tags", flattenTags(replica.Tags))
 
 	// Computed values
 	d.Set("host", replica.Connection.Host)

--- a/digitalocean/tags.go
+++ b/digitalocean/tags.go
@@ -128,7 +128,9 @@ func flattenTags(tags []string) *schema.Set {
 
 	flattenedTags := schema.NewSet(HashStringIgnoreCase, []interface{}{})
 	for _, v := range tags {
-		flattenedTags.Add(v)
+		if v != "" {
+			flattenedTags.Add(v)
+		}
 	}
 
 	return flattenedTags


### PR DESCRIPTION
There seems to have been a change in the DBaaS API. It is now returning:

```
  "tags": [
   ""
  ]
```

in the response body for MongoDB clusters without any tags applied. This is wrong, but we should still protect against this here. Without doing so, we end up with a diff and a failing acceptance test:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_MongoDBPassword'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_MongoDBPassword -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_MongoDBPassword
=== PAUSE TestAccDigitalOceanDatabaseCluster_MongoDBPassword
=== CONT  TestAccDigitalOceanDatabaseCluster_MongoDBPassword
    resource_digitalocean_database_cluster_test.go:409: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # digitalocean_database_cluster.foobar will be updated in-place
          ~ resource "digitalocean_database_cluster" "foobar" {
                id           = "1f706e9a-ada4-434c-9058-b7086a2a79e4"
                name         = "tf-acc-test-xda03f78tl"
              ~ tags         = [
                  - "",
                ]
                # (14 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
    testing_new.go:63: Error running post-test destroy, there may be dangling resources: DatabaseCluster still exists
--- FAIL: TestAccDigitalOceanDatabaseCluster_MongoDBPassword (385.09s)
```

These changes applied resolve that problem.