### PR TITLE
Updating Project Resource to have "is_default" configurable

### DIFF
--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -66,8 +66,10 @@ func resourceDigitalOceanProject() *schema.Resource {
 				Description: "the id of the project owner.",
 			},
 			"is_default": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "determine if the project is the default or not.",
 			},
 			"created_at": {
 				Type:        schema.TypeString,
@@ -121,6 +123,21 @@ func resourceDigitalOceanProjectCreate(ctx context.Context, d *schema.ResourceDa
 		}
 
 		d.Set("resources", resources)
+	}
+
+	if v, ok := d.GetOk("is_default"); ok {
+		updateReq := &godo.UpdateProjectRequest{
+			Name:        project.Name,
+			Description: project.Description,
+			Purpose:     project.Purpose,
+			Environment: project.Environment,
+			IsDefault:   v.(bool),
+		}
+
+		_, _, err := client.Projects.Update(context.Background(), project.ID, updateReq)
+		if err != nil {
+			return diag.Errorf("Error setting project as default: %s", err)
+		}
 	}
 
 	d.SetId(project.ID)

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `purpose` - (Optional) the purpose of the project, (Default: "Web Application")
 * `environment` - (Optional) the environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`)
 * `resources` - a list of uniform resource names (URNs) for the resources associated with the project
+* `is_default` - (Optional) a boolean indicating whether or not the project is the default project. (Default: "false")
 
 ## Attributes Reference
 


### PR DESCRIPTION
(murked my previous PR #849 bc got into a hairy merge issue)

Per https://github.com/digitalocean/terraform-provider-digitalocean/issues/848.

@yordis had a great suggestion for allowing to provision digitalocean_project resource as "Default Project". Making "is_default" configurable. This means:

- You can initialize a new project to be the default.
- You can’t edit a project to no longer be default (400 (request "acb5906e-bf48-49e3") you must always have a default project) even if you have other projects, it won’t automatically assign another project to be default
- You can’t delete a project that is the default (^^)
- You must first assign another project to be default first before you can delete the old default project