### PR TITLE
Suppress diffs on forced Redis version upgrades

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,10 +55,13 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 				// Required: true,
 				Optional: true,
 				ForceNew: true,
-				// Redis clusters are being force upgraded from version 5 to 6.
-				// Prevent attempting to recreate clusters specifying 5 in their config.
+				// When Redis clusters are forced to upgrade, this prevents attempting
+				// to recreate clusters specifying the previous version in their config.
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return d.Get("engine") == redisDBEngineSlug && old == "6" && new == "5"
+					remoteVersion, _ := strconv.Atoi(old)
+					configVersion, _ := strconv.Atoi(new)
+
+					return d.Get("engine") == redisDBEngineSlug && remoteVersion > configVersion
 				},
 			},
 

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -261,14 +261,22 @@ func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
 	})
 }
 
-// For backwards compatibility the API allows for POST requests that specify "5"
-// for the version, but a Redis 6 cluster is actually created. The response body
-// specifies "6" for the version. This should be handled without Terraform
-// attempting to recreate the cluster.
+// DigitalOcean only supports one version of Redis. For backwards compatibility
+// the API allows for POST requests that specifies a previous version, but new
+// clusters are created with the latest/only supported version, regardless of
+// the version specified in the config.
+// The provider suppresses diffs when the config version is <= to the latest
+// version. New clusters is always created with the latest version .
 func TestAccDigitalOceanDatabaseCluster_oldRedisVersion(t *testing.T) {
 	var database godo.Database
 	databaseName := randomTestName()
 
+	// Fetch the Databases Options and get the current supported version of
+	// Redis from the response.
+	var (
+		client       = &godo.Client{}
+		redisVersion string
+	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -277,6 +285,15 @@ func TestAccDigitalOceanDatabaseCluster_oldRedisVersion(t *testing.T) {
 			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterRedis, databaseName, "5"),
 				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						client = testAccProvider.Meta().(*CombinedConfig).godoClient()
+						options, _, err := client.Databases.ListOptions(context.Background())
+						if err != nil {
+							t.Error("Error fetching database options")
+						}
+						redisVersion = options.RedisOptions.Versions[0]
+						return nil
+					},
 					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
 					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
 					resource.TestCheckResourceAttr(
@@ -284,7 +301,7 @@ func TestAccDigitalOceanDatabaseCluster_oldRedisVersion(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_cluster.foobar", "engine", "redis"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_database_cluster.foobar", "version", "6"),
+						"digitalocean_database_cluster.foobar", "version", redisVersion),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -268,15 +268,14 @@ func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
 // The provider suppresses diffs when the config version is <= to the latest
 // version. New clusters is always created with the latest version .
 func TestAccDigitalOceanDatabaseCluster_oldRedisVersion(t *testing.T) {
-	var database godo.Database
-	databaseName := randomTestName()
-
-	// Fetch the Databases Options and get the current supported version of
-	// Redis from the response.
 	var (
+		database     godo.Database
 		client       = &godo.Client{}
 		redisVersion string
 	)
+
+	databaseName := randomTestName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -285,6 +284,8 @@ func TestAccDigitalOceanDatabaseCluster_oldRedisVersion(t *testing.T) {
 			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterRedis, databaseName, "5"),
 				Check: resource.ComposeTestCheckFunc(
+					// Fetch the Databases Options and get the current supported version of
+					// Redis from the response.
 					func(*terraform.State) error {
 						client = testAccProvider.Meta().(*CombinedConfig).godoClient()
 						options, _, err := client.Databases.ListOptions(context.Background())

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.82.0
+	github.com/digitalocean/godo v1.83.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitalocean/godo v1.82.0 h1:lqAit46H1CqJGjh7LDbsamng/UMBME5rvmfH3Vb5Yy8=
 github.com/digitalocean/godo v1.82.0/go.mod h1:BPCqvwbjbGqxuUnIKB4EvS/AX7IDnNmt5fwvIkWo+ew=
+github.com/digitalocean/godo v1.83.0 h1:K9CveJyECNLwrQnGZG+ovgapr7l5OuvQ6xZSKKW9Nz0=
+github.com/digitalocean/godo v1.83.0/go.mod h1:BPCqvwbjbGqxuUnIKB4EvS/AX7IDnNmt5fwvIkWo+ew=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.83.0] - 2022-08-10
+
+- #546 - @DWizGuy58 - Add support for database options
+
 ## [v1.82.0] - 2022-08-04
 
 - #544 - @andrewsomething - apps: Add URN() method.

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.82.0"
+	libraryVersion = "1.83.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.82.0
+# github.com/digitalocean/godo v1.83.0
 ## explicit; go 1.18
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
To ensure customer Redis instances do not get destroyed and recreated after their Redis clusters are forced to upgrade, this change updates the `DiffSuppressFunc` logic for Database Cluster resources to suppress diffs when the DB engine is `redis` and `version` is newer on the remote resource than what is specified in the configuration.

This should also help us avoid having to make this change for forced upgrades in the future.

for APICLI-1526