### PR TITLE
Prep v2.12.1 bugfix release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.12.1 (October 1, 2021)
+
+BUGFIXES:
+
+* docs: Correct the example for `digitalocean_monitor_alert` ([#710](https://github.com/digitalocean/terraform-provider-digitalocean/pull/710)). Thanks to @jessedobbelaere!
+
 ## 2.12.0 (September 22, 2021)
 
 FEATURES:


### PR DESCRIPTION
It's a bit annoying that the live docs can't be updated without cutting a release. Since this has tripped up a few people now, it's worth doing.