### PR TITLE
database user: Handle passwords for MongoDB.

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -100,7 +100,7 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								newSplit := strings.Split(new, ":")
 								if len(newSplit) == 3 {
-									newTrimed := strings.Join([]string{newSplit[0], newSplit[1]}, ":")
+									newTrimed := strings.Join(newSplit[:2], ":")
 									return newTrimed == old
 								}
 								return old == new

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -96,6 +96,15 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 						"hour": {
 							Type:     schema.TypeString,
 							Required: true,
+							// Prevent a diff when seconds in response, e.g: "13:00" -> "13:00:00"
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								newSplit := strings.Split(new, ":")
+								if len(newSplit) == 3 {
+									newTrimed := strings.Join([]string{newSplit[0], newSplit[1]}, ":")
+									return newTrimed == old
+								}
+								return old == new
+							},
 						},
 					},
 				},

--- a/digitalocean/resource_digitalocean_database_user.go
+++ b/digitalocean/resource_digitalocean_database_user.go
@@ -85,6 +85,10 @@ func resourceDigitalOceanDatabaseUserCreate(ctx context.Context, d *schema.Resou
 	d.SetId(makeDatabaseUserID(clusterID, user.Name))
 	log.Printf("[INFO] Database User Name: %s", user.Name)
 
+	// MongoDB clusters only return the password in response to the initial POST.
+	// So we need to set it here before any subsequent GETs.
+	d.Set("password", user.Password)
+
 	return resourceDigitalOceanDatabaseUserRead(ctx, d, meta)
 }
 
@@ -107,7 +111,11 @@ func resourceDigitalOceanDatabaseUserRead(ctx context.Context, d *schema.Resourc
 	}
 
 	d.Set("role", user.Role)
-	d.Set("password", user.Password)
+	// This will be blank for MongoDB clusters. Don't overwrite the password set on create.
+	if user.Password != "" {
+		d.Set("password", user.Password)
+	}
+
 	if user.MySQLSettings != nil {
 		d.Set("mysql_auth_plugin", user.MySQLSettings.AuthPlugin)
 	}


### PR DESCRIPTION
MongoDB clusters only return the password in response to the initial POST. We handle this in the database resource for the default user, but it looks like we missed it for new users created in with the database user resource.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/696

I was also seeing an expected diff preventing the tests from passing  when seconds were being included in response for database maintenance windows, e.g: "13:00" -> "13:00:00". I've added a DiffSuppressFunc to handle this case. 