### PR TITLE
floating_ip_assignment: Properly support importing existing assignments.

### DIFF
--- a/digitalocean/import_digitalocean_floating_ip_assignment_test.go
+++ b/digitalocean/import_digitalocean_floating_ip_assignment_test.go
@@ -1,0 +1,84 @@
+package digitalocean
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDigitalOceanFloatingIPAssignment_importBasic(t *testing.T) {
+	resourceName := "digitalocean_floating_ip_assignment.foobar"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseReplicaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanFloatingIPAssignmentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanFloatingIPAttachmentExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccFLIPAssignmentImportID(resourceName),
+				// floating_ip_assignments are "virtual" resources that have unique, timestamped IDs.
+				// As the imported one will have a different ID that the initial one, the states will not match.
+				// Verify the attachment is correct using an ImportStateCheck function instead.
+				ImportStateVerify: false,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %+v", s)
+					}
+
+					rs := s[0]
+					flipID := rs.Attributes["ip_address"]
+					dropletID, err := strconv.Atoi(rs.Attributes["droplet_id"])
+					if err != nil {
+						return err
+					}
+
+					client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+					foundFloatingIP, _, err := client.FloatingIPs.Get(context.Background(), flipID)
+					if err != nil {
+						return err
+					}
+
+					if foundFloatingIP.IP != flipID || foundFloatingIP.Droplet.ID != dropletID {
+						return fmt.Errorf("wrong floating IP attachment found")
+					}
+
+					return nil
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "192.0.2.1",
+				ExpectError:       regexp.MustCompile("joined with a comma"),
+			},
+		},
+	})
+}
+
+func testAccFLIPAssignmentImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		flip := rs.Primary.Attributes["ip_address"]
+		droplet := rs.Primary.Attributes["droplet_id"]
+
+		return fmt.Sprintf("%s,%s", flip, droplet), nil
+	}
+}

--- a/digitalocean/resource_digitalocean_floating_ip_assignment_test.go
+++ b/digitalocean/resource_digitalocean_floating_ip_assignment_test.go
@@ -90,10 +90,10 @@ func testAccCheckDigitalOceanFloatingIPAttachmentExists(n string) resource.TestC
 		}
 
 		if rs.Primary.Attributes["ip_address"] == "" {
-			return fmt.Errorf("No Record ID is set")
+			return fmt.Errorf("No floating IP is set")
 		}
 		fipID := rs.Primary.Attributes["ip_address"]
-		dropletId, err := strconv.Atoi(rs.Primary.Attributes["droplet_id"])
+		dropletID, err := strconv.Atoi(rs.Primary.Attributes["droplet_id"])
 		if err != nil {
 			return err
 		}
@@ -106,8 +106,8 @@ func testAccCheckDigitalOceanFloatingIPAttachmentExists(n string) resource.TestC
 			return err
 		}
 
-		if foundFloatingIP.IP != fipID || foundFloatingIP.Droplet.ID != dropletId {
-			return fmt.Errorf("Wrong volume attachment found")
+		if foundFloatingIP.IP != fipID || foundFloatingIP.Droplet.ID != dropletID {
+			return fmt.Errorf("wrong floating IP attachment found")
 		}
 
 		return nil

--- a/docs/resources/floating_ip_assignment.md
+++ b/docs/resources/floating_ip_assignment.md
@@ -36,3 +36,12 @@ The following arguments are supported:
 
 * `ip_address` - (Required) The Floating IP to assign to the Droplet.
 * `droplet_id` - (Optional) The ID of Droplet that the Floating IP will be assigned to.
+
+## Import
+
+Floating IP assignments can be imported using the Floating IP itself and the `id` of
+the Droplet joined with a comma. For example:
+
+```
+terraform import digitalocean_floating_ip_assignment.foobar 192.0.2.1,123456
+```


### PR DESCRIPTION
`floating_ip_assignment` resources currently use [`schema.ImportStatePassthrough`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema#ImportStatePassthroughContext) for importing. This is meant for use when an ID-only refresh is possible. It would have never worked for this resource which needs both the floating IP and the Droplet ID. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/763