### PR TITLE
Makefile: Only run sweep against the digitalocean package.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,7 +26,7 @@ vet:
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	go test $(TEST) -v -sweep=1
+	go test ./digitalocean -v -sweep=1
 
 fmt:
 	gofmt -w $(GOFMT_FILES)


### PR DESCRIPTION
The other packages don't import `github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource`, so that leads to failures when the sweeper is ran. E.g.

https://github.com/digitalocean/terraform-provider-digitalocean/runs/4565075328?check_suite_focus=true#step:4:205