### PR TITLE
Fixed issue about database cluster

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -480,7 +480,11 @@ func waitForDatabaseCluster(client *godo.Client, d *schema.ResourceData, status 
 	)
 
 	for range ticker.C {
-		database, _, err := client.Databases.Get(context.Background(), d.Id())
+		database, resp, err := client.Databases.Get(context.Background(), d.Id())
+		if resp.StatusCode == 404 {
+			continue
+		}
+
 		if err != nil {
 			ticker.Stop()
 			return nil, fmt.Errorf("Error trying to read database cluster state: %s", err)


### PR DESCRIPTION
After calling the following POST endpoint to create database cluster, database cluster should be created and calling GET endpoint should be succeeded
https://github.com/digitalocean/terraform-provider-digitalocean/blob/v2.14.0/digitalocean/resource_digitalocean_database_cluster.go#L248

But, according to #728, 404 error occurs occasionally when calling GET endpoint in the following line
https://github.com/digitalocean/terraform-provider-digitalocean/blob/v2.14.0/digitalocean/resource_digitalocean_database_cluster.go#L483

This PR is the workaround for this issue