### PR TITLE
Add SOA as possible record type

### DIFF
--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -37,6 +37,7 @@ func resourceDigitalOceanRecord() *schema.Resource {
 					"NS",
 					"TXT",
 					"SRV",
+					"SOA",
 				}, false),
 			},
 


### PR DESCRIPTION
Add `SOA` as possible record type.

Without it it's not possible to manage `SOA` records as the following error would be raised.

```shell
 Error: expected type to be one of [A AAAA CAA CNAME MX NS TXT SRV], got SOA
```