### PR TITLE
droplet: Fix configurable timeouts for Droplet creates.

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -296,7 +296,7 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Droplet create configuration: %#v", opts)
 
-	droplet, resp, err := client.Droplets.Create(context.Background(), opts)
+	droplet, _, err := client.Droplets.Create(context.Background(), opts)
 	if err != nil {
 		return diag.Errorf("Error creating droplet: %s", err)
 	}
@@ -304,17 +304,6 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 	// Assign the droplets id
 	d.SetId(strconv.Itoa(droplet.ID))
 	log.Printf("[INFO] Droplet ID: %s", d.Id())
-
-	// Wait for Droplet create action to successfully finish.
-	if len(resp.Links.Actions) == 1 {
-		actionID := resp.Links.Actions[0].ID
-		err = waitForAction(client, &godo.Action{ID: actionID})
-		if err != nil {
-			return diag.Errorf("Droplet (%s) create action (%d) errorred: %s", d.Id(), actionID, err)
-		}
-	} else {
-		return diag.Errorf("Unable to find Droplet (%s) create action.", d.Id())
-	}
 
 	// Ensure Droplet status has moved to "active."
 	_, err = waitForDropletAttribute(ctx, d, "active", []string{"new"}, "status", schema.TimeoutCreate, meta)

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -674,6 +674,30 @@ func TestAccDigitalOceanDroplet_withDropletAgentExpectError(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDroplet_withTimeout(t *testing.T) {
+	dropletName := randomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`resource "digitalocean_droplet" "foobar" {
+  name              = "%s"
+  size              = "s-1vcpu-1gb"
+  image             = "ubuntu-22-04-x64"
+  region            = "nyc3"
+  timeouts {
+	create = "5s"
+  }
+}`, dropletName),
+				ExpectError: regexp.MustCompile(`timeout while waiting for state`),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanDropletDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 


### PR DESCRIPTION
Follows up on https://github.com/digitalocean/terraform-provider-digitalocean/pull/839 After creating a Droplet, we're polling using both `waitForAction` and then `waitForDropletAttribute`. This is redundant and  `waitForAction` does not currently support configurable timeouts.  So configuring a create timeout is effectively ignored. This resolves the issue by removing the   `waitForAction` call. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/828