### PR TITLE
Add MONGODB as a database engine option

### DIFF
--- a/digitalocean/app_spec.go
+++ b/digitalocean/app_spec.go
@@ -623,6 +623,7 @@ func appSpecDatabaseSchema() *schema.Resource {
 					"MYSQL",
 					"PG",
 					"REDIS",
+					"MONGODB",
 				}, false),
 				Description: "The database engine to use.",
 			},

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -184,7 +184,7 @@ A `job` can contain:
 A `database` can contain:
 
 * `name` - The name of the component.
-* `engine` - The database engine to use (`MYSQL`, `PG`, or `REDIS`).
+* `engine` - The database engine to use (`MYSQL`, `PG`, `REDIS`, or `MONGODB`).
 * `version` - The version of the database engine.
 * `production` - Whether this is a production or dev database.
 * `cluster_name` - The name of the underlying DigitalOcean DBaaS cluster. This is required for production databases. For dev databases, if `cluster_name` is not set, a new cluster will be provisioned.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -306,7 +306,7 @@ A `job` can contain:
 A `database` can contain:
 
 * `name` - The name of the component.
-* `engine` - The database engine to use (`MYSQL`, `PG`, or `REDIS`).
+* `engine` - The database engine to use (`MYSQL`, `PG`, `REDIS`, or `MONGODB`).
 * `version` - The version of the database engine.
 * `production` - Whether this is a production or dev database.
 * `cluster_name` - The name of the underlying DigitalOcean DBaaS cluster. This is required for production databases. For dev databases, if `cluster_name` is not set, a new cluster will be provisioned.


### PR DESCRIPTION
This change adds `MONGODB` as an `engine` option to the `databases` block of an App spec. It's necessary for anyone wishing to attach an already-existing managed MongoDB cluster to an App Platform app.

From the [DigitalOcean docs](https://docs.digitalocean.com/products/app-platform/#limits): 

> App Platform’s engine support for dev databases is currently limited to PostgresSQL, but you can create a PostgresSQL, MySQL, Redis, or MongoDB managed database with DigitalOcean for use in your app.

Here's a working plan file that uses this change to provision a managed MongoDB cluster and then an App Platform app with a named reference (`db`) to it:

```tf
terraform {
  required_providers {
    digitalocean = {
      source = "digitalocean/digitalocean"
      version = "~> 2.0"
    }
  }
}

variable "do_token" {
    type = string
}

provider "digitalocean" {
  token = var.do_token
}

resource "digitalocean_database_cluster" "cluster" {
  name       = "some-cluster"
  engine     = "mongodb"
  version    = "4"
  size       = "db-s-1vcpu-1gb"
  region     = "sfo3"
  node_count = 1
}

resource "digitalocean_app" "app" {
  spec {
    name   = "some-app"
    region = "sfo3"

    database {
      cluster_name = digitalocean_database_cluster.cluster.name
      name         = "db"
      engine       = "MONGODB"
      production   = true
    }
  }
}
```

```
$ terraform apply

digitalocean_database_cluster.cluster: Creating...
digitalocean_database_cluster.cluster: Still creating... [10s elapsed]
...
digitalocean_database_cluster.cluster: Creation complete after 6m8s [id=ce4e5dd1-0927-4e55-adab-6b03347ac280]
digitalocean_app.app: Creating...
digitalocean_app.app: Still creating... [10s elapsed]
digitalocean_app.app: Creation complete after 33s [id=df979d07-53cc-4697-a782-e5a79a3a7339]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

<img width="658" alt="image" src="https://user-images.githubusercontent.com/274700/151568011-155a3254-7610-491c-8e44-8a49d197abb9.png">
