### PR TITLE
docs: Fix typo in digitalocean monitoring

### DIFF
--- a/docs/resources/monitor_alert.md
+++ b/docs/resources/monitor_alert.md
@@ -19,7 +19,7 @@ resource "digitalocean_droplet" "web" {
   size   = "s-1vcpu-1gb"
 }
 
-resource "digitalocean_monitoring" "cpu_alert" {
+resource "digitalocean_monitor_alert" "cpu_alert" {
   alerts {
     email = ["benny@digitalocean.com"]
     slack {

--- a/docs/resources/monitor_alert.md
+++ b/docs/resources/monitor_alert.md
@@ -2,7 +2,7 @@
 page_title: "DigitalOcean: digital_monitor_alert"
 ---
 
-# digitalocean_monitor
+# digitalocean_monitor_alert
 
 Provides a [DigitalOcean Monitoring](https://docs.digitalocean.com/reference/api/api-reference/#tag/Monitoring) resource.
 Monitor alerts can be configured to alert about, e.g., disk or memory usage exceeding certain threshold, or traffic at certain

--- a/docs/resources/monitor_alert.md
+++ b/docs/resources/monitor_alert.md
@@ -1,5 +1,5 @@
 ---
-page_title: "DigitalOcean: digital_monitor_alert"
+page_title: "DigitalOcean: digitalocean_monitor_alert"
 ---
 
 # digitalocean_monitor_alert


### PR DESCRIPTION
Resource name in the docs should be `digitalocean_monitor_alert` instead of `digitalocean_monitoring` according to what https://github.com/digitalocean/terraform-provider-digitalocean/pull/679 introduced in v2.12.0