### PR TITLE
Add digitalocean_database_ca data source.

### DIFF
--- a/digitalocean/datasource_digitalocean_database_ca.go
+++ b/digitalocean/datasource_digitalocean_database_ca.go
@@ -1,0 +1,42 @@
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceDigitalOceanDatabaseCA() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDigitalOceanDatabaseCARead,
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanDatabaseCARead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+	d.SetId(clusterID)
+
+	ca, _, err := client.Databases.GetCA(context.Background(), clusterID)
+	if err != nil {
+		return diag.Errorf("Error retrieving database CA certificate: %s", err)
+	}
+
+	d.Set("certificate", string(ca.Certificate))
+
+	return nil
+}

--- a/digitalocean/datasource_digitalocean_database_ca_test.go
+++ b/digitalocean/datasource_digitalocean_database_ca_test.go
@@ -1,0 +1,72 @@
+package digitalocean
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceDigitalOceanDatabaseCA(t *testing.T) {
+	var database godo.Database
+	databaseName := randomTestName()
+	databaseConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigMongoDB, databaseName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseReplicaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: databaseConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+				),
+			},
+			{
+				Config: databaseConfig + testAccCheckDigitalOceanDatasourceCAConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_database_ca.ca", "certificate"),
+					resource.TestCheckFunc(
+						// Do some basic validation by parsing the certificate.
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["data.digitalocean_database_ca.ca"]
+							if !ok {
+								return fmt.Errorf("Not found: %s", "data.digitalocean_database_ca.ca")
+							}
+
+							certString := rs.Primary.Attributes["certificate"]
+							block, _ := pem.Decode([]byte(certString))
+							if block == nil {
+								return fmt.Errorf("failed to parse certificate PEM")
+							}
+							cert, err := x509.ParseCertificate(block.Bytes)
+							if err != nil {
+								return fmt.Errorf("failed to parse certificate: " + err.Error())
+							}
+
+							if !cert.IsCA {
+								return fmt.Errorf("not a CA cert")
+							}
+
+							return nil
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+const (
+	testAccCheckDigitalOceanDatasourceCAConfig = `
+
+data "digitalocean_database_ca" "ca" {
+  cluster_id = digitalocean_database_cluster.foobar.id
+}`
+)

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -53,6 +53,8 @@ func Provider() *schema.Provider {
 			"digitalocean_certificate":           dataSourceDigitalOceanCertificate(),
 			"digitalocean_container_registry":    dataSourceDigitalOceanContainerRegistry(),
 			"digitalocean_database_cluster":      dataSourceDigitalOceanDatabaseCluster(),
+			"digitalocean_database_ca":           dataSourceDigitalOceanDatabaseCA(),
+			"digitalocean_database_replica":      dataSourceDigitalOceanDatabaseReplica(),
 			"digitalocean_domain":                dataSourceDigitalOceanDomain(),
 			"digitalocean_domains":               dataSourceDigitalOceanDomains(),
 			"digitalocean_droplet":               dataSourceDigitalOceanDroplet(),
@@ -83,7 +85,6 @@ func Provider() *schema.Provider {
 			"digitalocean_volume_snapshot":       dataSourceDigitalOceanVolumeSnapshot(),
 			"digitalocean_volume":                dataSourceDigitalOceanVolume(),
 			"digitalocean_vpc":                   dataSourceDigitalOceanVPC(),
-			"digitalocean_database_replica":      dataSourceDigitalOceanDatabaseReplica(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/docs/data-sources/database_ca.md
+++ b/docs/data-sources/database_ca.md
@@ -1,0 +1,32 @@
+---
+page_title: "DigitalOcean: digitalocean_database_ca"
+---
+
+# digitalocean\_database\_ca
+
+Provides the CA certificate for a DigitalOcean database.
+
+## Example Usage
+
+```hcl
+data "digitalocean_database_ca" "ca" {
+  cluster_id = "aaa-bbb-ccc-ddd"
+}
+
+output "ca_output" {
+  value = data.digitalocean_database_ca.ca.certificate
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required) The ID of the source database cluster.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `certificate` - The CA certificate used to secure database connections decoded to a string.


### PR DESCRIPTION
This PR adds a data source for retrieving the CA certificate for a database cluster. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/388