### PR TITLE
add option to override user_data

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -157,6 +157,13 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				},
 			},
 
+			"force_override_userdata": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
 			"user_data": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -165,6 +172,9 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				StateFunc:    HashStringStateFunc(),
 				// In order to support older statefiles with fully saved user data
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("force_override_userdata").(bool) {
+						return true
+					}
 					return new != "" && old == d.Get("user_data")
 				},
 			},


### PR DESCRIPTION
This is a proposal to solve #659: an issue that resulted in `Error: Provider produced inconsistent final plan` if a droplets `user_data` is altered between plan and apply phase of terraform.

This PR introduces an additional boolean field `force_override_userdata` which enforces the new user_data value.

More description can be found in #659.

If there is a decision that the proposed solution is good to go, I will add additional tests and docs.