### PR TITLE
Add Kubernetes example cluster naming and test_url output

### DIFF
--- a/examples/kubernetes/doks-cluster/main.tf
+++ b/examples/kubernetes/doks-cluster/main.tf
@@ -26,4 +26,11 @@ resource "digitalocean_kubernetes_cluster" "primary" {
     size       = var.worker_size
     node_count = var.worker_count
   }
+
+  # Ignore the tags/labels added by DigitalOcean
+  lifecycle {
+    ignore_changes = [
+      tags, node_pool["labels"], node_pool["tags"]
+    ]
+  }
 }

--- a/examples/kubernetes/doks-cluster/outputs.tf
+++ b/examples/kubernetes/doks-cluster/outputs.tf
@@ -1,7 +1,10 @@
-output "cluster_id" {
-  value = digitalocean_kubernetes_cluster.primary.id
-}
-
-output "cluster_name" {
-  value = digitalocean_kubernetes_cluster.primary.name
+output "primary_cluster" {
+  value = {
+    id                     = digitalocean_kubernetes_cluster.primary.id
+    name                   = digitalocean_kubernetes_cluster.primary.name
+    endpoint               = digitalocean_kubernetes_cluster.primary.endpoint
+    token                  = digitalocean_kubernetes_cluster.primary.kube_config[0].token
+    cluster_ca_certificate = digitalocean_kubernetes_cluster.primary.kube_config[0].cluster_ca_certificate
+    raw_config             = digitalocean_kubernetes_cluster.primary.kube_config[0].raw_config
+  }
 }

--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -105,6 +105,9 @@ resource "helm_release" "nginx_ingress" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "nginx-ingress-controller"
 
+  # Helm chart deployment can sometimes take longer than the default 5 minutes
+  timeout    = var.nginx_ingress_helm_timeout_seconds
+
   # Try to allow time for external endpoints to be applied to service
   wait_for_jobs = true
 

--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -109,6 +109,14 @@ resource "helm_release" "nginx_ingress" {
     name  = "service.type"
     value = "LoadBalancer"
   }
+  set {
+    name  = "service.annotations.service\\.beta\\.kubernetes\\.io/do-loadbalancer-name"
+    value = var.primary_cluster.name
+  }
+  set {
+    name  = "service.annotations.service\\.beta\\.kubernetes\\.io/do-loadbalancer-size-slug"
+    value = "lb-small"
+  }
 }
 
 resource "kubernetes_ingress" "test_ingress" {

--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -15,32 +15,24 @@ terraform {
   }
 }
 
-data "digitalocean_kubernetes_cluster" "primary" {
-  name = var.cluster_name
-}
-
 resource "local_file" "kubeconfig" {
-  depends_on = [var.cluster_id]
+  depends_on = [var.primary_cluster]
   count      = var.write_kubeconfig ? 1 : 0
-  content    = data.digitalocean_kubernetes_cluster.primary.kube_config[0].raw_config
+  content    = var.primary_cluster.raw_config
   filename   = "${path.root}/kubeconfig"
 }
 
 provider "kubernetes" {
-  host             = data.digitalocean_kubernetes_cluster.primary.endpoint
-  token            = data.digitalocean_kubernetes_cluster.primary.kube_config[0].token
-  cluster_ca_certificate = base64decode(
-    data.digitalocean_kubernetes_cluster.primary.kube_config[0].cluster_ca_certificate
-  )
+  host                   = var.primary_cluster.endpoint
+  token                  = var.primary_cluster.token
+  cluster_ca_certificate = base64decode(var.primary_cluster.cluster_ca_certificate)
 }
 
 provider "helm" {
   kubernetes {
-    host  = data.digitalocean_kubernetes_cluster.primary.endpoint
-    token = data.digitalocean_kubernetes_cluster.primary.kube_config[0].token
-    cluster_ca_certificate = base64decode(
-      data.digitalocean_kubernetes_cluster.primary.kube_config[0].cluster_ca_certificate
-    )
+    host                   = var.primary_cluster.endpoint
+    token                  = var.primary_cluster.token
+    cluster_ca_certificate = base64decode(var.primary_cluster.cluster_ca_certificate)
   }
 }
 

--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -105,6 +105,9 @@ resource "helm_release" "nginx_ingress" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "nginx-ingress-controller"
 
+  # Try to allow time for external endpoints to be applied to service
+  wait_for_jobs = true
+
   set {
     name  = "service.type"
     value = "LoadBalancer"
@@ -143,5 +146,15 @@ resource "kubernetes_ingress" "test_ingress" {
         }
       }
     }
+  }
+}
+
+data "kubernetes_service" "nginx-ingress-controller" {  
+  depends_on = [
+    helm_release.nginx_ingress
+  ]
+  metadata {
+    name      = "nginx-ingress-controller"
+    namespace = kubernetes_namespace.test.metadata.0.name
   }
 }

--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -108,9 +108,6 @@ resource "helm_release" "nginx_ingress" {
   # Helm chart deployment can sometimes take longer than the default 5 minutes
   timeout    = var.nginx_ingress_helm_timeout_seconds
 
-  # Try to allow time for external endpoints to be applied to service
-  wait_for_jobs = true
-
   set {
     name  = "service.type"
     value = "LoadBalancer"

--- a/examples/kubernetes/kubernetes-config/outputs.tf
+++ b/examples/kubernetes/kubernetes-config/outputs.tf
@@ -1,3 +1,3 @@
-output "test_url" {
-  value = "http://${data.kubernetes_service.nginx-ingress-controller.status.0.load_balancer.0.ingress.0.ip}/test"
+output "load_balancer_ip" {
+  value = one(data.kubernetes_service.nginx-ingress-controller.status.0.load_balancer.0.ingress[*].ip)
 }

--- a/examples/kubernetes/kubernetes-config/outputs.tf
+++ b/examples/kubernetes/kubernetes-config/outputs.tf
@@ -1,0 +1,3 @@
+output "test_url" {
+  value = "http://${data.kubernetes_service.nginx-ingress-controller.status.0.load_balancer.0.ingress.0.ip}/test"
+}

--- a/examples/kubernetes/kubernetes-config/variables.tf
+++ b/examples/kubernetes/kubernetes-config/variables.tf
@@ -9,8 +9,9 @@ variable "primary_cluster" {
   })
 }
 
-variable "cluster_id" {
-  type = string
+# Helm chart deployment can sometimes take longer than the default 5 minutes
+variable "nginx_ingress_helm_timeout_seconds" {
+  default     = 600
 }
 
 variable "write_kubeconfig" {

--- a/examples/kubernetes/kubernetes-config/variables.tf
+++ b/examples/kubernetes/kubernetes-config/variables.tf
@@ -1,5 +1,12 @@
-variable "cluster_name" {
-  type = string
+variable "primary_cluster" {
+  type = object({
+    id                     = string
+    name                   = string
+    endpoint               = string
+    token                  = string
+    cluster_ca_certificate = string
+    raw_config             = string
+  })
 }
 
 variable "cluster_id" {

--- a/examples/kubernetes/main.tf
+++ b/examples/kubernetes/main.tf
@@ -15,18 +15,14 @@ terraform {
   }
 }
 
-resource "random_id" "cluster_name" {
-  byte_length = 5
-}
-
 locals {
-  cluster_name = "tf-k8s-${random_id.cluster_name.hex}"
+  cluster_name = "${var.cluster_name}-${var.cluster_region}"
 }
 
 module "doks-cluster" {
   source             = "./doks-cluster"
   cluster_name       = local.cluster_name
-  cluster_region     = "nyc3"
+  cluster_region     = var.cluster_region
   cluster_version    = var.cluster_version
 
   worker_size        = var.worker_size
@@ -35,8 +31,7 @@ module "doks-cluster" {
 
 module "kubernetes-config" {
   source           = "./kubernetes-config"
-  cluster_name     = module.doks-cluster.cluster_name
-  cluster_id       = module.doks-cluster.cluster_id
+  primary_cluster  = module.doks-cluster.primary_cluster
 
   write_kubeconfig = var.write_kubeconfig
 }

--- a/examples/kubernetes/outputs.tf
+++ b/examples/kubernetes/outputs.tf
@@ -5,3 +5,7 @@ output "cluster_name" {
 output "kubeconfig_path" {
   value = var.write_kubeconfig ? abspath("${path.root}/kubeconfig") : "none"
 }
+
+output "test_url" {
+  value = module.kubernetes-config.test_url
+}

--- a/examples/kubernetes/outputs.tf
+++ b/examples/kubernetes/outputs.tf
@@ -6,6 +6,10 @@ output "kubeconfig_path" {
   value = var.write_kubeconfig ? abspath("${path.root}/kubeconfig") : "none"
 }
 
+output "test_url_status" {
+  value = module.kubernetes-config.load_balancer_ip != null ? "available" : "pending load balancer IP address assignment"
+}
+
 output "test_url" {
-  value = module.kubernetes-config.test_url
+  value = module.kubernetes-config.load_balancer_ip != null ? "http://${module.kubernetes-config.load_balancer_ip}/test" : null
 }

--- a/examples/kubernetes/outputs.tf
+++ b/examples/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "cluster_name" {
-  value = module.doks-cluster.cluster_name
+  value = module.doks-cluster.primary_cluster.name
 }
 
 output "kubeconfig_path" {

--- a/examples/kubernetes/variables.tf
+++ b/examples/kubernetes/variables.tf
@@ -1,3 +1,10 @@
+variable "cluster_name" {
+  default = "test-cluster"
+}
+
+variable "cluster_region" {
+  default = "nyc3"
+}
 
 variable "cluster_version" {
   default = "1.19"


### PR DESCRIPTION
- Fixes cluster naming by replacing data dependency with an injected variable (fixes #693)
- Gives a name to load balancer, otherwise it is random (resolves #691)
- Output test_url to easily click and check that the example has worked (resolves #692)
- Add increased timeout for the NGINX ingress Helm chart (fixes #694)