### PR TITLE
Acceptance tests: Use 2048 bit private keys in test data.

### DIFF
--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -234,7 +234,7 @@ func randTLSCert(orgName string, dnsName string) (string, string, error) {
 }
 
 func genPrivateKey() (*rsa.PrivateKey, string, error) {
-	privateKey, err := rsa.GenerateKey(crand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(crand.Reader, 2048)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
We have a number of new acceptance test failures around certificates. The API recently began enforcing that customer certificates use private keys using a minimum of 2048 bits (RSA) or 224 bits (ECDSA). The dummy test data we've been generating is only 1024 bits. This fixes these errors:

```
=== CONT  TestAccDigitalOceanLoadbalancer_sslCertByName
    resource_digitalocean_loadbalancer_test.go:404: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating Certificate: POST https://api.digitalocean.com/v2/certificates: 422 (request "242f60e5-2a57-48fe-83ff-2f84b5d4c82e") Invalid certificate data: the provided private key is not a minimum of 2048 bits (RSA) or 224 bits (ECDSA)
        
          with digitalocean_certificate.foobar,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_certificate" "foobar":
           2: resource "digitalocean_certificate" "foobar" {
        
--- FAIL: TestAccDigitalOceanLoadbalancer_sslCertByName (8.82s)


=== CONT  TestAccDigitalOceanLoadbalancer_sslTermination
    resource_digitalocean_loadbalancer_test.go:359: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating Certificate: POST https://api.digitalocean.com/v2/certificates: 422 (request "f5149f70-1b97-45c5-b306-26531b204099") Invalid certificate data: the provided private key is not a minimum of 2048 bits (RSA) or 224 bits (ECDSA)
        
          with digitalocean_certificate.foobar,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_certificate" "foobar":
           2: resource "digitalocean_certificate" "foobar" {
        
--- FAIL: TestAccDigitalOceanLoadbalancer_sslTermination (9.21s)


=== CONT  TestAccDigitalOceanCertificate_Basic
    resource_digitalocean_certificate_test.go:95: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating Certificate: POST https://api.digitalocean.com/v2/certificates: 422 (request "9db0ed5f-8f4e-4bca-ae30-5b2036892a10") Invalid certificate data: the provided private key is not a minimum of 2048 bits (RSA) or 224 bits (ECDSA)
        
          with digitalocean_certificate.foobar,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_certificate" "foobar":
           2: resource "digitalocean_certificate" "foobar" {
        
--- FAIL: TestAccDigitalOceanCertificate_Basic (0.99s)


=== CONT  TestAccDigitalOceanCertificate_importBasic
    import_digitalocean_certificate_test.go:16: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating Certificate: POST https://api.digitalocean.com/v2/certificates: 422 (request "45fcca71-5b1b-4f2d-8c54-e5d8f43eec36") Invalid certificate data: the provided private key is not a minimum of 2048 bits (RSA) or 224 bits (ECDSA)
        
          with digitalocean_certificate.foobar,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_certificate" "foobar":
           2: resource "digitalocean_certificate" "foobar" {
        
--- FAIL: TestAccDigitalOceanCertificate_importBasic (0.97s)


=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_tlsCert
    datasource_digitalocean_loadbalancer_test.go:209: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating Certificate: POST https://api.digitalocean.com/v2/certificates: 422 (request "bf51b3b3-dd85-4771-9715-0da66652cf8d") Invalid certificate data: the provided private key is not a minimum of 2048 bits (RSA) or 224 bits (ECDSA)
        
          with digitalocean_certificate.foobar,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_certificate" "foobar":
           2: resource "digitalocean_certificate" "foobar" {
        
--- FAIL: TestAccDataSourceDigitalOceanLoadBalancer_tlsCert (2.88s)


=== CONT  TestAccDataSourceDigitalOceanCertificate_Basic
    datasource_digitalocean_certificate_test.go:19: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating Certificate: POST https://api.digitalocean.com/v2/certificates: 422 (request "dfc9d370-0b4c-45c9-96ec-914dab034229") Invalid certificate data: the provided private key is not a minimum of 2048 bits (RSA) or 224 bits (ECDSA)
        
          with digitalocean_certificate.foo,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_certificate" "foo":
           2: resource "digitalocean_certificate" "foo" {
        
--- FAIL: TestAccDataSourceDigitalOceanCertificate_Basic (1.36s)
```