### PR TITLE
record: Move validation by type out of CustomizeDiff.

### DIFF
--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -125,14 +125,10 @@ func resourceDigitalOceanRecord() *schema.Resource {
 				}
 			}
 
-			_, hasPort := diff.GetOkExists("port")
 			_, hasWeight := diff.GetOkExists("weight")
 			if recordType == "SRV" {
 				if !hasPriority {
 					return fmt.Errorf("`priority` is required for when type is `SRV`")
-				}
-				if !hasPort {
-					return fmt.Errorf("`port` is required for when type is `SRV`")
 				}
 				if !hasWeight {
 					return fmt.Errorf("`weight` is required for when type is `SRV`")
@@ -164,6 +160,11 @@ func resourceDigitalOceanRecordCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	newRecord.Type = d.Get("type").(string)
+
+	_, hasPort := d.GetOkExists("port")
+	if newRecord.Type == "SRV" && !hasPort {
+		return diag.Errorf("`port` is required for when type is `SRV`")
+	}
 
 	log.Printf("[DEBUG] record create configuration: %#v", newRecord)
 	rec, _, err := client.Domains.CreateRecord(context.Background(), d.Get("domain").(string), newRecord)


### PR DESCRIPTION
Fixes: #670 

We're doing validation inside of a `CustomizeDiff` function. The interpolated values are not available there on plan. This prevents user from doing things like referencing a database cluster's port in a SRV record. This is similar to hashicorp/terraform-provider-consul#260 This PR moves that validation to later in the process.

This has one side effect. The reason for using a `CustomizeDiff` for something like this is that it allows you to error out early before any of the plan runs. Now the error will not happen until the record is being created. I don't love that, but not sure I see a better way to do it.