### PR TITLE
Fetch loadbalancer resource in datasource by ID

### DIFF
--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -15,11 +15,19 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 		ReadContext: dataSourceDigitalOceanLoadbalancerRead,
 		Schema: map[string]*schema.Schema{
 
+			"id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "id of the load balancer",
+				ValidateFunc: validation.NoZeroValues,
+				ExactlyOneOf: []string{"id", "name"},
+			},
 			"name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  "name of the load balancer",
 				ValidateFunc: validation.NoZeroValues,
+				ExactlyOneOf: []string{"id", "name"},
 			},
 			// computed attributes
 			"urn": {
@@ -214,75 +222,87 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 func dataSourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*CombinedConfig).godoClient()
 
-	name := d.Get("name").(string)
+	var foundLoadbalancer *godo.LoadBalancer
 
-	opts := &godo.ListOptions{
-		Page:    1,
-		PerPage: 200,
-	}
-
-	lbList := []godo.LoadBalancer{}
-
-	for {
-		lbs, resp, err := client.LoadBalancers.List(context.Background(), opts)
-
+	if id, ok := d.GetOk("id"); ok {
+		loadbalancer, _, err := client.LoadBalancers.Get(context.Background(), id.(string))
 		if err != nil {
-			return diag.Errorf("Error retrieving load balancers: %s", err)
+			return diag.FromErr(err)
 		}
 
-		lbList = append(lbList, lbs...)
-
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
+		foundLoadbalancer = loadbalancer
+	} else if name, ok := d.GetOk("name"); ok {
+		opts := &godo.ListOptions{
+			Page:    1,
+			PerPage: 200,
 		}
 
-		page, err := resp.Links.CurrentPage()
+		lbList := []godo.LoadBalancer{}
+
+		for {
+			lbs, resp, err := client.LoadBalancers.List(context.Background(), opts)
+
+			if err != nil {
+				return diag.Errorf("Error retrieving load balancers: %s", err)
+			}
+
+			lbList = append(lbList, lbs...)
+
+			if resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				return diag.Errorf("Error retrieving load balancers: %s", err)
+			}
+
+			opts.Page = page + 1
+		}
+
+		loadbalancer, err := findLoadBalancerByName(lbList, name.(string))
 		if err != nil {
-			return diag.Errorf("Error retrieving load balancers: %s", err)
+			return diag.FromErr(err)
 		}
 
-		opts.Page = page + 1
+		foundLoadbalancer = loadbalancer
+	} else {
+		return diag.Errorf("Error: specify either a name, or id to use to look up the load balancer")
 	}
 
-	loadbalancer, err := findLoadBalancerByName(lbList, name)
-
-	if err != nil {
-		return diag.FromErr(err)
+	d.SetId(foundLoadbalancer.ID)
+	d.Set("name", foundLoadbalancer.Name)
+	d.Set("urn", foundLoadbalancer.URN())
+	d.Set("region", foundLoadbalancer.Region.Slug)
+	if foundLoadbalancer.SizeUnit > 0 {
+		d.Set("size_unit", foundLoadbalancer.SizeUnit)
+	} else if foundLoadbalancer.SizeSlug != "" {
+		d.Set("size", foundLoadbalancer.SizeSlug)
 	}
 
-	d.SetId(loadbalancer.ID)
-	d.Set("name", loadbalancer.Name)
-	d.Set("urn", loadbalancer.URN())
-	d.Set("region", loadbalancer.Region.Slug)
-	if loadbalancer.SizeUnit > 0 {
-		d.Set("size_unit", loadbalancer.SizeUnit)
-	} else if loadbalancer.SizeSlug != "" {
-		d.Set("size", loadbalancer.SizeSlug)
-	}
+	d.Set("ip", foundLoadbalancer.IP)
+	d.Set("algorithm", foundLoadbalancer.Algorithm)
+	d.Set("status", foundLoadbalancer.Status)
+	d.Set("droplet_tag", foundLoadbalancer.Tag)
+	d.Set("redirect_http_to_https", foundLoadbalancer.RedirectHttpToHttps)
+	d.Set("enable_proxy_protocol", foundLoadbalancer.EnableProxyProtocol)
+	d.Set("enable_backend_keepalive", foundLoadbalancer.EnableBackendKeepalive)
+	d.Set("disable_lets_encrypt_dns_records", foundLoadbalancer.DisableLetsEncryptDNSRecords)
+	d.Set("vpc_uuid", foundLoadbalancer.VPCUUID)
 
-	d.Set("ip", loadbalancer.IP)
-	d.Set("algorithm", loadbalancer.Algorithm)
-	d.Set("status", loadbalancer.Status)
-	d.Set("droplet_tag", loadbalancer.Tag)
-	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
-	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
-	d.Set("enable_backend_keepalive", loadbalancer.EnableBackendKeepalive)
-	d.Set("disable_lets_encrypt_dns_records", loadbalancer.DisableLetsEncryptDNSRecords)
-	d.Set("vpc_uuid", loadbalancer.VPCUUID)
-
-	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {
+	if err := d.Set("droplet_ids", flattenDropletIds(foundLoadbalancer.DropletIDs)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting Load Balancer droplet_ids - error: %#v", err)
 	}
 
-	if err := d.Set("sticky_sessions", flattenStickySessions(loadbalancer.StickySessions)); err != nil {
+	if err := d.Set("sticky_sessions", flattenStickySessions(foundLoadbalancer.StickySessions)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting Load Balancer sticky_sessions - error: %#v", err)
 	}
 
-	if err := d.Set("healthcheck", flattenHealthChecks(loadbalancer.HealthCheck)); err != nil {
+	if err := d.Set("healthcheck", flattenHealthChecks(foundLoadbalancer.HealthCheck)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting Load Balancer healthcheck - error: %#v", err)
 	}
 
-	forwardingRules, err := flattenForwardingRules(client, loadbalancer.ForwardingRules)
+	forwardingRules, err := flattenForwardingRules(client, foundLoadbalancer.ForwardingRules)
 	if err != nil {
 		return diag.Errorf("[DEBUG] Error building Load Balancer forwarding rules - error: %#v", err)
 	}

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
+func TestAccDataSourceDigitalOceanLoadBalancer_BasicByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := randomTestName()
 	resourceConfig := testAccCheckDataSourceDigitalOceanLoadBalancerConfig(testName, "lb-small")
@@ -76,7 +76,71 @@ data "digitalocean_loadbalancer" "foobar" {
 	})
 }
 
-func TestAccDataSourceDigitalOceanLoadBalancer_Large(t *testing.T) {
+func TestAccDataSourceDigitalOceanLoadBalancer_BasicById(t *testing.T) {
+	var loadbalancer godo.LoadBalancer
+	testName := randomTestName()
+	resourceConfig := testAccCheckDataSourceDigitalOceanLoadBalancerConfig(testName, "lb-small")
+	dataSourceConfig := `
+data "digitalocean_loadbalancer" "foobar" {
+  id = digitalocean_loadbalancer.foo.id
+}`
+
+	expectedURNRegEx, _ := regexp.Compile(`do:loadbalancer:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+			},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanLoadBalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "name", testName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "size_unit", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.digitalocean_loadbalancer.foobar",
+						"forwarding_rule.*",
+						map[string]string{
+							"entry_port":      "80",
+							"entry_protocol":  "http",
+							"target_port":     "80",
+							"target_protocol": "http",
+						},
+					),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.0.port", "22"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "droplet_ids.#", "2"),
+					resource.TestMatchResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "urn", expectedURNRegEx),
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_loadbalancer.foobar", "vpc_uuid"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "disable_lets_encrypt_dns_records", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanLoadBalancer_LargeByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := randomTestName()
 	resourceConfig := testAccCheckDataSourceDigitalOceanLoadBalancerConfig(testName, "lb-large")
@@ -138,7 +202,69 @@ data "digitalocean_loadbalancer" "foobar" {
 	})
 }
 
-func TestAccDataSourceDigitalOceanLoadBalancer_Size2(t *testing.T) {
+func TestAccDataSourceDigitalOceanLoadBalancer_LargeById(t *testing.T) {
+	var loadbalancer godo.LoadBalancer
+	testName := randomTestName()
+	resourceConfig := testAccCheckDataSourceDigitalOceanLoadBalancerConfig(testName, "lb-large")
+	dataSourceConfig := `
+data "digitalocean_loadbalancer" "foobar" {
+  id = digitalocean_loadbalancer.foo.id
+}`
+
+	expectedURNRegEx, _ := regexp.Compile(`do:loadbalancer:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+			},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanLoadBalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "name", testName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "size_unit", "6"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.digitalocean_loadbalancer.foobar",
+						"forwarding_rule.*",
+						map[string]string{
+							"entry_port":      "80",
+							"entry_protocol":  "http",
+							"target_port":     "80",
+							"target_protocol": "http",
+						},
+					),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.0.port", "22"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "droplet_ids.#", "2"),
+					resource.TestMatchResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "urn", expectedURNRegEx),
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_loadbalancer.foobar", "vpc_uuid"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanLoadBalancer_Size2ByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := randomTestName()
 	resourceConfig := testAccCheckDataSourceDigitalOceanLoadBalancerConfigSizeUnit(testName, 2)
@@ -200,7 +326,69 @@ data "digitalocean_loadbalancer" "foobar" {
 	})
 }
 
-func TestAccDataSourceDigitalOceanLoadBalancer_multipleRules(t *testing.T) {
+func TestAccDataSourceDigitalOceanLoadBalancer_Size2ById(t *testing.T) {
+	var loadbalancer godo.LoadBalancer
+	testName := randomTestName()
+	resourceConfig := testAccCheckDataSourceDigitalOceanLoadBalancerConfigSizeUnit(testName, 2)
+	dataSourceConfig := `
+data "digitalocean_loadbalancer" "foobar" {
+  id = digitalocean_loadbalancer.foo.id
+}`
+
+	expectedURNRegEx, _ := regexp.Compile(`do:loadbalancer:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+			},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanLoadBalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "name", testName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "size_unit", "2"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.digitalocean_loadbalancer.foobar",
+						"forwarding_rule.*",
+						map[string]string{
+							"entry_port":      "80",
+							"entry_protocol":  "http",
+							"target_port":     "80",
+							"target_protocol": "http",
+						},
+					),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.0.port", "22"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "healthcheck.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "droplet_ids.#", "2"),
+					resource.TestMatchResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "urn", expectedURNRegEx),
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_loadbalancer.foobar", "vpc_uuid"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := randomTestName()
 	resourceConfig := testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(testName)
@@ -255,7 +443,62 @@ data "digitalocean_loadbalancer" "foobar" {
 	})
 }
 
-func TestAccDataSourceDigitalOceanLoadBalancer_tlsCert(t *testing.T) {
+func TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesById(t *testing.T) {
+	var loadbalancer godo.LoadBalancer
+	testName := randomTestName()
+	resourceConfig := testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(testName)
+	dataSourceConfig := `
+data "digitalocean_loadbalancer" "foobar" {
+  id = digitalocean_loadbalancer.foobar.id
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+			},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "name", testName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "size_unit", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.digitalocean_loadbalancer.foobar",
+						"forwarding_rule.*",
+						map[string]string{
+							"entry_port":      "443",
+							"entry_protocol":  "https",
+							"target_port":     "443",
+							"target_protocol": "https",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.digitalocean_loadbalancer.foobar",
+						"forwarding_rule.*",
+						map[string]string{
+							"entry_port":      "80",
+							"entry_protocol":  "http",
+							"target_port":     "80",
+							"target_protocol": "http",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanLoadBalancer_tlsCertByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := randomTestName()
 	rInt := acctest.RandInt()
@@ -266,6 +509,61 @@ func TestAccDataSourceDigitalOceanLoadBalancer_tlsCert(t *testing.T) {
 	dataSourceConfig := `
 data "digitalocean_loadbalancer" "foobar" {
   name = digitalocean_loadbalancer.foobar.name
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+			},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanLoadbalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.digitalocean_loadbalancer.foobar",
+						"forwarding_rule.*",
+						map[string]string{
+							"entry_port":       "443",
+							"entry_protocol":   "https",
+							"target_port":      "80",
+							"target_protocol":  "http",
+							"certificate_name": testName + "-cert",
+							"tls_passthrough":  "false",
+						},
+					),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "size_unit", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "redirect_http_to_https", "true"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanLoadBalancer_tlsCertById(t *testing.T) {
+	var loadbalancer godo.LoadBalancer
+	testName := randomTestName()
+	rInt := acctest.RandInt()
+	privateKeyMaterial, leafCertMaterial, certChainMaterial := generateTestCertMaterial(t)
+	resourceConfig := testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(
+		testName+"-cert", rInt, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name",
+	)
+	dataSourceConfig := `
+data "digitalocean_loadbalancer" "foobar" {
+  id = digitalocean_loadbalancer.foobar.id
 }`
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -641,7 +641,7 @@ func testAccCheckDataSourceDigitalOceanLoadBalancerExists(n string, loadbalancer
 func testAccCheckDataSourceDigitalOceanLoadBalancerConfig(testName string, sizeSlug string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_tag" "foo" {
-  name = "web"
+  name = "%s"
 }
 
 resource "digitalocean_droplet" "foo" {
@@ -674,13 +674,13 @@ resource "digitalocean_loadbalancer" "foo" {
 
   droplet_tag = digitalocean_tag.foo.id
   depends_on  = ["digitalocean_droplet.foo"]
-}`, testName, testName, sizeSlug)
+}`, testName, testName, testName, sizeSlug)
 }
 
 func testAccCheckDataSourceDigitalOceanLoadBalancerConfigSizeUnit(testName string, sizeUnit uint32) string {
 	return fmt.Sprintf(`
 resource "digitalocean_tag" "foo" {
-  name = "web"
+  name = "%s"
 }
 
 resource "digitalocean_droplet" "foo" {
@@ -713,5 +713,5 @@ resource "digitalocean_loadbalancer" "foo" {
 
   droplet_tag = digitalocean_tag.foo.id
   depends_on  = ["digitalocean_droplet.foo"]
-}`, testName, testName, sizeUnit)
+}`, testName, testName, testName, sizeUnit)
 }

--- a/docs/data-sources/loadbalancer.md
+++ b/docs/data-sources/loadbalancer.md
@@ -13,7 +13,7 @@ An error is triggered if the provided load balancer name does not exist.
 
 ## Example Usage
 
-Get the load balancer:
+Get the load balancer by name:
 
 ```hcl
 data "digitalocean_loadbalancer" "example" {
@@ -25,11 +25,20 @@ output "lb_output" {
 }
 ```
 
+Get the load balancer by ID:
+
+```hcl
+data "digitalocean_loadbalancer" "example" {
+  id = "loadbalancer_id"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of load balancer.
+* `name` - (Optional) The name of load balancer.
+* `id` - (Optional) The ID of load balancer.
 * `urn` - The uniform resource name for the Load Balancer
 
 ## Attributes Reference


### PR DESCRIPTION
Issue: https://github.com/digitalocean/terraform-provider-digitalocean/issues/772

Currently we can fetch loadbalancer resource in datasource by only its name.
https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/loadbalancer

By this update, we will be able to fetch loadbalancer resource by its ID in addition to name like below.

```
data "digitalocean_loadbalancer" "example" {
  id = "loadbalancer_id"
}
```

This update is referring to the following droplet datasource.
https://github.com/digitalocean/terraform-provider-digitalocean/blob/main/digitalocean/datasource_digitalocean_droplet.go#L40