### PR TITLE
add attributes for kubernetes cluster IDs to firewall rules

### DIFF
--- a/digitalocean/firewalls.go
+++ b/digitalocean/firewalls.go
@@ -109,6 +109,14 @@ func firewallRuleSchema(prefix string) *schema.Resource {
 				},
 				Optional: true,
 			},
+			prefix + "kubernetes_ids": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
+				Optional: true,
+			},
 			prefix + "tags": tagsSchema(),
 		},
 	}
@@ -145,6 +153,8 @@ func expandFirewallInboundRules(rules []interface{}) []godo.InboundRule {
 
 		src.LoadBalancerUIDs = expandFirewallRuleStringSet(rule["source_load_balancer_uids"].(*schema.Set).List())
 
+		src.KubernetesIDs = expandFirewallRuleStringSet(rule["source_kubernetes_ids"].(*schema.Set).List())
+
 		src.Tags = expandTags(rule["source_tags"].(*schema.Set).List())
 
 		r := godo.InboundRule{
@@ -170,6 +180,8 @@ func expandFirewallOutboundRules(rules []interface{}) []godo.OutboundRule {
 		dest.Addresses = expandFirewallRuleStringSet(rule["destination_addresses"].(*schema.Set).List())
 
 		dest.LoadBalancerUIDs = expandFirewallRuleStringSet(rule["destination_load_balancer_uids"].(*schema.Set).List())
+
+		dest.KubernetesIDs = expandFirewallRuleStringSet(rule["destination_kubernetes_ids"].(*schema.Set).List())
 
 		dest.Tags = expandTags(rule["destination_tags"].(*schema.Set).List())
 
@@ -261,6 +273,10 @@ func flattenFirewallInboundRules(rules []godo.InboundRule) []interface{} {
 			rawRule["source_load_balancer_uids"] = flattenFirewallRuleStringSet(sources.LoadBalancerUIDs)
 		}
 
+		if sources.KubernetesIDs != nil {
+			rawRule["source_kubernetes_ids"] = flattenFirewallRuleStringSet(sources.KubernetesIDs)
+		}
+
 		flattenedRules[i] = rawRule
 	}
 
@@ -307,6 +323,10 @@ func flattenFirewallOutboundRules(rules []godo.OutboundRule) []interface{} {
 
 		if destinations.LoadBalancerUIDs != nil {
 			rawRule["destination_load_balancer_uids"] = flattenFirewallRuleStringSet(destinations.LoadBalancerUIDs)
+		}
+
+		if destinations.KubernetesIDs != nil {
+			rawRule["destination_kubernetes_ids"] = flattenFirewallRuleStringSet(destinations.KubernetesIDs)
 		}
 
 		flattenedRules[i] = rawRule

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -95,6 +95,8 @@ The following arguments are supported:
   will be accepted.
 * `source_load_balancer_uids` - (Optional) An array containing the IDs
   of the Load Balancers from which the inbound traffic will be accepted.
+* `source_kubernetes_ids` - (Optional) An array containing the IDs of
+  the Kubernetes clusters from which the inbound traffic will be accepted.
 
 `outbound_rule` supports the following:
 
@@ -109,10 +111,11 @@ The following arguments are supported:
   outbound traffic will be allowed.
 * `destination_droplet_ids` - (Optional) An array containing the IDs of
   the Droplets to which the outbound traffic will be allowed.
+* `destination_kubernetes_ids` - (Optional) An array containing the IDs of
+  the Kubernetes clusters to which the outbound traffic will be allowed.
 * `destination_tags` - (Optional) An array containing the names of Tags
   corresponding to groups of Droplets to which the outbound traffic will
   be allowed.
-  traffic.
 * `destination_load_balancer_uids` - (Optional) An array containing the IDs
   of the Load Balancers to which the outbound traffic will be allowed.
 


### PR DESCRIPTION
Add `source_kubernetes_ids` and `destination_kubernetes_ids` attributes to firewall rules.