### PR TITLE
Do not change the state of tags and labels when they are not defined

### DIFF
--- a/digitalocean/kubernetes.go
+++ b/digitalocean/kubernetes.go
@@ -189,6 +189,10 @@ func expandLabels(labels map[string]interface{}) map[string]string {
 }
 
 func flattenLabels(labels map[string]string) map[string]interface{} {
+	if labels == nil {
+		return nil
+	}
+
 	flattenedLabels := make(map[string]interface{})
 	for key, value := range labels {
 		flattenedLabels[key] = value

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -703,6 +703,10 @@ func renderKubeconfig(name string, region string, creds *godo.KubernetesClusterC
 // we need to filter tags to remove any automatically added to avoid state problems,
 // these are tags starting with "k8s:" or named "k8s"
 func filterTags(tags []string) []string {
+	if tags == nil {
+		return nil
+	}
+
 	filteredTags := make([]string, 0)
 	for _, t := range tags {
 		if !strings.HasPrefix(t, "k8s:") &&


### PR DESCRIPTION
We cannot change the state of `tags` and `labels` when they are not defined to kubernetes resources.

When a user create a kubernetes cluster or a pool of nodes without set the `tags` and `lables`, the state of tags and labels of resource will be saved as empty array [] or empty map {}. 

But when update another parameters of this resources and the read function runs, the schema will be show that the local state is different, given that in remote api of digitalocean return `null`.

 This PR can fix this behavior.