### PR TITLE
projects: Environment is optional, don't set default.

### DIFF
--- a/digitalocean/import_digitalocean_project_test.go
+++ b/digitalocean/import_digitalocean_project_test.go
@@ -1,0 +1,30 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDigitalOceanProject_importBasic(t *testing.T) {
+	name := generateProjectName()
+	resourceName := "digitalocean_project.myproj"
+	createConfig := fixtureCreateWithDefaults(name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -49,7 +49,6 @@ func resourceDigitalOceanProject() *schema.Resource {
 			"environment": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "Development",
 				Description:  "the environment of the project's resources",
 				ValidateFunc: validation.StringInSlice([]string{"development", "staging", "production"}, true),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {

--- a/digitalocean/resource_digitalocean_project_test.go
+++ b/digitalocean/resource_digitalocean_project_test.go
@@ -31,7 +31,7 @@ func TestAccDigitalOceanProject_CreateWithDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_project.myproj", "purpose", "Web Application"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_project.myproj", "environment", "Development"),
+						"digitalocean_project.myproj", "environment", ""),
 					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "id"),
 					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "owner_uuid"),
 					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "owner_id"),


### PR DESCRIPTION
Setting a default value for an optional filed can create an issue when importing a resource with that field not set. For projects, the environment is optional. 

We were missing an import test, but that wouldn't have actually caught this as the resource being imported would have been created by Terraform and thus would have had the default set. :upside_down_face: 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/787