### PR TITLE
make user optional in db connection pool, update acc tests

### DIFF
--- a/digitalocean/resource_digitalocean_database_connection_pool.go
+++ b/digitalocean/resource_digitalocean_database_connection_pool.go
@@ -39,7 +39,7 @@ func resourceDigitalOceanDatabaseConnectionPool() *schema.Resource {
 
 			"user": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},

--- a/docs/resources/database_connection_pool.md
+++ b/docs/resources/database_connection_pool.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `mode` - (Required) The PGBouncer transaction mode for the connection pool. The allowed values are session, transaction, and statement.
 * `size` - (Required) The desired size of the PGBouncer connection pool.
 * `db_name` - (Required) The database for use with the connection pool.
-* `user` - (Required) The name of the database user for use with the connection pool.
+* `user` - (Optional) The name of the database user for use with the connection pool. When excluded, all sessions connect to the database as the inbound user.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The DO API allows DB pools to be created without a user specified. This PR modifies the `digitalocean_database_connection_pool` resource and removes user as a required field. Without user specified, pool uses the connection credentials of the inbound user. 

Adds  new test case for creates w.o specified user, `TestAccDigitalOceanDatabaseConnectionPool_InboundUser`, and modifies `TestAccDigitalOceanDatabaseConnectionPool_Basic` to cover pool updates.