### PR TITLE
Fix reference in documentation of `project_resources`

### DIFF
--- a/docs/resources/project_resources.md
+++ b/docs/resources/project_resources.md
@@ -35,7 +35,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_project_resources" "barfoo" {
-  project = data.digitalocean_project.foo.id
+  project = data.digitalocean_project.playground.id
   resources = [
     digitalocean_droplet.foobar.urn
   ]


### PR DESCRIPTION
The `digitalocean_project_resources` resource was referencing a non-existing data source.