### PR TITLE
Change k8s example to use ingress v1

### DIFF
--- a/examples/kubernetes/kubernetes-config/main.tf
+++ b/examples/kubernetes/kubernetes-config/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = ">= 2.0.0"
+      version = ">= 2.7.0"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -123,7 +123,7 @@ resource "helm_release" "nginx_ingress" {
   }
 }
 
-resource "kubernetes_ingress" "test_ingress" {
+resource "kubernetes_ingress_v1" "test_ingress" {
   wait_for_load_balancer = true
   metadata {
     name = "test-ingress"
@@ -139,8 +139,12 @@ resource "kubernetes_ingress" "test_ingress" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.test.metadata.0.name
-            service_port = 5678
+            service {
+              name = kubernetes_service.test.metadata.0.name
+              port {
+                number = 5678
+              }
+            }
           }
 
           path = "/test"


### PR DESCRIPTION
In Kubernetes 1.22, the v1beta1 version of Ingress
is [no longer available](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122), thus the example fails to create
the ingress on Kubernetes >= 1.22 with the following error:

```
╷
│ Error: Failed to create Ingress 'test/test-ingress' because: the server could not find the requested resource (post ingresses.extensions)
│ 
│   with module.kubernetes-config.kubernetes_ingress.test_ingress,
│   on kubernetes-config/main.tf line 126, in resource "kubernetes_ingress" "test_ingress":
│  126: resource "kubernetes_ingress" "test_ingress" {
│ 
```

Instead, switch the example to use `kubernetes_ingress_v1`. 

Note that this now increases the minimum version of
terraform-provider-kubernetes since kubernetes_ingress_v1 was
added in [v2.7.0](https://github.com/hashicorp/terraform-provider-kubernetes/pull/1458).