### PR TITLE
load balancers: Support disabling automatic DNS records.

### DIFF
--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -192,6 +192,11 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				Computed:    true,
 				Description: "whether HTTP keepalive connections are maintained to target Droplets",
 			},
+			"disable_lets_encrypt_dns_records": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "whether to disable automatic DNS record creation for Let's Encrypt certificates that are added to the load balancer",
+			},
 			"vpc_uuid": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -252,6 +257,7 @@ func dataSourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resou
 	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
 	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
 	d.Set("enable_backend_keepalive", loadbalancer.EnableBackendKeepalive)
+	d.Set("disable_lets_encrypt_dns_records", loadbalancer.DisableLetsEncryptDNSRecords)
 	d.Set("vpc_uuid", loadbalancer.VPCUUID)
 
 	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -68,6 +68,8 @@ data "digitalocean_loadbalancer" "foobar" {
 						"data.digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "disable_lets_encrypt_dns_records", "false"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -321,6 +321,12 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 				Default:  false,
 			},
 
+			"disable_lets_encrypt_dns_records": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"vpc_uuid": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -378,14 +384,15 @@ func buildLoadBalancerRequest(client *godo.Client, d *schema.ResourceData) (*god
 	}
 
 	opts := &godo.LoadBalancerRequest{
-		Name:                   d.Get("name").(string),
-		SizeSlug:               d.Get("size").(string),
-		Region:                 d.Get("region").(string),
-		Algorithm:              d.Get("algorithm").(string),
-		RedirectHttpToHttps:    d.Get("redirect_http_to_https").(bool),
-		EnableProxyProtocol:    d.Get("enable_proxy_protocol").(bool),
-		EnableBackendKeepalive: d.Get("enable_backend_keepalive").(bool),
-		ForwardingRules:        forwardingRules,
+		Name:                         d.Get("name").(string),
+		SizeSlug:                     d.Get("size").(string),
+		Region:                       d.Get("region").(string),
+		Algorithm:                    d.Get("algorithm").(string),
+		RedirectHttpToHttps:          d.Get("redirect_http_to_https").(bool),
+		EnableProxyProtocol:          d.Get("enable_proxy_protocol").(bool),
+		EnableBackendKeepalive:       d.Get("enable_backend_keepalive").(bool),
+		ForwardingRules:              forwardingRules,
+		DisableLetsEncryptDNSRecords: godo.Bool(d.Get("disable_lets_encrypt_dns_records").(bool)),
 	}
 
 	if v, ok := d.GetOk("droplet_tag"); ok {

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -98,6 +98,8 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "true"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "true"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "disable_lets_encrypt_dns_records", "false"),
 				),
 			},
 		},
@@ -148,6 +150,8 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "true"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "true"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "disable_lets_encrypt_dns_records", "false"),
 				),
 			},
 			{
@@ -185,6 +189,8 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "disable_lets_encrypt_dns_records", "true"),
 				),
 			},
 		},
@@ -672,8 +678,9 @@ resource "digitalocean_loadbalancer" "foobar" {
     protocol = "tcp"
   }
 
-  enable_proxy_protocol    = false
-  enable_backend_keepalive = false
+  enable_proxy_protocol            = false
+  enable_backend_keepalive         = false
+  disable_lets_encrypt_dns_records = true
 
   droplet_ids = [digitalocean_droplet.foobar.id, digitalocean_droplet.foo.id]
 }`, rInt, rInt, rInt)

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `name` - (Required) The Load Balancer name
 * `region` - (Required) The region to start in
-* `size` - (Optional) The size of the Load Balancer. It must be either `lb-small`, `lb-medium`, or `lb-large`. Defaults to `lb-small`. 
+* `size` - (Optional) The size of the Load Balancer. It must be either `lb-small`, `lb-medium`, or `lb-large`. Defaults to `lb-small`.
 * `algorithm` - (Optional) The load balancing algorithm used to determine
 which backend Droplet will be selected by a client. It must be either `round_robin`
 or `least_connections`. The default value is `round_robin`.
@@ -108,6 +108,7 @@ Default value is `false`.
 Protocol should be used to pass information from connecting client requests to
 the backend service. Default value is `false`.
 * `enable_backend_keepalive` - (Optional) A boolean value indicating whether HTTP keepalive connections are maintained to target Droplets. Default value is `false`.
+* `disable_lets_encrypt_dns_records` - (Optional) A boolean value indicating whether to disable automatic DNS record creation for Let's Encrypt certificates that are added to the load balancer. Default value is `false`.
 * `vpc_uuid` - (Optional) The ID of the VPC where the load balancer will be located.
 * `droplet_ids` (Optional) - A list of the IDs of each droplet to be attached to the Load Balancer.
 * `droplet_tag` (Optional) - The name of a Droplet tag corresponding to Droplets to be assigned to the Load Balancer.


### PR DESCRIPTION
The DO API now [supports disabling automatic DNS record creation](https://docs.digitalocean.com/release-notes/#october-12) for load balancers using Let's Encrypt certificates. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/456