### PR TITLE
digitalocean_kubernetes_cluster: fix k8s versions in acceptance tests

### DIFF
--- a/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 	expectedURNRegEx, _ := regexp.Compile(`do:kubernetes:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
-	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersion19, rName)
+	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersion22, rName)
 	dataSourceConfig := `
 data "digitalocean_kubernetes_cluster" "foobar" {
 	name = digitalocean_kubernetes_cluster.foo.name

--- a/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 	expectedURNRegEx, _ := regexp.Compile(`do:kubernetes:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
-	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersion22, rName)
+	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersionLatest, rName)
 	dataSourceConfig := `
 data "digitalocean_kubernetes_cluster" "foobar" {
 	name = digitalocean_kubernetes_cluster.foo.name

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -21,7 +21,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, clusterName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionLatest, clusterName),
 				// Remove the default node pool tag so that the import code which infers
 				// the need to add the tag gets triggered.
 				Check: testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
@@ -112,7 +112,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testClusterVersion22, testName1, testName2)
+`, testClusterVersionLatest, testName1, testName2)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -21,7 +21,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, clusterName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, clusterName),
 				// Remove the default node pool tag so that the import code which infers
 				// the need to add the tag gets triggered.
 				Check: testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
@@ -112,7 +112,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testClusterVersion19, testName1, testName2)
+`, testClusterVersion22, testName1, testName2)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -32,7 +32,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testClusterVersion19, testName1, testName2)
+`, testClusterVersion22, testName1, testName2)
 	resourceName := "digitalocean_kubernetes_node_pool.barfoo"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -32,7 +32,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testClusterVersion22, testName1, testName2)
+`, testClusterVersionLatest, testName1, testName2)
 	resourceName := "digitalocean_kubernetes_node_pool.barfoo"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -17,14 +17,11 @@ import (
 )
 
 const (
-	testClusterVersion18 = `data "digitalocean_kubernetes_versions" "test" {
-  version_prefix = "1.18."
-}`
-	testClusterVersion19 = `data "digitalocean_kubernetes_versions" "test" {
-  version_prefix = "1.19."
-}`
 	testClusterVersion21 = `data "digitalocean_kubernetes_versions" "test" {
   version_prefix = "1.21."
+}`
+	testClusterVersion22 = `data "digitalocean_kubernetes_versions" "test" {
+  version_prefix = "1.22."
 }`
 )
 
@@ -74,7 +71,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -140,7 +137,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
         priority = "high"
       }
 	}
-}`, testClusterVersion19, rName),
+}`, testClusterVersion22, rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.#", "3"),
@@ -178,7 +175,7 @@ func TestAccDigitalOceanKubernetesCluster_CreateWithHAControlPlane(t *testing.T)
 							node_count = 1
 						}
 					}
-				`, testClusterVersion21, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -206,14 +203,14 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion19, rName+"-updated"),
+				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion22, rName+"-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName+"-updated"),
@@ -252,7 +249,7 @@ func TestAccDigitalOceanKubernetesCluster_MaintenancePolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion19, rName, policy),
+				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion22, rName, policy),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -262,7 +259,7 @@ func TestAccDigitalOceanKubernetesCluster_MaintenancePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion19, rName, updatedPolicy),
+				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion22, rName, updatedPolicy),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -285,7 +282,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -296,7 +293,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -324,7 +321,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -335,7 +332,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -381,7 +378,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							day = "sunday"
 						}
 					}
-				`, testClusterVersion19, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -415,7 +412,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion19, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -446,7 +443,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion19, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -474,7 +471,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							node_count = 2
 						}
 					}
-				`, testClusterVersion19, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -515,7 +512,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 						node_count = 1
 					}
 				}
-			`, testClusterVersion19, rName),
+			`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -546,7 +543,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion19, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -576,7 +573,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion19, rName),
+				`, testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -609,7 +606,7 @@ func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s), resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.raw_config"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.cluster_ca_certificate"),
@@ -631,14 +628,14 @@ func TestAccDigitalOceanKubernetesCluster_UpgradeVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion18, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion21, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion19, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPtr("digitalocean_kubernetes_cluster.foobar", "id", &k8s.ID),
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	testClusterVersion21 = `data "digitalocean_kubernetes_versions" "test" {
+	testClusterVersionPrevious = `data "digitalocean_kubernetes_versions" "test" {
   version_prefix = "1.21."
 }`
-	testClusterVersion22 = `data "digitalocean_kubernetes_versions" "test" {
+	testClusterVersionLatest = `data "digitalocean_kubernetes_versions" "test" {
   version_prefix = "1.22."
 }`
 )
@@ -71,7 +71,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -137,7 +137,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
         priority = "high"
       }
 	}
-}`, testClusterVersion22, rName),
+}`, testClusterVersionLatest, rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.#", "3"),
@@ -175,7 +175,7 @@ func TestAccDigitalOceanKubernetesCluster_CreateWithHAControlPlane(t *testing.T)
 							node_count = 1
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -203,14 +203,14 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion22, rName+"-updated"),
+				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersionLatest, rName+"-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName+"-updated"),
@@ -249,7 +249,7 @@ func TestAccDigitalOceanKubernetesCluster_MaintenancePolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion22, rName, policy),
+				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersionLatest, rName, policy),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -259,7 +259,7 @@ func TestAccDigitalOceanKubernetesCluster_MaintenancePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion22, rName, updatedPolicy),
+				Config: testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersionLatest, rName, updatedPolicy),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -282,7 +282,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -293,7 +293,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -321,7 +321,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -332,7 +332,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -378,7 +378,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							day = "sunday"
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -391,7 +391,6 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.max_nodes", "3"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "auto_upgrade", "true"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.day", "sunday"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.duration", "04:00"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.start_time", "05:00"),
 				),
 			},
@@ -412,7 +411,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -443,7 +442,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -471,7 +470,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							node_count = 2
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -512,7 +511,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 						node_count = 1
 					}
 				}
-			`, testClusterVersion22, rName),
+			`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -543,7 +542,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -573,7 +572,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, testClusterVersion22, rName),
+				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -606,7 +605,7 @@ func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s), resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.raw_config"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.cluster_ca_certificate"),
@@ -628,14 +627,14 @@ func TestAccDigitalOceanKubernetesCluster_UpgradeVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion21, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionPrevious, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion22, rName),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPtr("digitalocean_kubernetes_cluster.foobar", "id", &k8s.ID),
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -29,7 +29,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 		tags  = ["one","two"]
 	}
 }
-`, testClusterVersion22, rName)
+`, testClusterVersionLatest, rName)
 
 	nodePoolConfig := fmt.Sprintf(`resource digitalocean_kubernetes_node_pool "barfoo" {
 	cluster_id = digitalocean_kubernetes_cluster.foobar.id
@@ -192,7 +192,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 5
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -230,7 +230,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -269,7 +269,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -305,7 +305,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 2
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -355,7 +355,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 1
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -394,7 +394,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -432,7 +432,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion22, rName, rName),
+				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -475,7 +475,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 	node_count = 1
 	tags  = ["three","four"]
 }
-`, testClusterVersion22, rName, rName)
+`, testClusterVersionLatest, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePoolTaint(rName string) string {
@@ -511,7 +511,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 		effect = "NoSchedule"
 	}
 }
-`, testClusterVersion22, rName, rName)
+`, testClusterVersionLatest, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePoolTaint2(rName string) string {
@@ -552,7 +552,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 		effect = "PreferNoSchedule"
 	}
 }
-`, testClusterVersion22, rName, rName)
+`, testClusterVersionLatest, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string {
@@ -583,7 +583,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
       priority = "high"
 	}
 }
-`, testClusterVersion22, rName, rName)
+`, testClusterVersionLatest, rName, rName)
 }
 
 func testAccCheckDigitalOceanKubernetesNodePoolExists(n string, cluster *godo.KubernetesCluster, pool *godo.KubernetesNodePool) resource.TestCheckFunc {

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -29,7 +29,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 		tags  = ["one","two"]
 	}
 }
-`, testClusterVersion19, rName)
+`, testClusterVersion22, rName)
 
 	nodePoolConfig := fmt.Sprintf(`resource digitalocean_kubernetes_node_pool "barfoo" {
 	cluster_id = digitalocean_kubernetes_cluster.foobar.id
@@ -192,7 +192,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 5
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -230,7 +230,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -269,7 +269,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -305,7 +305,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 2
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -355,7 +355,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 1
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -394,7 +394,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -432,7 +432,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, testClusterVersion19, rName, rName),
+				`, testClusterVersion22, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -475,7 +475,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 	node_count = 1
 	tags  = ["three","four"]
 }
-`, testClusterVersion19, rName, rName)
+`, testClusterVersion22, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePoolTaint(rName string) string {
@@ -511,7 +511,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 		effect = "NoSchedule"
 	}
 }
-`, testClusterVersion19, rName, rName)
+`, testClusterVersion22, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePoolTaint2(rName string) string {
@@ -552,7 +552,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 		effect = "PreferNoSchedule"
 	}
 }
-`, testClusterVersion19, rName, rName)
+`, testClusterVersion22, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string {
@@ -583,7 +583,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
       priority = "high"
 	}
 }
-`, testClusterVersion19, rName, rName)
+`, testClusterVersion22, rName, rName)
 }
 
 func testAccCheckDigitalOceanKubernetesNodePoolExists(n string, cluster *godo.KubernetesCluster, pool *godo.KubernetesNodePool) resource.TestCheckFunc {

--- a/docs/data-sources/kubernetes_versions.md
+++ b/docs/data-sources/kubernetes_versions.md
@@ -40,7 +40,7 @@ resource "digitalocean_kubernetes_cluster" "example-cluster" {
 
 ```hcl
 data "digitalocean_kubernetes_versions" "example" {
-  version_prefix = "1.16."
+  version_prefix = "1.22."
 }
 
 resource "digitalocean_kubernetes_cluster" "example-cluster" {

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -15,7 +15,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name   = "foo"
   region = "nyc1"
   # Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.20.2-do.0"
+  version = "1.22.8-do.1"
 
   node_pool {
     name       = "worker-pool"
@@ -40,7 +40,7 @@ For example:
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.20.2-do.0"
+  version = "1.22.8-do.1"
 
   node_pool {
     name       = "autoscale-worker-pool"
@@ -61,7 +61,7 @@ For example:
 
 ```hcl
 data "digitalocean_kubernetes_versions" "example" {
-  version_prefix = "1.18."
+  version_prefix = "1.22."
 }
 
 resource "digitalocean_kubernetes_cluster" "foo" {

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -14,7 +14,7 @@ Provides a DigitalOcean Kubernetes node pool resource. While the default node po
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.20.2-do.0"
+  version = "1.22.8-do.1"
 
   node_pool {
     name       = "front-end-pool"

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -23,7 +23,7 @@ Optionally, the Kubernetes version, the number of worker nodes, and the instance
 type of the worker nodes can also be specified:
 
 ```
-terraform apply -var=cluster_version=1.18 -var=worker_size=s-4vcpu-8gb -var=worker_count=5
+terraform apply -var=cluster_version=1.22 -var=worker_size=s-4vcpu-8gb -var=worker_count=5
 ```
 
 

--- a/examples/kubernetes/variables.tf
+++ b/examples/kubernetes/variables.tf
@@ -1,6 +1,6 @@
 
 variable "cluster_version" {
-  default = "1.19"
+  default = "1.22"
 }
 
 variable "worker_count" {


### PR DESCRIPTION
* update k8s versions used for tests
* docs: refresh example with current versions
* rename symbols to avoid mentioning specific versions and ease future tests maintenance

Closes #825