### PR TITLE
Acceptance tests: Don't use deprecated size slugs.

### DIFF
--- a/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -161,7 +161,7 @@ func testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name               = "foobar-%d"
-  size               = "1gb"
+  size               = "s-1vcpu-1gb"
   image              = "centos-7-x64"
   region             = "nyc3"
   ipv6               = true
@@ -178,7 +178,7 @@ func testAccCheckDigitalOceanFloatingIPConfig_Reassign(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "baz" {
   name               = "baz-%d"
-  size               = "1gb"
+  size               = "s-1vcpu-1gb"
   image              = "centos-7-x64"
   region             = "nyc3"
   ipv6               = true
@@ -195,7 +195,7 @@ func testAccCheckDigitalOceanFloatingIPConfig_Unassign(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "baz" {
   name               = "baz-%d"
-  size               = "1gb"
+  size               = "s-1vcpu-1gb"
   image              = "centos-7-x64"
   region             = "nyc3"
   ipv6               = true

--- a/digitalocean/resource_digitalocean_volume_attachment_test.go
+++ b/digitalocean/resource_digitalocean_volume_attachment_test.go
@@ -225,7 +225,7 @@ resource "digitalocean_volume" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
 	name               = "baz-%d"
-	size               = "1gb"
+	size               = "s-1vcpu-1gb"
 	image              = "centos-7-x64"
 	region             = "nyc1"
 }
@@ -254,7 +254,7 @@ resource "digitalocean_volume" "barfoo" {
 
 resource "digitalocean_droplet" "foobar" {
 	name               = "baz-%d"
-	size               = "1gb"
+	size               = "s-1vcpu-1gb"
 	image              = "centos-7-x64"
 	region             = "nyc1"
 }
@@ -288,7 +288,7 @@ resource "digitalocean_volume" "foobar_second" {
 
 resource "digitalocean_droplet" "foobar" {
 	name               = "baz-%d"
-	size               = "1gb"
+	size               = "s-1vcpu-1gb"
 	image              = "centos-7-x64"
 	region             = "nyc1"
 }

--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -192,7 +192,7 @@ resource "digitalocean_volume" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name               = "baz-%d"
-  size               = "1gb"
+  size               = "s-1vcpu-1gb"
   image              = "centos-7-x64"
   region             = "nyc1"
   ipv6               = true
@@ -337,7 +337,7 @@ resource "digitalocean_volume" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name               = "baz-%d"
-  size               = "1gb"
+  size               = "s-1vcpu-1gb"
   image              = "centos-7-x64"
   region             = "nyc1"
   ipv6               = true

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -40,7 +40,7 @@ The following example demonstrates the creation of a project with a Droplet reso
 ```hcl
 resource "digitalocean_droplet" "foobar" {
   name   = "example"
-  size   = "512mb"
+  size   = "s-1vcpu-1gb"
   image  = "centos-7-x64"
   region = "nyc3"
 }

--- a/docs/resources/project_resources.md
+++ b/docs/resources/project_resources.md
@@ -28,7 +28,7 @@ data "digitalocean_project" "playground" {
 
 resource "digitalocean_droplet" "foobar" {
   name   = "example"
-  size   = "512mb"
+  size   = "s-1vcpu-1gb"
   image  = "centos-7-x64"
   region = "nyc3"
 }


### PR DESCRIPTION
These size slugs pointing to legacy Droplet plans have been deprecated and are not available on most accounts. This leads to test failures when run under the new acceptance testing account.