### PR TITLE
apps: Support functions components.

### DIFF
--- a/digitalocean/resource_digitalocean_app.go
+++ b/digitalocean/resource_digitalocean_app.go
@@ -180,15 +180,26 @@ func waitForAppDeployment(client *godo.Client, id string, timeout time.Duration)
 		}
 
 		if deploymentID == "" {
-			app, _, err := client.Apps.Get(context.Background(), id)
+			// The InProgressDeployment is generally not known and returned as
+			// part of the initial response to the request. For config updates
+			// (as opposed to updates to the app's source), the "deployment"
+			// can complete before the first time we poll the app. We can not
+			// know if the InProgressDeployment has not started or if it has
+			// already completed. So instead we need to list all of the
+			// deployments for the application.
+			deployments, err := listAppDeployments(client, id)
 			if err != nil {
 				return fmt.Errorf("Error trying to read app deployment state: %s", err)
 			}
 
-			if app.InProgressDeployment != nil {
-				deploymentID = app.InProgressDeployment.ID
+			// We choose the most recent deployment. Note that there is a possibility
+			// that the deployment has not been created yet. If that is true,
+			// we will do the wrong thing here and test the status of a previously
+			// completed deployment and exit. However there is no better way to
+			// correlate a deployment with the request that triggered it.
+			if len(deployments) > 0 {
+				deploymentID = deployments[0].ID
 			}
-
 		} else {
 			deployment, _, err := client.Apps.GetDeployment(context.Background(), id, deploymentID)
 			if err != nil {
@@ -215,4 +226,31 @@ func waitForAppDeployment(client *godo.Client, id string, timeout time.Duration)
 	}
 
 	return fmt.Errorf("timeout waiting for app (%s) deployment", id)
+}
+
+func listAppDeployments(client *godo.Client, appID string) ([]*godo.Deployment, error) {
+	list := []*godo.Deployment{}
+
+	opts := &godo.ListOptions{PerPage: 200}
+	for {
+		deployments, resp, err := client.Apps.ListDeployments(context.Background(), appID, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		list = append(list, deployments...)
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Page = page + 1
+	}
+
+	return list, nil
 }

--- a/digitalocean/resource_digitalocean_app_test.go
+++ b/digitalocean/resource_digitalocean_app_test.go
@@ -524,6 +524,70 @@ func TestAccDigitalOceanApp_Worker(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanApp_Function(t *testing.T) {
+	var app godo.App
+	appName := randomTestName()
+	fnConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_function, appName, "")
+
+	corsConfig := `
+       cors {
+         allow_origins {
+           prefix = "https://example.com"
+         }
+         allow_methods     = ["GET"]
+         allow_headers     = ["X-Custom-Header"]
+         expose_headers    = ["Content-Encoding", "ETag"]
+         max_age           = "1h"
+       }
+`
+	updatedFnConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_function, appName, corsConfig)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fnConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.name", appName),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "updated_at"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "created_at"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.source_dir", "/"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.routes.0.path", "/api"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.git.0.repo_clone_url",
+						"https://github.com/digitalocean/sample-functions-nodejs-helloworld.git"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.git.0.branch", "master"),
+				),
+			},
+			{
+				Config: updatedFnConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.cors.0.allow_origins.0.prefix", "https://example.com"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.cors.0.allow_methods.*", "GET"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.cors.0.allow_headers.*", "X-Custom-Header"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.cors.0.expose_headers.*", "Content-Encoding"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.cors.0.expose_headers.*", "ETag"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.function.0.cors.0.max_age", "1h"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanApp_Domain(t *testing.T) {
 	var app godo.App
 	appName := randomTestName()
@@ -1051,6 +1115,29 @@ resource "digitalocean_app" "foobar" {
       routes {
         path = "/foo"
       }
+    }
+  }
+}`
+
+var testAccCheckDigitalOceanAppConfig_function = `
+resource "digitalocean_app" "foobar" {
+  spec {
+    name = "%s"
+    region = "nyc"
+
+    function {
+      name              = "example"
+	  source_dir        = "/"
+      git {
+        repo_clone_url = "https://github.com/digitalocean/sample-functions-nodejs-helloworld.git"
+        branch         = "master"
+      }
+      routes {
+        path = "/api"
+      }
+
+%s
+
     }
   }
 }`

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -181,6 +181,55 @@ A `job` can contain:
   - `scope` - The visibility scope of the environment variable. One of `RUN_TIME`, `BUILD_TIME`, or `RUN_AND_BUILD_TIME` (default).
   - `type` - The type of the environment variable, `GENERAL` or `SECRET`.
 
+A `function` component can contain:
+
+* `name` - The name of the component.
+* `source_dir` - An optional path to the working directory to use for the build.
+* `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication.  Only one of `git`, `github` or `gitlab`  may be set.
+  - `repo_clone_url` - The clone URL of the repo.
+  - `branch` - The name of the branch to use.
+* `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `env` - Describes an environment variable made available to an app competent.
+  - `key` - The name of the environment variable.
+  - `value` - The value of the environment variable.
+  - `scope` - The visibility scope of the environment variable. One of `RUN_TIME`, `BUILD_TIME`, or `RUN_AND_BUILD_TIME` (default).
+  - `type` - The type of the environment variable, `GENERAL` or `SECRET`.
+* `route` - An HTTP paths that should be routed to this component.
+  - `path` - Paths must start with `/` and must be unique within the app.
+  - `preserve_path_prefix` -  An optional flag to preserve the path that is forwarded to the backend service.
+* `cors` - The [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policies of the app.
+	- `allow_origins` - The `Access-Control-Allow-Origin` can be
+    - `exact` - The `Access-Control-Allow-Origin` header will be set to the client's origin only if the client's origin exactly matches the value you provide.
+    - `prefix` -  The `Access-Control-Allow-Origin` header will be set to the client's origin if the beginning of the client's origin matches the value you provide.
+    - `regex` - The `Access-Control-Allow-Origin` header will be set to the client's origin if the client’s origin matches the regex you provide, in [RE2 style syntax](https://github.com/google/re2/wiki/Syntax).
+  - `allow_headers` - The set of allowed HTTP request headers. This configures the `Access-Control-Allow-Headers` header.
+  - `max_age` - An optional duration specifying how long browsers can cache the results of a preflight request. This configures the Access-Control-Max-Age header. Example: `5h30m`.
+  - `expose_headers` - The set of HTTP response headers that browsers are allowed to access. This configures the `Access-Control-Expose-Headers` header.
+  - `allow_methods` - The set of allowed HTTP methods. This configures the `Access-Control-Allow-Methods` header.
+  - `allow_credentials` - Whether browsers should expose the response to the client-side JavaScript code when the request's credentials mode is `include`. This configures the `Access-Control-Allow-Credentials` header.
+* `alert` - Describes an alert policy for the component.
+  - `rule` - The type of the alert to configure. Component app alert policies can be: `CPU_UTILIZATION`, `MEM_UTILIZATION`, or `RESTART_COUNT`.
+  - `value` - The threshold for the type of the warning.
+  - `operator` - The operator to use. This is either of `GREATER_THAN` or `LESS_THAN`.
+  - `window` - The time before alerts should be triggered. This is may be one of: `FIVE_MINUTES`, `TEN_MINUTES`, `THIRTY_MINUTES`, `ONE_HOUR`.
+  - `disabled` - Determines whether or not the alert is disabled (default: `false`).
+* `log_destination` - Describes a log forwarding destination.
+  - `name` - Name of the log destination. Minimum length: 2. Maximum length: 42.
+  - `papertrail` - Papertrail configuration.
+    - `endpoint` - Papertrail syslog endpoint.
+  - `datadog` - Datadog configuration.
+    - `endpoint` - Datadog HTTP log intake endpoint.
+    - `api_key` - Datadog API key.
+  - `logtail` - Logtail configuration.
+    - `token` - Logtail token.
+
 A `database` can contain:
 
 * `name` - The name of the component.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -369,6 +369,56 @@ A `job` can contain:
   - `logtail` - Logtail configuration.
     - `token` - Logtail token.
 
+
+A `function` component can contain:
+
+* `name` - The name of the component.
+* `source_dir` - An optional path to the working directory to use for the build.
+* `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication.  Only one of `git`, `github` or `gitlab`  may be set.
+  - `repo_clone_url` - The clone URL of the repo.
+  - `branch` - The name of the branch to use.
+* `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `env` - Describes an environment variable made available to an app competent.
+  - `key` - The name of the environment variable.
+  - `value` - The value of the environment variable.
+  - `scope` - The visibility scope of the environment variable. One of `RUN_TIME`, `BUILD_TIME`, or `RUN_AND_BUILD_TIME` (default).
+  - `type` - The type of the environment variable, `GENERAL` or `SECRET`.
+* `route` - An HTTP paths that should be routed to this component.
+  - `path` - Paths must start with `/` and must be unique within the app.
+  - `preserve_path_prefix` -  An optional flag to preserve the path that is forwarded to the backend service.
+* `cors` - The [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policies of the app.
+	- `allow_origins` - The `Access-Control-Allow-Origin` can be
+    - `exact` - The `Access-Control-Allow-Origin` header will be set to the client's origin only if the client's origin exactly matches the value you provide.
+    - `prefix` -  The `Access-Control-Allow-Origin` header will be set to the client's origin if the beginning of the client's origin matches the value you provide.
+    - `regex` - The `Access-Control-Allow-Origin` header will be set to the client's origin if the client’s origin matches the regex you provide, in [RE2 style syntax](https://github.com/google/re2/wiki/Syntax).
+  - `allow_headers` - The set of allowed HTTP request headers. This configures the `Access-Control-Allow-Headers` header.
+  - `max_age` - An optional duration specifying how long browsers can cache the results of a preflight request. This configures the Access-Control-Max-Age header. Example: `5h30m`.
+  - `expose_headers` - The set of HTTP response headers that browsers are allowed to access. This configures the `Access-Control-Expose-Headers` header.
+  - `allow_methods` - The set of allowed HTTP methods. This configures the `Access-Control-Allow-Methods` header.
+  - `allow_credentials` - Whether browsers should expose the response to the client-side JavaScript code when the request's credentials mode is `include`. This configures the `Access-Control-Allow-Credentials` header.
+* `alert` - Describes an alert policy for the component.
+  - `rule` - The type of the alert to configure. Component app alert policies can be: `CPU_UTILIZATION`, `MEM_UTILIZATION`, or `RESTART_COUNT`.
+  - `value` - The threshold for the type of the warning.
+  - `operator` - The operator to use. This is either of `GREATER_THAN` or `LESS_THAN`.
+  - `window` - The time before alerts should be triggered. This is may be one of: `FIVE_MINUTES`, `TEN_MINUTES`, `THIRTY_MINUTES`, `ONE_HOUR`.
+  - `disabled` - Determines whether or not the alert is disabled (default: `false`).
+* `log_destination` - Describes a log forwarding destination.
+  - `name` - Name of the log destination. Minimum length: 2. Maximum length: 42.
+  - `papertrail` - Papertrail configuration.
+    - `endpoint` - Papertrail syslog endpoint.
+  - `datadog` - Datadog configuration.
+    - `endpoint` - Datadog HTTP log intake endpoint.
+    - `api_key` - Datadog API key.
+  - `logtail` - Logtail configuration.
+    - `token` - Logtail token.
+
 A `database` can contain:
 
 * `name` - The name of the component.


### PR DESCRIPTION
This PR adds support functions components to the app resource and data source. 

The new acceptance test creates an app with a functions component and then updates it by adding a CORs configuration. The update was triggering an infinite loop as the in-progress deployment completes before we poll the app to find it. I've fixed this with an approach like what we are now doing in doctl (https://github.com/digitalocean/doctl/pull/1143). I've left comments around why this fix is not ideal, but after conversations with the Apps team for the doctl issue, it is currently the best solution. Unfortunately, it actually looks like we missed reviewing a PR attempting to fix this (https://github.com/digitalocean/terraform-provider-digitalocean/pull/818) previously. 

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanApp -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanApp -count=1 -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanApp_importBasic
=== PAUSE TestAccDigitalOceanApp_importBasic
=== RUN   TestAccDigitalOceanApp_Image
=== PAUSE TestAccDigitalOceanApp_Image
=== RUN   TestAccDigitalOceanApp_Basic
=== PAUSE TestAccDigitalOceanApp_Basic
=== RUN   TestAccDigitalOceanApp_Job
=== PAUSE TestAccDigitalOceanApp_Job
=== RUN   TestAccDigitalOceanApp_StaticSite
=== PAUSE TestAccDigitalOceanApp_StaticSite
=== RUN   TestAccDigitalOceanApp_InternalPort
=== PAUSE TestAccDigitalOceanApp_InternalPort
=== RUN   TestAccDigitalOceanApp_Envs
=== PAUSE TestAccDigitalOceanApp_Envs
=== RUN   TestAccDigitalOceanApp_Worker
=== PAUSE TestAccDigitalOceanApp_Worker
=== RUN   TestAccDigitalOceanApp_Function
=== PAUSE TestAccDigitalOceanApp_Function
=== RUN   TestAccDigitalOceanApp_Domain
=== PAUSE TestAccDigitalOceanApp_Domain
=== RUN   TestAccDigitalOceanApp_DomainsDeprecation
=== PAUSE TestAccDigitalOceanApp_DomainsDeprecation
=== RUN   TestAccDigitalOceanApp_CORS
=== PAUSE TestAccDigitalOceanApp_CORS
=== RUN   TestAccDigitalOceanApp_TimeoutConfig
=== PAUSE TestAccDigitalOceanApp_TimeoutConfig
=== CONT  TestAccDigitalOceanApp_importBasic
=== CONT  TestAccDigitalOceanApp_Worker
=== CONT  TestAccDigitalOceanApp_TimeoutConfig
=== CONT  TestAccDigitalOceanApp_Domain
=== CONT  TestAccDigitalOceanApp_StaticSite
=== CONT  TestAccDigitalOceanApp_InternalPort
=== CONT  TestAccDigitalOceanApp_DomainsDeprecation
=== CONT  TestAccDigitalOceanApp_Envs
--- PASS: TestAccDigitalOceanApp_TimeoutConfig (33.34s)
=== CONT  TestAccDigitalOceanApp_Function
--- PASS: TestAccDigitalOceanApp_importBasic (146.01s)
=== CONT  TestAccDigitalOceanApp_CORS
--- PASS: TestAccDigitalOceanApp_Domain (152.35s)
=== CONT  TestAccDigitalOceanApp_Basic
--- PASS: TestAccDigitalOceanApp_Function (160.97s)
=== CONT  TestAccDigitalOceanApp_Job
--- PASS: TestAccDigitalOceanApp_DomainsDeprecation (267.98s)
=== CONT  TestAccDigitalOceanApp_Image
--- PASS: TestAccDigitalOceanApp_Image (26.90s)
--- PASS: TestAccDigitalOceanApp_CORS (219.79s)
--- PASS: TestAccDigitalOceanApp_Worker (450.08s)
--- PASS: TestAccDigitalOceanApp_StaticSite (497.34s)
--- PASS: TestAccDigitalOceanApp_InternalPort (595.99s)
--- PASS: TestAccDigitalOceanApp_Job (417.60s)
--- PASS: TestAccDigitalOceanApp_Envs (877.86s)
--- PASS: TestAccDigitalOceanApp_Basic (1010.22s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    1162.585s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv        0.001s [no tests to run]
```