### PR TITLE
spaces: add endpoint attribute to bucket

### DIFF
--- a/digitalocean/datasource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/datasource_digitalocean_spaces_bucket_test.go
@@ -45,6 +45,7 @@ data "digitalocean_spaces_bucket" "bucket" {
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket.bucket", "name", bucketName),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket.bucket", "region", bucketRegion),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket.bucket", "bucket_domain_name", bucketDomainName(bucketName, bucketRegion)),
+					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket.bucket", "endpoint", bucketEndpoint(bucketRegion)),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket.bucket", "urn", fmt.Sprintf("do:space:%s", bucketName)),
 				),
 			},

--- a/digitalocean/datasource_digitalocean_spaces_buckets_test.go
+++ b/digitalocean/datasource_digitalocean_spaces_buckets_test.go
@@ -51,6 +51,7 @@ data "digitalocean_spaces_buckets" "result" {
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_buckets.result", "buckets.0.name", bucketName1),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_buckets.result", "buckets.0.region", bucketRegion1),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_buckets.result", "buckets.0.bucket_domain_name", bucketDomainName(bucketName1, bucketRegion1)),
+					resource.TestCheckResourceAttr("data.digitalocean_spaces_buckets.result", "buckets.0.endpoint", bucketEndpoint(bucketRegion1)),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_buckets.result", "buckets.0.urn", fmt.Sprintf("do:space:%s", bucketName1)),
 				),
 			},

--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -113,6 +113,12 @@ func resourceDigitalOceanBucket() *schema.Resource {
 				Computed:    true,
 			},
 
+			"endpoint": {
+				Type:        schema.TypeString,
+				Description: "The FQDN of the bucket without the bucket name",
+				Computed:    true,
+			},
+
 			"lifecycle_rule": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -462,6 +468,9 @@ func resourceDigitalOceanBucketRead(ctx context.Context, d *schema.ResourceData,
 	urn := fmt.Sprintf("do:space:%s", d.Get("name"))
 	d.Set("urn", urn)
 
+	// Set the bucket's endpoint.
+	d.Set("endpoint", bucketEndpoint(d.Get("region").(string)))
+
 	return nil
 }
 
@@ -772,6 +781,10 @@ func resourceDigitalOceanBucketImport(d *schema.ResourceData, meta interface{}) 
 
 func bucketDomainName(bucket string, region string) string {
 	return fmt.Sprintf("%s.%s.digitaloceanspaces.com", bucket, region)
+}
+
+func bucketEndpoint(region string) string {
+	return fmt.Sprintf("%s.digitaloceanspaces.com", region)
 }
 
 func retryOnAwsCode(code string, f func() (interface{}, error)) (interface{}, error) {

--- a/digitalocean/spaces_buckets.go
+++ b/digitalocean/spaces_buckets.go
@@ -36,6 +36,10 @@ func spacesBucketSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The FQDN of the bucket",
 		},
+		"endpoint": {
+			Type:        schema.TypeString,
+			Description: "The FQDN of the bucket without the bucket name",
+		},
 	}
 }
 
@@ -90,6 +94,7 @@ func flattenSpacesBucket(rawBucketMetadata, meta interface{}, extra map[string]i
 	flattenedBucket["region"] = region
 	flattenedBucket["bucket_domain_name"] = bucketDomainName(name, region)
 	flattenedBucket["urn"] = fmt.Sprintf("do:space:%s", name)
+	flattenedBucket["endpoint"] = bucketEndpoint(region)
 
 	return flattenedBucket, nil
 }

--- a/docs/data-sources/spaces_bucket.md
+++ b/docs/data-sources/spaces_bucket.md
@@ -37,3 +37,4 @@ The following attributes are exported:
 * `region` - The slug of the region where the bucket is stored.
 * `urn` - The uniform resource name of the bucket
 * `bucket_domain_name` - The FQDN of the bucket (e.g. bucket-name.nyc3.digitaloceanspaces.com)
+* `endpoint` - The FQDN of the bucket without the bucket name (e.g. nyc3.digitaloceanspaces.com)

--- a/docs/data-sources/spaces_buckets.md
+++ b/docs/data-sources/spaces_buckets.md
@@ -75,3 +75,4 @@ data "digitalocean_spaces_buckets" "nyc3" {
   - `region` - The slug of the region where the bucket is stored.
   - `urn` - The uniform resource name of the bucket
   - `bucket_domain_name` - The FQDN of the bucket (e.g. bucket-name.nyc3.digitaloceanspaces.com)
+  - `endpoint` - The FQDN of the bucket without the bucket name (e.g. nyc3.digitaloceanspaces.com)

--- a/docs/resources/spaces_bucket.md
+++ b/docs/resources/spaces_bucket.md
@@ -123,6 +123,7 @@ The following attributes are exported:
 * `urn` - The uniform resource name for the bucket
 * `region` - The name of the region
 * `bucket_domain_name` - The FQDN of the bucket (e.g. bucket-name.nyc3.digitaloceanspaces.com)
+* `endpoint` - The FQDN of the bucket without the bucket name (e.g. nyc3.digitaloceanspaces.com)
 
 ## Import
 


### PR DESCRIPTION
This pull request adds an `endpoint` attribute to the `digitalocean_spaces_bucket` data source and resource.

What do we think about the attribute name and description?
```
endpoint: The FQDN of the bucket without the bucket name
```

Example terraform manifest with resource
```
terraform {
  required_providers {
    digitalocean = {
      source = "digitalocean/digitalocean"
      version = ">= 2.22.3"
    }
  }
}

provider "digitalocean" {}

resource "digitalocean_spaces_bucket" "example" {
  name   = "unique-bucket-cc7bf683"
  region = "nyc3"
}

output "bucket_attributes" {
    value = digitalocean_spaces_bucket.example
}
```

Current output for `digitalocean_spaces_bucket` resource with `Terraform 1.3.1` and `terraform-provider-digitalocean_v2.22.3`
```
root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces# terraform plan -out tf.plan
 
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # digitalocean_spaces_bucket.example will be created
  + resource "digitalocean_spaces_bucket" "example" {
      + acl                = "private"
      + bucket_domain_name = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + name               = "unique-bucket-cc7bf683"
      + region             = "nyc3"
      + urn                = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bucket_attributes = {
      + acl                = "private"
      + bucket_domain_name = (known after apply)
      + cors_rule          = []
      + force_destroy      = false
      + id                 = (known after apply)
      + lifecycle_rule     = []
      + name               = "unique-bucket-cc7bf683"
      + region             = "nyc3"
      + urn                = (known after apply)
      + versioning         = []
    }

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: tf.plan

To perform exactly these actions, run the following command to apply:
    terraform apply "tf.plan"


root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces# terraform apply -auto-approve tf.plan
digitalocean_spaces_bucket.example: Creating...
digitalocean_spaces_bucket.example: Still creating... [10s elapsed]
digitalocean_spaces_bucket.example: Still creating... [20s elapsed]
digitalocean_spaces_bucket.example: Creation complete after 30s [id=unique-bucket-cc7bf683]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

bucket_attributes = {
  "acl" = "private"
  "bucket_domain_name" = "unique-bucket-cc7bf683.nyc3.digitaloceanspaces.com"
  "cors_rule" = tolist([])
  "force_destroy" = false
  "id" = "unique-bucket-cc7bf683"
  "lifecycle_rule" = tolist([])
  "name" = "unique-bucket-cc7bf683"
  "region" = "nyc3"
  "urn" = "do:space:unique-bucket-cc7bf683"
  "versioning" = tolist([
    {
      "enabled" = false
    },
  ])
}
```

New resource output after change:
```
root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces# terraform plan -out tf.plan 
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # digitalocean_spaces_bucket.example will be created
  + resource "digitalocean_spaces_bucket" "example" {
      + acl                = "private"
      + bucket_domain_name = (known after apply)
      + endpoint           = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + name               = "unique-bucket-cc7bf683"
      + region             = "nyc3"
      + urn                = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bucket_attributes = {
      + acl                = "private"
      + bucket_domain_name = (known after apply)
      + cors_rule          = []
      + endpoint           = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + lifecycle_rule     = []
      + name               = "unique-bucket-cc7bf683"
      + region             = "nyc3"
      + urn                = (known after apply)
      + versioning         = []
    }

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: tf.plan

To perform exactly these actions, run the following command to apply:
    terraform apply "tf.plan"


root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces# terraform apply -auto-approve tf.plan
digitalocean_spaces_bucket.example: Creating...
digitalocean_spaces_bucket.example: Still creating... [10s elapsed]
digitalocean_spaces_bucket.example: Still creating... [20s elapsed]
digitalocean_spaces_bucket.example: Still creating... [30s elapsed]
digitalocean_spaces_bucket.example: Creation complete after 38s [id=unique-bucket-cc7bf683]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

bucket_attributes = {
  "acl" = "private"
  "bucket_domain_name" = "unique-bucket-cc7bf683.nyc3.digitaloceanspaces.com"
  "cors_rule" = tolist([])
  "endpoint" = "nyc3.digitaloceanspaces.com"
  "force_destroy" = false
  "id" = "unique-bucket-cc7bf683"
  "lifecycle_rule" = tolist([])
  "name" = "unique-bucket-cc7bf683"
  "region" = "nyc3"
  "urn" = "do:space:unique-bucket-cc7bf683"
  "versioning" = tolist([
    {
      "enabled" = false
    },
  ])
}
```

Example terraform manifest with data source
```
terraform {
  required_providers {
    digitalocean = {
      source = "digitalocean/digitalocean"
      version = ">= 2.22.3"
    }
  }
}

provider "digitalocean" {}

data "digitalocean_spaces_bucket" "example" {
  name   = "unique-bucket-cc7bf683"
  region = "nyc3"
}

output "bucket_attributes" {
    value = data.digitalocean_spaces_bucket.example
}
```

Current output for `digitalocean_spaces_bucket` data source with `Terraform 1.3.1` and `terraform-provider-digitalocean_v2.22.3`
```
root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces-data# terraform plan -out tf.plan
data.digitalocean_spaces_bucket.example: Reading...
data.digitalocean_spaces_bucket.example: Read complete after 5s [id=unique-bucket-cc7bf683]

Changes to Outputs:
  + bucket_attributes = {
      + bucket_domain_name = "unique-bucket-cc7bf683.nyc3.digitaloceanspaces.com"
      + id                 = "unique-bucket-cc7bf683"
      + name               = "unique-bucket-cc7bf683"
      + region             = "nyc3"
      + urn                = "do:space:unique-bucket-cc7bf683"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: tf.plan

To perform exactly these actions, run the following command to apply:
    terraform apply "tf.plan"


root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces-data# terraform apply -auto-approve tf.plan

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

bucket_attributes = {
  "bucket_domain_name" = "unique-bucket-cc7bf683.nyc3.digitaloceanspaces.com"
  "id" = "unique-bucket-cc7bf683"
  "name" = "unique-bucket-cc7bf683"
  "region" = "nyc3"
  "urn" = "do:space:unique-bucket-cc7bf683"
}
```

New data source output after change:
```
root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces-data# terraform plan -out tf.plan
data.digitalocean_spaces_bucket.example: Reading...
data.digitalocean_spaces_bucket.example: Read complete after 5s [id=unique-bucket-cc7bf683]

Changes to Outputs:
  + bucket_attributes = {
      + bucket_domain_name = "unique-bucket-cc7bf683.nyc3.digitaloceanspaces.com"
      + endpoint           = "nyc3.digitaloceanspaces.com"
      + id                 = "unique-bucket-cc7bf683"
      + name               = "unique-bucket-cc7bf683"
      + region             = "nyc3"
      + urn                = "do:space:unique-bucket-cc7bf683"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: tf.plan

To perform exactly these actions, run the following command to apply:
    terraform apply "tf.plan"


root@2d7700f3d983:/go/src/github.com/digitalocean/terraform-provider-digitalocean/examples/spaces-data# terraform apply -auto-approve tf.plan

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

bucket_attributes = {
  "bucket_domain_name" = "unique-bucket-cc7bf683.nyc3.digitaloceanspaces.com"
  "endpoint" = "nyc3.digitaloceanspaces.com"
  "id" = "unique-bucket-cc7bf683"
  "name" = "unique-bucket-cc7bf683"
  "region" = "nyc3"
  "urn" = "do:space:unique-bucket-cc7bf683"
}
```
