### PR TITLE
Add increased timeout for the NGINX ingress Helm chart

### DIFF
--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -113,6 +113,9 @@ resource "helm_release" "nginx_ingress" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "nginx-ingress-controller"
 
+  # Helm chart deployment can sometimes take longer than the default 5 minutes
+  timeout    = var.nginx_ingress_helm_timeout_seconds
+
   set {
     name  = "service.type"
     value = "LoadBalancer"

--- a/examples/kubernetes/kubernetes-config/variables.tf
+++ b/examples/kubernetes/kubernetes-config/variables.tf
@@ -10,3 +10,9 @@ variable "write_kubeconfig" {
   type        = bool
   default     = false
 }
+
+# Helm chart deployment can sometimes take longer than the default 5 minutes
+variable "nginx_ingress_helm_timeout_seconds" {
+  type        = number
+  default     = 600
+}


### PR DESCRIPTION
- Sometimes the Helm chart takes longer than default 5 min timeout, resolves #694