### PR TITLE
APICLI-900: update k8s HA test to check for endpoint attr

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -184,7 +184,7 @@ func TestAccDigitalOceanKubernetesCluster_CreateWithHAControlPlane(t *testing.T)
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "nyc1"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "ha", "true"),
-					resource.TestCheckNoResourceAttr("digitalocean_kubernetes_cluster.foobar", "ipv4"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "ipv4_address", ""),
 					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "status"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "created_at"),

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -172,7 +172,7 @@ In addition to the arguments listed above, the following additional attributes a
 * `id` - A unique ID that can be used to identify and reference a Kubernetes cluster.
 * `cluster_subnet` - The range of IP addresses in the overlay network of the Kubernetes cluster.
 * `service_subnet` - The range of assignable IP addresses for services running in the Kubernetes cluster.
-* `ipv4_address` - The public IPv4 address of the Kubernetes master node.
+* `ipv4_address` - The public IPv4 address of the Kubernetes master node. This will not be set if high availability is configured on the cluster (v1.21+)
 * `endpoint` - The base URL of the API server on the Kubernetes master node.
 * `status` -  A string indicating the current status of the cluster. Potential values include running, provisioning, and errored.
 * `created_at` - The date and time when the Kubernetes cluster was created.


### PR DESCRIPTION
For clusters created with HA enabled on K8S v1.21, it looks like an Endpoint is set, but the IPv4 will not be set. The docs should be updated to reflect this, and the HA test case in Terraform should probably be updated to check for this as well.