### PR TITLE
Simplified some loops based on go-staticcheck S1011

### DIFF
--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -138,9 +138,7 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 			return diag.Errorf("Error retrieving DatabaseClusters: %s", err)
 		}
 
-		for _, d := range databases {
-			databaseList = append(databaseList, d)
-		}
+		databaseList = append(databaseList, databases...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/datasource_digitalocean_droplet_snapshot.go
+++ b/digitalocean/datasource_digitalocean_droplet_snapshot.go
@@ -92,9 +92,7 @@ func dataSourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.Re
 			return diag.Errorf("Error retrieving Droplet snapshots: %s", err)
 		}
 
-		for _, s := range snapshots {
-			snapshotList = append(snapshotList, s)
-		}
+		snapshotList = append(snapshotList, snapshots...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -220,9 +220,7 @@ func dataSourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resou
 			return diag.Errorf("Error retrieving load balancers: %s", err)
 		}
 
-		for _, lb := range lbs {
-			lbList = append(lbList, lb)
-		}
+		lbList = append(lbList, lbs...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/datasource_digitalocean_tags.go
+++ b/digitalocean/datasource_digitalocean_tags.go
@@ -58,9 +58,7 @@ func getDigitalOceanTags(meta interface{}, extra map[string]interface{}) ([]inte
 			return nil, fmt.Errorf("Error retrieving tags: %s", err)
 		}
 
-		for _, tag := range tags {
-			tagsList = append(tagsList, tag)
-		}
+		tagsList = append(tagsList, tags)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/datasource_digitalocean_volume.go
+++ b/digitalocean/datasource_digitalocean_volume.go
@@ -95,9 +95,7 @@ func dataSourceDigitalOceanVolumeRead(ctx context.Context, d *schema.ResourceDat
 			return diag.Errorf("Error retrieving volumes: %s", err)
 		}
 
-		for _, volume := range volumes {
-			volumeList = append(volumeList, volume)
-		}
+		volumeList = append(volumeList, volumes...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/datasource_digitalocean_volume_snapshot.go
+++ b/digitalocean/datasource_digitalocean_volume_snapshot.go
@@ -96,9 +96,7 @@ func dataSourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Res
 			return diag.Errorf("Error retrieving volume snapshots: %s", err)
 		}
 
-		for _, s := range snapshots {
-			snapshotList = append(snapshotList, s)
-		}
+		snapshotList = append(snapshotList, snapshots...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/datasource_digitalocean_vpc.go
+++ b/digitalocean/datasource_digitalocean_vpc.go
@@ -122,9 +122,7 @@ func listVPCs(client *godo.Client) ([]*godo.VPC, error) {
 			return vpcList, fmt.Errorf("Error retrieving VPCs: %s", err)
 		}
 
-		for _, v := range vpcs {
-			vpcList = append(vpcList, v)
-		}
+		vpcList = append(vpcList, vpcs...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break

--- a/digitalocean/kubernetes.go
+++ b/digitalocean/kubernetes.go
@@ -182,20 +182,16 @@ func nodeSchema() *schema.Schema {
 
 func expandLabels(labels map[string]interface{}) map[string]string {
 	expandedLabels := make(map[string]string)
-	if labels != nil {
-		for key, value := range labels {
-			expandedLabels[key] = value.(string)
-		}
+	for key, value := range labels {
+		expandedLabels[key] = value.(string)
 	}
 	return expandedLabels
 }
 
 func flattenLabels(labels map[string]string) map[string]interface{} {
 	flattenedLabels := make(map[string]interface{})
-	if labels != nil {
-		for key, value := range labels {
-			flattenedLabels[key] = value
-		}
+	for key, value := range labels {
+		flattenedLabels[key] = value
 	}
 	return flattenedLabels
 }

--- a/digitalocean/loadbalancer.go
+++ b/digitalocean/loadbalancer.go
@@ -190,30 +190,28 @@ func flattenStickySessions(session *godo.StickySessions) []map[string]interface{
 func flattenForwardingRules(client *godo.Client, rules []godo.ForwardingRule) ([]map[string]interface{}, error) {
 	result := make([]map[string]interface{}, 0, 1)
 
-	if rules != nil {
-		for _, rule := range rules {
-			r := make(map[string]interface{})
+	for _, rule := range rules {
+		r := make(map[string]interface{})
 
-			r["entry_protocol"] = rule.EntryProtocol
-			r["entry_port"] = rule.EntryPort
-			r["target_protocol"] = rule.TargetProtocol
-			r["target_port"] = rule.TargetPort
-			r["tls_passthrough"] = rule.TlsPassthrough
+		r["entry_protocol"] = rule.EntryProtocol
+		r["entry_port"] = rule.EntryPort
+		r["target_protocol"] = rule.TargetProtocol
+		r["target_port"] = rule.TargetPort
+		r["tls_passthrough"] = rule.TlsPassthrough
 
-			if rule.CertificateID != "" {
-				// When the certificate type is lets_encrypt, the certificate
-				// ID will change when it's renewed, so we have to rely on the
-				// certificate name as the primary identifier instead.
-				cert, _, err := client.Certificates.Get(context.Background(), rule.CertificateID)
-				if err != nil {
-					return nil, err
-				}
-				r["certificate_id"] = cert.Name
-				r["certificate_name"] = cert.Name
+		if rule.CertificateID != "" {
+			// When the certificate type is lets_encrypt, the certificate
+			// ID will change when it's renewed, so we have to rely on the
+			// certificate name as the primary identifier instead.
+			cert, _, err := client.Certificates.Get(context.Background(), rule.CertificateID)
+			if err != nil {
+				return nil, err
 			}
-
-			result = append(result, r)
+			r["certificate_id"] = cert.Name
+			r["certificate_name"] = cert.Name
 		}
+
+		result = append(result, r)
 	}
 
 	return result, nil

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -309,9 +309,7 @@ func loadResourceURNs(client *godo.Client, projectId string) (*[]string, error) 
 			return nil, fmt.Errorf("Error loading project resources: %s", err)
 		}
 
-		for _, r := range resources {
-			resourceList = append(resourceList, r)
-		}
+		resourceList = append(resourceList, resources...)
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break


### PR DESCRIPTION
More details about the pattern are given in https://staticcheck.io/docs/checks#S1011

I found the matches with `staticcheck . | grep S1011` inside the digitalocean directory.

**Edit**: Same with S1031.