### PR TITLE
Altering is_default to be configurable for projects

### DIFF
--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -66,8 +66,10 @@ func resourceDigitalOceanProject() *schema.Resource {
 				Description: "the id of the project owner.",
 			},
 			"is_default": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "determine if the project is the default or not.",
 			},
 			"created_at": {
 				Type:        schema.TypeString,

--- a/digitalocean/resource_digitalocean_project_test.go
+++ b/digitalocean/resource_digitalocean_project_test.go
@@ -43,6 +43,42 @@ func TestAccDigitalOceanProject_CreateWithDefaults(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanProject_CreateWithIsDefault(t *testing.T) {
+
+	expectedName := generateProjectName()
+	expectedIsDefault := "true"
+	createConfig := fixtureCreateWithIsDefault(expectedName, expectedIsDefault)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "name", expectedName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "description", ""),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "purpose", "Web Application"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "environment", ""),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "is_default", expectedIsDefault),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "id"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "owner_uuid"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "owner_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "created_at"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanProject_CreateWithInitialValues(t *testing.T) {
 
 	expectedName := generateProjectName()
@@ -440,4 +476,12 @@ func fixtureWithManyResources(domainBase string, name string) string {
 			name = "%s"
 			resources = digitalocean_domain.foobar[*].urn
 		}`, domainBase, name)
+}
+
+func fixtureCreateWithIsDefault(name string, is_default string) string {
+	return fmt.Sprintf(`
+		resource "digitalocean_project" "myproj" {
+			name = "%s"
+			is_default = "%s"
+		}`, name, is_default)
 }


### PR DESCRIPTION
Per #848.

@Yordis had a great suggestion for allowing to provision digitalocean_project resource as "Default Project".  Making "is_default" configurable. This means:

- You can initialize a new project to be the default.
- You can’t edit a project to no longer be default (`400 (request "acb5906e-bf48-49e3") you must always have a default project`) even if you have other projects, it won’t automatically assign another project to be default
- You can’t delete a project that is the default (^^)
- You must first assign another project to be default first before you can delete the old default project