### PR TITLE
Fix database cluster documentation

### DIFF
--- a/docs/data-sources/database_cluster.md
+++ b/docs/data-sources/database_cluster.md
@@ -9,7 +9,6 @@ Provides information on a DigitalOcean database cluster resource.
 ## Example Usage
 
 ```hcl
-# Create a new database cluster
 data "digitalocean_database_cluster" "example" {
   name = "example-cluster"
 }


### PR DESCRIPTION
Remove an incorrect comment from the `digitalocean_database_cluster` data source example