### PR TITLE
docs: Update records examples to use domain id over name.

### DIFF
--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -15,7 +15,7 @@ resource "digitalocean_domain" "default" {
 
 # Add an A record to the domain for www.example.com.
 resource "digitalocean_record" "www" {
-  domain = digitalocean_domain.default.name
+  domain = digitalocean_domain.default.id
   type   = "A"
   name   = "www"
   value  = "192.168.0.11"
@@ -23,7 +23,7 @@ resource "digitalocean_record" "www" {
 
 # Add a MX record for the example.com domain itself.
 resource "digitalocean_record" "mx" {
-  domain   = digitalocean_domain.default.name
+  domain   = digitalocean_domain.default.id
   type     = "MX"
   name     = "@"
   priority = 10


### PR DESCRIPTION
As discussed in https://github.com/digitalocean/terraform-provider-digitalocean/issues/769, using the domain's `id` instead of its `name` can be useful to ensure a record is recreated when a domain is.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/769