### PR TITLE
docs: add default ttl to `digitalocean_record`

### DIFF
--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `port` - (Optional) The port of the record. Only valid when type is `SRV`.  Must be between 1 and 65535.
 * `priority` - (Optional) The priority of the record. Only valid when type is `MX` or `SRV`. Must be between 0 and 65535.
 * `weight` - (Optional) The weight of the record. Only valid when type is `SRV`.  Must be between 0 and 65535.
-* `ttl` - (Optional) The time to live for the record, in seconds. Must be at least 0.
+* `ttl` - (Optional) The time to live for the record, in seconds. Must be at least 0. Defaults to 1800.
 * `flags` - (Optional) The flags of the record. Only valid when type is `CAA`. Must be between 0 and 255.
 * `tag` - (Optional) The tag of the record. Only valid when type is `CAA`. Must be one of `issue`, `issuewild`, or `iodef`.
 


### PR DESCRIPTION
figured it out myself and thought it might be helpful in the docs.