### PR TITLE
databases: Provide better error messages importing sub-resources.

### DIFF
--- a/digitalocean/import_digitalocean_database_connection_pool_test.go
+++ b/digitalocean/import_digitalocean_database_connection_pool_test.go
@@ -39,6 +39,13 @@ func TestAccDigitalOceanDatabaseConnectionPool_importBasic(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", databaseConnectionPoolName),
 				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "replica",
+				ExpectError:       regexp.MustCompile("joined with a comma"),
+			},
 		},
 	})
 }

--- a/digitalocean/import_digitalocean_database_db_test.go
+++ b/digitalocean/import_digitalocean_database_db_test.go
@@ -39,6 +39,13 @@ func TestAccDigitalOceanDatabaseDB_importBasic(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", databaseDBName),
 				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "db",
+				ExpectError:       regexp.MustCompile("joined with a comma"),
+			},
 		},
 	})
 }

--- a/digitalocean/import_digitalocean_database_replica_test.go
+++ b/digitalocean/import_digitalocean_database_replica_test.go
@@ -51,6 +51,13 @@ func TestAccDigitalOceanDatabaseReplica_importBasic(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", databaseReplicaName),
 				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "replica",
+				ExpectError:       regexp.MustCompile("joined with a comma"),
+			},
 		},
 	})
 }

--- a/digitalocean/import_digitalocean_database_user_test.go
+++ b/digitalocean/import_digitalocean_database_user_test.go
@@ -38,6 +38,13 @@ func TestAccDigitalOceanDatabaseUser_importBasic(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", databaseUserName),
 				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "username",
+				ExpectError:       regexp.MustCompile("joined with a comma"),
+			},
 		},
 	})
 }

--- a/digitalocean/resource_digitalocean_database_connection_pool.go
+++ b/digitalocean/resource_digitalocean_database_connection_pool.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -168,6 +169,8 @@ func resourceDigitalOceanDatabaseConnectionPoolImport(d *schema.ResourceData, me
 		d.SetId(createConnectionPoolID(s[0], s[1]))
 		d.Set("cluster_id", s[0])
 		d.Set("name", s[1])
+	} else {
+		return nil, errors.New("must use the ID of the source database cluster and the name of the connection pool joined with a comma (e.g. `id,name`)")
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/digitalocean/resource_digitalocean_database_db.go
+++ b/digitalocean/resource_digitalocean_database_db.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -100,6 +101,8 @@ func resourceDigitalOceanDatabaseDBImport(d *schema.ResourceData, meta interface
 		d.SetId(makeDatabaseDBID(s[0], s[1]))
 		d.Set("cluster_id", s[0])
 		d.Set("name", s[1])
+	} else {
+		return nil, errors.New("must use the ID of the source database cluster and the name of the database joined with a comma (e.g. `id,name`)")
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/digitalocean/resource_digitalocean_database_replica.go
+++ b/digitalocean/resource_digitalocean_database_replica.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -185,6 +186,8 @@ func resourceDigitalOceanDatabaseReplicaImport(d *schema.ResourceData, meta inte
 		d.SetId(makeReplicaId(s[0], s[1]))
 		d.Set("cluster_id", s[0])
 		d.Set("name", s[1])
+	} else {
+		return nil, errors.New("must use the ID of the source database cluster and the replica name joined with a comma (e.g. `id,name`)")
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/digitalocean/resource_digitalocean_database_user.go
+++ b/digitalocean/resource_digitalocean_database_user.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -169,6 +170,8 @@ func resourceDigitalOceanDatabaseUserImport(d *schema.ResourceData, meta interfa
 		d.SetId(makeDatabaseUserID(s[0], s[1]))
 		d.Set("cluster_id", s[0])
 		d.Set("name", s[1])
+	} else {
+		return nil, errors.New("must use the ID of the source database cluster and the name of the user joined with a comma (e.g. `id,name`)")
 	}
 
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
Some database cluster sub-resources (e.g. users) require passing the ID of the cluster and the name of the sub-resource joined with a comma when importing. This PR provide more helpful error messaging if the argument is not comma separated. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/743