### PR TITLE
Fix unexpected diffs for when TXT records are for the apex domain

### DIFF
--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -313,6 +313,10 @@ func expandDigitalOceanRecordResource(d *schema.ResourceData) (*godo.DomainRecor
 }
 
 func constructFqdn(name, domain string) string {
+	if name == "@" {
+		return domain
+	}
+
 	rn := strings.ToLower(name)
 	domainSuffix := domain + "."
 	if strings.HasSuffix(rn, domainSuffix) {

--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -54,7 +54,7 @@ func resourceDigitalOceanRecord() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					domain := d.Get("domain").(string) + "."
 
-					return old+"."+domain == new
+					return (old == "@" && new == domain) || (old+"."+domain == new)
 				},
 			},
 

--- a/digitalocean/resource_digitalocean_record_test.go
+++ b/digitalocean/resource_digitalocean_record_test.go
@@ -557,6 +557,31 @@ func TestAccDigitalOceanRecord_iodefCAA(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanRecord_TXT(t *testing.T) {
+	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanRecordTXT, domain, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanRecordExists("digitalocean_record.txt", &record),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.txt", "type", "TXT"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.txt", "domain", domain),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.txt", "value", "v=spf1 a:smtp01.example.com a:mail.example.com -all"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 
@@ -857,4 +882,15 @@ resource "digitalocean_record" "CAA_iodef" {
   flags = "0"
   name  = "@"
   value = "mailto:caa-failures@example.com"
+}`
+
+const testAccCheckDigitalOceanRecordTXT = `
+resource "digitalocean_domain" "foobar" {
+  name       = "%s"
+}
+resource "digitalocean_record" "txt" {
+  domain = digitalocean_domain.foobar.name
+  type  = "TXT"
+  name  = "%s."
+  value = "v=spf1 a:smtp01.example.com a:mail.example.com -all"
 }`

--- a/digitalocean/resource_digitalocean_record_test.go
+++ b/digitalocean/resource_digitalocean_record_test.go
@@ -24,6 +24,7 @@ func TestDigitalOceanRecordConstructFqdn(t *testing.T) {
 		{"nonexample.com", "nonexample.com.nonexample.com"},
 		{"test.nonexample.com", "test.nonexample.com.nonexample.com"},
 		{"test.nonexample.com.", "test.nonexample.com"},
+		{"@", "nonexample.com"},
 	}
 
 	domain := "nonexample.com"
@@ -576,6 +577,8 @@ func TestAccDigitalOceanRecord_TXT(t *testing.T) {
 						"digitalocean_record.txt", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.txt", "value", "v=spf1 a:smtp01.example.com a:mail.example.com -all"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.txt", "fqdn", domain),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes: #664 

`@` is synonymous with for the current domain. There are some places in the API where the full value may be supplied but `@` is returned. We need to compensate for that using a `DiffSuppressFunc`. We have something similar in place for the `value` attribute, but for some record types this behavior can be with the  `name` attribute as well. 

https://github.com/digitalocean/terraform-provider-digitalocean/blob/4fdccb665316809b4e797bd263b019142ac1af85/digitalocean/resource_digitalocean_record.go#L89-L93

This also required a change to the `constructFqdn` function to prevent output like `@.example.com`