### PR TITLE
testing: Use supported OS for Droplet image slug.

### DIFF
--- a/digitalocean/datasource_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_snapshot_test.go
@@ -81,7 +81,7 @@ resource "digitalocean_droplet" "bar" {
   region = "lon1"
   name   = "%s"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
 }
 
 resource "digitalocean_droplet_snapshot" "bar" {
@@ -148,7 +148,7 @@ const testAccCheckDataSourceDigitalOceanDropletSnapshot_basic = `
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 

--- a/digitalocean/datasource_digitalocean_droplet_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_test.go
@@ -35,7 +35,7 @@ data "digitalocean_droplet" "foobar" {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_droplet.foobar", "image", "centos-7-x64"),
+						"data.digitalocean_droplet.foobar", "image", "ubuntu-22-04-x64"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -66,7 +66,7 @@ func TestAccDataSourceDigitalOceanDroplet_BasicById(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_droplet.foobar", "image", "centos-7-x64"),
+						"data.digitalocean_droplet.foobar", "image", "ubuntu-22-04-x64"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -103,7 +103,7 @@ func TestAccDataSourceDigitalOceanDroplet_BasicByTag(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_droplet.foobar", "image", "centos-7-x64"),
+						"data.digitalocean_droplet.foobar", "image", "ubuntu-22-04-x64"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -165,7 +165,7 @@ resource "digitalocean_vpc" "foobar" {
 resource "digitalocean_droplet" "foo" {
   name     = "%s"
   size     = "s-1vcpu-1gb"
-  image    = "centos-7-x64"
+  image    = "ubuntu-22-04-x64"
   region   = "nyc3"
   ipv6     = true
   vpc_uuid = digitalocean_vpc.foobar.id
@@ -177,7 +177,7 @@ func testAccCheckDataSourceDigitalOceanDropletConfig_basicById(name string) stri
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
   ipv6   = true
 }
@@ -197,7 +197,7 @@ resource "digitalocean_tag" "foo" {
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
   ipv6   = true
   tags   = [digitalocean_tag.foo.id]
@@ -214,7 +214,7 @@ resource "digitalocean_tag" "foo" {
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
   ipv6   = true
   tags   = [digitalocean_tag.foo.id]

--- a/digitalocean/datasource_digitalocean_droplets_test.go
+++ b/digitalocean/datasource_digitalocean_droplets_test.go
@@ -16,14 +16,14 @@ func TestAccDataSourceDigitalOceanDroplets_Basic(t *testing.T) {
 resource "digitalocean_droplet" "foo" {
   name     = "%s"
   size     = "s-1vcpu-1gb"
-  image    = "centos-7-x64"
+  image    = "ubuntu-22-04-x64"
   region   = "nyc3"
 }
 
 resource "digitalocean_droplet" "bar" {
   name     = "%s"
   size     = "s-1vcpu-1gb"
-  image    = "centos-7-x64"
+  image    = "ubuntu-22-04-x64"
   region   = "nyc3"
 }
 `, name1, name2)

--- a/digitalocean/resource_digitalocean_database_firewall_test.go
+++ b/digitalocean/resource_digitalocean_database_firewall_test.go
@@ -144,7 +144,7 @@ resource "digitalocean_database_cluster" "foobar" {
 resource "digitalocean_droplet" "foobar" {
 	name      = "%s"
 	size      = "s-1vcpu-1gb"
-	image     = "centos-7-x64"
+	image     = "ubuntu-22-04-x64"
 	region    = "nyc3"
 }
 

--- a/digitalocean/resource_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/resource_digitalocean_droplet_snapshot_test.go
@@ -122,7 +122,7 @@ const testAccCheckDigitalOceanDropletSnapshotConfig_basic = `
 resource "digitalocean_droplet" "foo" {
 	name      = "foo-%d"
 	size      = "s-1vcpu-1gb"
-	image     = "centos-7-x64"
+	image     = "ubuntu-22-04-x64"
 	region    = "nyc3"
 	user_data = "foobar"
   }

--- a/digitalocean/resource_digitalocean_floating_ip_assignment_test.go
+++ b/digitalocean/resource_digitalocean_floating_ip_assignment_test.go
@@ -123,7 +123,7 @@ resource "digitalocean_droplet" "foobar" {
   count              = 2
   name               = "tf-acc-test-${count.index}"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -144,7 +144,7 @@ resource "digitalocean_droplet" "foobar" {
   count              = 2
   name               = "tf-acc-test-${count.index}"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -165,7 +165,7 @@ resource "digitalocean_droplet" "foobar" {
   count              = 2
   name               = "tf-acc-test-${count.index}"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -174,7 +174,7 @@ resource "digitalocean_droplet" "foobar" {
 
 var testAccCheckDigitalOceanFloatingIPAssignmentConfig_createBeforeDestroy = `
 resource "digitalocean_droplet" "foobar" {
-  image = "centos-7-x64"
+  image = "ubuntu-22-04-x64"
   name = "tf-acc-test"
   region = "nyc3"
   size = "s-1vcpu-1gb"

--- a/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -162,7 +162,7 @@ func testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt int) string {
 resource "digitalocean_droplet" "foobar" {
   name               = "tf-acc-test-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -179,7 +179,7 @@ func testAccCheckDigitalOceanFloatingIPConfig_Reassign(rInt int) string {
 resource "digitalocean_droplet" "baz" {
   name               = "tf-acc-test-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -196,7 +196,7 @@ func testAccCheckDigitalOceanFloatingIPConfig_Unassign(rInt int) string {
 resource "digitalocean_droplet" "baz" {
   name               = "tf-acc-test-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -705,7 +705,7 @@ func testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt int) string {
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
 }
 
@@ -738,14 +738,14 @@ func testAccCheckDigitalOceanLoadbalancerConfig_updated(rInt int) string {
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
 }
 
 resource "digitalocean_droplet" "foo" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
 }
 
@@ -783,7 +783,7 @@ resource "digitalocean_tag" "barbaz" {
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   tags = ["${digitalocean_tag.barbaz.id}"]
 }
@@ -816,7 +816,7 @@ func testAccCheckDigitalOceanLoadbalancerConfig_minimal(rInt int) string {
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
 }
 
@@ -842,7 +842,7 @@ func testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(rInt int) string {
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
 }
 
@@ -868,7 +868,7 @@ func testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(rInt int) string 
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
 }
 
@@ -990,7 +990,7 @@ resource "digitalocean_vpc" "foobar" {
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region   = "nyc3"
   vpc_uuid = digitalocean_vpc.foobar.id
 }

--- a/digitalocean/resource_digitalocean_project_resources_test.go
+++ b/digitalocean/resource_digitalocean_project_resources_test.go
@@ -22,7 +22,7 @@ resource "digitalocean_project" "foo" {
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
   size      = "s-1vcpu-1gb"
-  image     = "centos-7-x64"
+  image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
 }

--- a/digitalocean/resource_digitalocean_project_test.go
+++ b/digitalocean/resource_digitalocean_project_test.go
@@ -394,7 +394,7 @@ func fixtureCreateWithDropletResource(dropletName, name string) string {
 		resource "digitalocean_droplet" "foobar" {
 		  name      = "%s"
 		  size      = "s-1vcpu-1gb"
-		  image     = "centos-7-x64"
+		  image     = "ubuntu-22-04-x64"
 		  region    = "nyc3"
 		  user_data = "foobar"
 		}

--- a/digitalocean/resource_digitalocean_reserved_ip_assignment_test.go
+++ b/digitalocean/resource_digitalocean_reserved_ip_assignment_test.go
@@ -123,7 +123,7 @@ resource "digitalocean_droplet" "foobar" {
   count              = 2
   name               = "tf-acc-test-${count.index}"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -144,7 +144,7 @@ resource "digitalocean_droplet" "foobar" {
   count              = 2
   name               = "tf-acc-test-${count.index}"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -165,7 +165,7 @@ resource "digitalocean_droplet" "foobar" {
   count              = 2
   name               = "tf-acc-test-${count.index}"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -174,7 +174,7 @@ resource "digitalocean_droplet" "foobar" {
 
 var testAccCheckDigitalOceanReservedIPAssignmentConfig_createBeforeDestroy = `
 resource "digitalocean_droplet" "foobar" {
-  image = "centos-7-x64"
+  image = "ubuntu-22-04-x64"
   name = "tf-acc-test"
   region = "nyc3"
   size = "s-1vcpu-1gb"

--- a/digitalocean/resource_digitalocean_reserved_ip_test.go
+++ b/digitalocean/resource_digitalocean_reserved_ip_test.go
@@ -162,7 +162,7 @@ func testAccCheckDigitalOceanReservedIPConfig_droplet(rInt int) string {
 resource "digitalocean_droplet" "foobar" {
   name               = "tf-acc-test-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -179,7 +179,7 @@ func testAccCheckDigitalOceanReservedIPConfig_Reassign(rInt int) string {
 resource "digitalocean_droplet" "baz" {
   name               = "tf-acc-test-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
@@ -196,7 +196,7 @@ func testAccCheckDigitalOceanReservedIPConfig_Unassign(rInt int) string {
 resource "digitalocean_droplet" "baz" {
   name               = "tf-acc-test-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true

--- a/digitalocean/resource_digitalocean_volume_attachment_test.go
+++ b/digitalocean/resource_digitalocean_volume_attachment_test.go
@@ -226,7 +226,7 @@ resource "digitalocean_volume" "foobar" {
 resource "digitalocean_droplet" "foobar" {
 	name               = "baz-%d"
 	size               = "s-1vcpu-1gb"
-	image              = "centos-7-x64"
+	image              = "ubuntu-22-04-x64"
 	region             = "nyc1"
 }
 
@@ -255,7 +255,7 @@ resource "digitalocean_volume" "barfoo" {
 resource "digitalocean_droplet" "foobar" {
 	name               = "baz-%d"
 	size               = "s-1vcpu-1gb"
-	image              = "centos-7-x64"
+	image              = "ubuntu-22-04-x64"
 	region             = "nyc1"
 }
 
@@ -289,7 +289,7 @@ resource "digitalocean_volume" "foobar_second" {
 resource "digitalocean_droplet" "foobar" {
 	name               = "baz-%d"
 	size               = "s-1vcpu-1gb"
-	image              = "centos-7-x64"
+	image              = "ubuntu-22-04-x64"
 	region             = "nyc1"
 }
 

--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -192,7 +192,7 @@ resource "digitalocean_volume" "foobar" {
 resource "digitalocean_droplet" "foobar" {
   name               = "baz-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc1"
   ipv6               = true
   private_networking = true
@@ -337,7 +337,7 @@ resource "digitalocean_volume" "foobar" {
 resource "digitalocean_droplet" "foobar" {
   name               = "baz-%d"
   size               = "s-1vcpu-1gb"
-  image              = "centos-7-x64"
+  image              = "ubuntu-22-04-x64"
   region             = "nyc1"
   ipv6               = true
   private_networking = true

--- a/docs/resources/database_firewall.md
+++ b/docs/resources/database_firewall.md
@@ -52,7 +52,7 @@ resource "digitalocean_database_firewall" "example-fw" {
 resource "digitalocean_droplet" "web" {
   name   = "web-01"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 

--- a/docs/resources/droplet_snapshot.md
+++ b/docs/resources/droplet_snapshot.md
@@ -12,7 +12,7 @@ Provides a resource which can be used to create a snapshot from an existing Digi
 resource "digitalocean_droplet" "web" {
   name   = "web-01"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -42,7 +42,7 @@ The following example demonstrates the creation of a project with a Droplet reso
 resource "digitalocean_droplet" "foobar" {
   name   = "example"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 

--- a/docs/resources/project_resources.md
+++ b/docs/resources/project_resources.md
@@ -30,7 +30,7 @@ data "digitalocean_project" "playground" {
 resource "digitalocean_droplet" "foobar" {
   name   = "example"
   size   = "s-1vcpu-1gb"
-  image  = "centos-7-x64"
+  image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 


### PR DESCRIPTION
The CentOS images were retired in favor of the new CentOS Stream ones. All tests referencing them fail.  EOL for Ubuntu 22.04 LTS isn't until April 2032, so this shouldn't need updating again for a long time. :crossed_fingers: 

https://wiki.ubuntu.com/Releases