### PR TITLE
Remove database cluster and/or database firewall rule from state if missing

### DIFF
--- a/digitalocean/resource_digitalocean_database_firewall.go
+++ b/digitalocean/resource_digitalocean_database_firewall.go
@@ -89,8 +89,12 @@ func resourceDigitalOceanDatabaseFirewallRead(ctx context.Context, d *schema.Res
 	client := meta.(*CombinedConfig).godoClient()
 	clusterID := d.Get("cluster_id").(string)
 
-	rules, _, err := client.Databases.GetFirewallRules(context.TODO(), clusterID)
+	rules, resp, err := client.Databases.GetFirewallRules(context.TODO(), clusterID)
 	if err != nil {
+		if resp.StatusCode == 404 {
+			d.SetId("")
+			return nil;
+		}
 		return diag.Errorf("Error retrieving DatabaseFirewall: %s", err)
 	}
 

--- a/digitalocean/resource_digitalocean_database_firewall.go
+++ b/digitalocean/resource_digitalocean_database_firewall.go
@@ -91,9 +91,9 @@ func resourceDigitalOceanDatabaseFirewallRead(ctx context.Context, d *schema.Res
 
 	rules, resp, err := client.Databases.GetFirewallRules(context.TODO(), clusterID)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
-			return nil;
+			return nil
 		}
 		return diag.Errorf("Error retrieving DatabaseFirewall: %s", err)
 	}


### PR DESCRIPTION
Uncovered an issue whereby refreshing Terraform state would return an error stating a database cluster didn't exist if a previously existing cluster with a firewall rule is manually deleted rather than deleting the resource from its state. This PR hopes to address this problem by checking the status code, and if it's a 404, then clear the ID for that resource and return nil from its read method.

Since one rule can only be attached to one cluster, simply deleting the rule from state should be safe.