### PR TITLE
Update domains sweeper

### DIFF
--- a/.github/workflows/acceptance-test-schedule.yml
+++ b/.github/workflows/acceptance-test-schedule.yml
@@ -28,3 +28,22 @@ jobs:
           DIGITALOCEAN_TOKEN: ${{ secrets.ACCEPTANCE_TESTS_TOKEN }}
           SPACES_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY_ID }}
           SPACES_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}
+
+  sweep:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: make sweep
+        run: make sweep
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.ACCEPTANCE_TESTS_TOKEN }}
+          SPACES_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY_ID }}
+          SPACES_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,24 @@ jobs:
           DIGITALOCEAN_TOKEN: ${{ secrets.ACCEPTANCE_TESTS_TOKEN }}
           SPACES_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY_ID }}
           SPACES_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}
+
+  sweep:
+    runs-on: ubuntu-latest
+    needs: acceptance
+    concurrency: acceptance_tests
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: make sweep
+        run: make sweep
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.ACCEPTANCE_TESTS_TOKEN }}
+          SPACES_ACCESS_KEY_ID: ${{ secrets.SPACES_ACCESS_KEY_ID }}
+          SPACES_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}

--- a/digitalocean/datasource_digitalocean_domain_test.go
+++ b/digitalocean/datasource_digitalocean_domain_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceDigitalOceanDomain_Basic(t *testing.T) {
 	var domain godo.Domain
-	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domainName := randomTestName() + ".com"
 	expectedURN := fmt.Sprintf("do:domain:%s", domainName)
 
 	resourceConfig := fmt.Sprintf(`

--- a/digitalocean/datasource_digitalocean_domains_test.go
+++ b/digitalocean/datasource_digitalocean_domains_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanDomains_Basic(t *testing.T) {
-	name1 := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
-	name2 := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	name1 := randomTestName() + ".com"
+	name2 := randomTestName() + ".com"
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_domain" "foo" {

--- a/digitalocean/datasource_digitalocean_record_test.go
+++ b/digitalocean/datasource_digitalocean_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceDigitalOceanRecord_Basic(t *testing.T) {
 	var record godo.DomainRecord
 	recordDomain := fmt.Sprintf("%s.com", randomTestName())
-	recordName := randomTestName()
+	recordName := randomTestName("record")
 	resourceConfig := fmt.Sprintf(`
 resource "digitalocean_domain" "foo" {
   name       = "%s"

--- a/digitalocean/datasource_digitalocean_records_test.go
+++ b/digitalocean/datasource_digitalocean_records_test.go
@@ -2,13 +2,13 @@ package digitalocean
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanRecords_Basic(t *testing.T) {
-	name1 := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	name1 := randomTestName("records") + ".com"
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_domain" "foo" {

--- a/digitalocean/import_digitalocean_domain_test.go
+++ b/digitalocean/import_digitalocean_domain_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanDomain_importBasic(t *testing.T) {
 	resourceName := "digitalocean_domain.foobar"
-	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domainName := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/digitalocean/import_digitalocean_record_test.go
+++ b/digitalocean/import_digitalocean_record_test.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanRecord_importBasic(t *testing.T) {
 	resourceName := "digitalocean_record.foobar"
-	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domainName := randomTestName("record") + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/digitalocean/provider_test.go
+++ b/digitalocean/provider_test.go
@@ -3,11 +3,12 @@ package digitalocean
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -174,8 +175,12 @@ func TestSpaceAPIEndpointOverride(t *testing.T) {
 	}
 }
 
-func randomTestName() string {
-	return randomName(testNamePrefix, 10)
+func randomTestName(additionalNames ...string) string {
+	prefix := testNamePrefix
+	for _, n := range additionalNames {
+		prefix += "-" + strings.Replace(n, " ", "_", -1)
+	}
+	return randomName(prefix, 10)
 }
 
 func randomName(prefix string, length int) string {

--- a/digitalocean/resource_digitalocean_domain_test.go
+++ b/digitalocean/resource_digitalocean_domain_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -36,7 +35,7 @@ func testSweepDomain(region string) error {
 	}
 
 	for _, d := range domains {
-		if strings.HasPrefix(d.Name, "foobar-") {
+		if strings.HasPrefix(d.Name, testNamePrefix) {
 			log.Printf("Destroying domain %s", d.Name)
 
 			if _, err := client.Domains.Delete(context.Background(), d.Name); err != nil {
@@ -50,7 +49,7 @@ func testSweepDomain(region string) error {
 
 func TestAccDigitalOceanDomain_Basic(t *testing.T) {
 	var domain godo.Domain
-	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domainName := randomTestName() + ".com"
 
 	expectedURN := fmt.Sprintf("do:domain:%s", domainName)
 
@@ -78,7 +77,7 @@ func TestAccDigitalOceanDomain_Basic(t *testing.T) {
 
 func TestAccDigitalOceanDomain_WithoutIp(t *testing.T) {
 	var domain godo.Domain
-	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domainName := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/digitalocean/resource_digitalocean_project_test.go
+++ b/digitalocean/resource_digitalocean_project_test.go
@@ -240,7 +240,7 @@ func TestAccDigitalOceanProject_UpdateFromDropletToSpacesResource(t *testing.T) 
 
 func TestAccDigitalOceanProject_WithManyResources(t *testing.T) {
 	projectName := generateProjectName()
-	domainBase := randomTestName()
+	domainBase := randomTestName("project")
 
 	createConfig := fixtureCreateDomainResources(domainBase)
 	updateConfig := fixtureWithManyResources(domainBase, projectName)

--- a/digitalocean/resource_digitalocean_record_test.go
+++ b/digitalocean/resource_digitalocean_record_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -39,7 +38,7 @@ func TestDigitalOceanRecordConstructFqdn(t *testing.T) {
 
 func TestAccDigitalOceanRecord_Basic(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -67,7 +66,7 @@ func TestAccDigitalOceanRecord_Basic(t *testing.T) {
 
 func TestAccDigitalOceanRecord_BasicFullName(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName("record") + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -95,7 +94,7 @@ func TestAccDigitalOceanRecord_BasicFullName(t *testing.T) {
 
 func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName("record") + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -143,7 +142,7 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 
 func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -172,7 +171,7 @@ func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 
 func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -201,7 +200,7 @@ func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
 
 func TestAccDigitalOceanRecord_FlagsAndTag(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -234,7 +233,7 @@ func TestAccDigitalOceanRecord_FlagsAndTag(t *testing.T) {
 
 func TestAccDigitalOceanRecord_MX(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -263,7 +262,7 @@ func TestAccDigitalOceanRecord_MX(t *testing.T) {
 
 func TestAccDigitalOceanRecord_MX_at(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -292,7 +291,7 @@ func TestAccDigitalOceanRecord_MX_at(t *testing.T) {
 
 func TestAccDigitalOceanRecord_SRV_zero_weight_port(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -325,7 +324,7 @@ func TestAccDigitalOceanRecord_SRV_zero_weight_port(t *testing.T) {
 
 func TestAccDigitalOceanRecord_UpdateBasic(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -374,7 +373,7 @@ func TestAccDigitalOceanRecord_UpdateBasic(t *testing.T) {
 
 func TestAccDigitalOceanRecord_MXUpdated(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -423,7 +422,7 @@ func TestAccDigitalOceanRecord_MXUpdated(t *testing.T) {
 
 func TestAccDigitalOceanRecord_SrvUpdated(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -476,7 +475,7 @@ func TestAccDigitalOceanRecord_SrvUpdated(t *testing.T) {
 
 func TestAccDigitalOceanRecord_CaaUpdated(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -529,7 +528,7 @@ func TestAccDigitalOceanRecord_CaaUpdated(t *testing.T) {
 
 func TestAccDigitalOceanRecord_iodefCAA(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -561,7 +560,7 @@ func TestAccDigitalOceanRecord_iodefCAA(t *testing.T) {
 
 func TestAccDigitalOceanRecord_TXT(t *testing.T) {
 	var record godo.DomainRecord
-	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+	domain := randomTestName() + ".com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },


### PR DESCRIPTION
I noticed domain resources aren't getting cleaned up after acceptance tests but it's difficult to identify which tests aren't properly cleaning up after themselves.

This change includes a few things to help diagnose as well clean up:

1. Update the domains resource sweeper to use match resources with the common `testNamePrefix` (a const value set in the [digitalocean/provider_test.go#L17](https://github.com/digitalocean/terraform-provider-digitalocean/blob/main/digitalocean/provider_test.go#L17))
2. Update the names used for domains in tests to call `randomTestName()` (which uses the above common prefix)
3. Extended `randomTestName()` to allow a list of strings that will get concatenated with `-` (and will replace spaces with `_`). 
   * **_I'm curious what thoughts there are on this_**. I made the function variadic so existing calls don't fail. However, I know some resources have a relatively short name length limit and this could cause issues if misused.
4. Lastly, I added a job to the acceptance test workflows to call `make sweep`. This will allow the resources to be cleaned up after every acceptance test run regardless of the tests handling clean up properly, and help reduce future errors due to resource limits being reached.

