### PR TITLE
apps: Only warn on read if there is no active deployment.

### DIFF
--- a/digitalocean/resource_digitalocean_app.go
+++ b/digitalocean/resource_digitalocean_app.go
@@ -122,7 +122,12 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 	if app.ActiveDeployment != nil {
 		d.Set("active_deployment_id", app.ActiveDeployment.ID)
 	} else {
-		return diag.Errorf("No active deployment found for app: %s (%s)", app.Spec.Name, app.ID)
+		deploymentWarning := diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("No active deployment found for app: %s (%s)", app.Spec.Name, app.ID),
+		}
+		d.Set("active_deployment_id", "")
+		return diag.Diagnostics{deploymentWarning}
 	}
 
 	return nil


### PR DESCRIPTION
`resourceDigitalOceanAppRead` currently errors out if there is no active deployment. This can cause issues in a few circumstances as an app can exist in a state where there are no active deployments. Changing this to be a warning allows for importing existing apps that do not have active deployments. It also allows for `terraform apply` to succeed if something outside of Terraform has caused an existing app to have no active deployments. Since deployments can be triggered by pushes to the app's repo, Terraform doesn't really handle the state of deployments, only the "app" resource.

This does not change the existing behavior for creates of new apps. We still poll until the app deployment succeeds and error if it fails. It's possible we might want to reconsider this in the future, but that has other considerations. This does help recovering from a failed create. Running `terraform untaint digitalocean_app.{name}` will now allow applies to complete successfully.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/842