### PR TITLE
docs: Note limitations on importing MongoDB users.

### DIFF
--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -50,3 +50,5 @@ and the `name` of the user joined with a comma. For example:
 ```
 terraform import digitalocean_database_user.user-example 245bcfd0-7f31-4ce6-a2bc-475a116cca97,foobar
 ```
+
+~> **Note:** MongoDB user passwords are only available when the user is created. An existing MongoDB user that is imported will not have its `password` attribute exported. Recreate the user if it is necessary to access the password with Terraform.


### PR DESCRIPTION
Document the limitations on importing MongoDB users discussed in https://github.com/digitalocean/terraform-provider-digitalocean/issues/814