### PR TITLE
vpc: Allow updating name and description of default vpcs.

### DIFF
--- a/digitalocean/resource_digitalocean_vpc.go
+++ b/digitalocean/resource_digitalocean_vpc.go
@@ -144,6 +144,7 @@ func resourceDigitalOceanVPCUpdate(ctx context.Context, d *schema.ResourceData, 
 		vpcUpdateRequest := &godo.VPCUpdateRequest{
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
+			Default:     godo.Bool(d.Get("default").(bool)),
 		}
 		_, _, err := client.VPCs.Update(context.Background(), d.Id(), vpcUpdateRequest)
 

--- a/digitalocean/resource_digitalocean_vpc_test.go
+++ b/digitalocean/resource_digitalocean_vpc_test.go
@@ -49,6 +49,8 @@ func TestAccDigitalOceanVPC_Basic(t *testing.T) {
 						"digitalocean_vpc.foobar", "name", updatedVPCName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_vpc.foobar", "description", updatedVPVDesc),
+					resource.TestCheckResourceAttr(
+						"digitalocean_vpc.foobar", "default", "false"),
 				),
 			},
 		},
@@ -72,6 +74,8 @@ func TestAccDigitalOceanVPC_IPRange(t *testing.T) {
 						"digitalocean_vpc.foobar", "name", vpcName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_vpc.foobar", "ip_range", "10.10.10.0/24"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_vpc.foobar", "default", "false"),
 				),
 			},
 		},


### PR DESCRIPTION
The PUT request for updating a VPC needs to include the `default` attribute even if it is not changed in order to support updating  the name or description of a region's default vpc.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/747