### PR TITLE
Limit acceptance test job/workflow to single run at a time

### DIFF
--- a/.github/workflows/acceptance-test-schedule.yml
+++ b/.github/workflows/acceptance-test-schedule.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Acceptance Test Schedule
 
 # Runs acceptance tests on a cron schedule
 

--- a/.github/workflows/acceptance-test-schedule.yml
+++ b/.github/workflows/acceptance-test-schedule.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: 0 14 * * MON-FRI # Every weekday at 14:00 UTC (10a Eastern)
 
+concurrency: acceptance_tests
+
 jobs:
   acceptance:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
     environment:
       name: Acceptance Tests
 
+    concurrency: acceptance_tests
+
     continue-on-error: true
 
     steps:


### PR DESCRIPTION
This sets the [concurrency group](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) for the acceptance test job and workflow to ensure only one runs at any given time.