### PR TITLE
Fix tag collection in digitalocean_tags data source

### DIFF
--- a/digitalocean/datasource_digitalocean_tags.go
+++ b/digitalocean/datasource_digitalocean_tags.go
@@ -58,7 +58,9 @@ func getDigitalOceanTags(meta interface{}, extra map[string]interface{}) ([]inte
 			return nil, fmt.Errorf("Error retrieving tags: %s", err)
 		}
 
-		tagsList = append(tagsList, tags)
+		for _, tag := range tags {
+			tagsList = append(tagsList, tag)
+		}
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break


### PR DESCRIPTION
Fixes a regression introduced in 35e97db3 (2.11.0). Previously, any use of `digitalocean_tags` would fail with an interface conversion error:

```
Stack trace from the terraform-provider-digitalocean_v2.12.1 plugin:

panic: interface conversion: interface {} is []godo.Tag, not godo.Tag

goroutine 27 [running]:
github.com/digitalocean/terraform-provider-digitalocean/digitalocean.flattenDigitalOceanTag(0xef8d80, 0xc000522f18, 0xf67880, 0xc00059ae40, 0xc000827aa0, 0x1, 0x0, 0x0)
        github.com/digitalocean/terraform-provider-digitalocean/digitalocean/datasource_digitalocean_tags.go:79 +0x458
github.com/digitalocean/terraform-provider-digitalocean/internal/datalist.dataListResourceRead.func1(0x1242f78, 0xc000140d80, 0xc00019d200, 0xf67880, 0xc00059ae40, 0xc000762ab0, 0xc0003a5
948, 0x40e0f8)                                
        github.com/digitalocean/terraform-provider-digitalocean/internal/datalist/schema.go:95 +0x3a3
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0001c88c0, 0x1242f08, 0xc0004ac480, 0xc00019d200, 0xf67880, 0xc00059ae40, 0x0, 0x0, 0x0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:347 +0x17f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc0001c88c0, 0x1242f08, 0xc0004ac480, 0xc0004ae460, 0xf67880, 0xc00059ae40, 0xc00059ae40, 0xc0004ae46
0, 0x0, 0x0)                                  
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:558 +0xfd
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc00000c030, 0x1242f08, 0xc0004ac480, 0xc0004ae340, 0xc0004ac480, 0x40b965, 0x100ea00)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/grpc_provider.go:1105 +0x4d6
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadDataSource(0xc00071d3a0, 0x1242fb0, 0xc0004ac480, 0xc000145040, 0xc00071d3a0, 0xc000826ff0, 0xc0004c0ba0)
        github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:247 +0xe5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler(0x10508e0, 0xc00071d3a0, 0x1242fb0, 0xc000826ff0, 0xc000140720, 0x0, 0x1242fb0, 0xc0
00826ff0, 0xc00082a0c0, 0x35)                 
        github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000a6380, 0x124c7b8, 0xc000103980, 0xc00063a300, 0xc00061e570, 0x17e2bf0, 0x0, 0x0, 0x0)
        google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc0000a6380, 0x124c7b8, 0xc000103980, 0xc00063a300, 0x0)
        google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00049e1c0, 0xc0000a6380, 0x124c7b8, 0xc000103980, 0xc00063a300)
        google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
```