### PR TITLE
droplet: Refactor post-create polling code.

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -721,6 +721,7 @@ func waitForDropletAttribute(
 func newDropletStateRefreshFunc(
 	ctx context.Context, d *schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
 	client := meta.(*CombinedConfig).godoClient()
+	dropletID := d.Id()
 	return func() (interface{}, string, error) {
 		id, err := strconv.Atoi(d.Id())
 		if err != nil {
@@ -732,6 +733,8 @@ func newDropletStateRefreshFunc(
 		if diags.HasError() {
 			return nil, "", err
 		}
+		// On 404 response resourceDigitalOceanDropletRead() will unset ID while we want it to remain set.
+		d.SetId(dropletID)
 
 		// If the droplet is locked, continue waiting. We can
 		// only perform actions on unlocked droplets, so it's

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -174,9 +174,9 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "name", fmt.Sprintf("baz-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
+						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "disk", "30"),
+						"digitalocean_droplet.foobar", "disk", "50"),
 				),
 			},
 		},
@@ -210,9 +210,9 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
+						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "disk", "20"),
+						"digitalocean_droplet.foobar", "disk", "25"),
 				),
 			},
 		},
@@ -237,7 +237,7 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 				),
 			},
-
+			// Test moving to larger plan with resize_disk = false only increases RAM, not disk.
 			{
 				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -246,12 +246,12 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
+						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "disk", "20"),
+						"digitalocean_droplet.foobar", "disk", "25"),
 				),
 			},
-
+			// Test that we can downgrade a Droplet plan as long as the disk remains the same
 			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -262,10 +262,10 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "disk", "20"),
+						"digitalocean_droplet.foobar", "disk", "25"),
 				),
 			},
-
+			// Test that resizing resize_disk = true increases the disk
 			{
 				Config: testAccCheckDigitalOceanDropletConfig_resize(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -274,9 +274,9 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
+						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "disk", "30"),
+						"digitalocean_droplet.foobar", "disk", "50"),
 				),
 			},
 		},
@@ -736,11 +736,11 @@ func testAccCheckDigitalOceanDropletAttributes(droplet *godo.Droplet) resource.T
 func testAccCheckDigitalOceanDropletRenamedAndResized(droplet *godo.Droplet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if droplet.Size.Slug != "s-1vcpu-1gb" {
+		if droplet.Size.Slug != "s-1vcpu-2gb" {
 			return fmt.Errorf("Bad size_slug: %s", droplet.SizeSlug)
 		}
 
-		if droplet.Disk != 30 {
+		if droplet.Disk != 50 {
 			return fmt.Errorf("Bad disk: %d", droplet.Disk)
 		}
 
@@ -751,11 +751,11 @@ func testAccCheckDigitalOceanDropletRenamedAndResized(droplet *godo.Droplet) res
 func testAccCheckDigitalOceanDropletResizeWithOutDisk(droplet *godo.Droplet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if droplet.Size.Slug != "s-1vcpu-1gb" {
+		if droplet.Size.Slug != "s-1vcpu-2gb" {
 			return fmt.Errorf("Bad size_slug: %s", droplet.SizeSlug)
 		}
 
-		if droplet.Disk != 20 {
+		if droplet.Disk != 25 {
 			return fmt.Errorf("Bad disk: %d", droplet.Disk)
 		}
 
@@ -766,11 +766,11 @@ func testAccCheckDigitalOceanDropletResizeWithOutDisk(droplet *godo.Droplet) res
 func testAccCheckDigitalOceanDropletResizeSmaller(droplet *godo.Droplet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if droplet.Size.Slug != "s-1vcpu-1gb" {
+		if droplet.Size.Slug != "s-1vcpu-2gb" {
 			return fmt.Errorf("Bad size_slug: %s", droplet.SizeSlug)
 		}
 
-		if droplet.Disk != 30 {
+		if droplet.Disk != 50 {
 			return fmt.Errorf("Bad disk: %d", droplet.Disk)
 		}
 
@@ -940,7 +940,7 @@ func testAccCheckDigitalOceanDropletConfig_RenameAndResize(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name     = "baz-%d"
-  size     = "s-1vcpu-1gb"
+  size     = "s-1vcpu-2gb"
   image    = "centos-8-x64"
   region   = "nyc3"
 }
@@ -951,7 +951,7 @@ func testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt int) string 
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name     = "foo-%d"
-  size     = "s-1vcpu-1gb"
+  size     = "s-1vcpu-2gb"
   image    = "centos-8-x64"
   region   = "nyc3"
   user_data = "foobar"
@@ -964,7 +964,7 @@ func testAccCheckDigitalOceanDropletConfig_resize(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name     = "foo-%d"
-  size     = "s-1vcpu-1gb"
+  size     = "s-1vcpu-2gb"
   image    = "centos-8-x64"
   region   = "nyc3"
   user_data = "foobar"


### PR DESCRIPTION
This PR refactors the code used to poll a Droplet's status after the request to create it. https://github.com/digitalocean/terraform-provider-digitalocean/pull/767 points out one issue with the existing implementation, but it also exposes another issue with it. So I've taken the opportunity to fix those and make the entire process more efficient.

It now first uses `waitForAction` to ensure that the Droplet create action completes successfully. This allows us to fail fast in the case of a real error instead of continuing to poll the non-existent Droplet. Polling the action endpoint allows for an error to be reported while polling the droplet endpoint just 404s (which we retry on) if the create fails.

The call to `waitForDropletAttribute` checking for the Droplet's `status` attribute to move from `new` to `active` is still made after that. This is possibly unnecessary, but I've kept it to make sure we don't introduce any unexpected behavior changes. (I'm not 100% positive that the action completing is entirely equivalent to the Droplet becoming active.)

It also removes the usage of `resourceDigitalOceanDropletRead` in `dropletStateRefreshFunc` in order to reduce the overall number of API calls made. Currently in `main`, each pass through `newDropletStateRefreshFunc` actually calls `client.Droplets.Get` twice. The final call in `resourceDigitalOceanDropletCreate` to `resourceDigitalOceanDropletRead` is also removed to cut another redundant API call.

So while this now makes calls to both the actions and droplets endpoints to make sure the Droplet has been successfully created, it is still more efficient and reduces the overall number of API call made substantially.

Additionally, there are a number of unrelated fixes to the Droplet acceptance tests so that they all now pass. These failure seem to be the result of moving the tests from using legacy Droplet plans to new ones without updating the expected disk sizes.
