### PR TITLE
Add scheduled acceptance test runs

### DIFF
--- a/.github/workflows/acceptance-test-schedule.yml
+++ b/.github/workflows/acceptance-test-schedule.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+# Runs acceptance tests on a cron schedule
+
+on:
+  schedule:
+    - cron: 0 14 * * MON-FRI # Every weekday at 14:00 UTC (10a Eastern)
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: make testacc
+        run: make testacc
+        env:
+          TESTARGS: -parallel 20
+          DIGITALOCEAN_TOKEN: ${{ secrets.ACCEPTANCE_TESTS_TOKEN }}
+          SPACES_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY_ID }}
+          SPACES_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This workflow runs the acceptance tests every weekday at 14:00 UTC (10a Eastern)