### PR TITLE
load-balancers: support udp as a target and entry protocol

### DIFF
--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -185,6 +185,7 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 								"https",
 								"http2",
 								"tcp",
+								"udp",
 							}, false),
 						},
 						"entry_port": {
@@ -200,6 +201,7 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 								"https",
 								"http2",
 								"tcp",
+								"udp",
 							}, false),
 						},
 						"target_port": {


### PR DESCRIPTION
This adds UDP as a target and entry protocol for DigitalOcean Load Balancers.