### PR TITLE
add retry on db replica create

### DIFF
--- a/digitalocean/resource_digitalocean_database_replica.go
+++ b/digitalocean/resource_digitalocean_database_replica.go
@@ -133,7 +133,6 @@ func resourceDigitalOceanDatabaseReplicaCreate(ctx context.Context, d *schema.Re
 
 	log.Printf("[DEBUG] DatabaseReplica create configuration: %#v", opts)
 
-
 	var replicaCluster *godo.DatabaseReplica
 
 	// Retry requests that fail w. Failed Precondition (412). New DBs can be marked ready while

--- a/digitalocean/resource_digitalocean_vpc.go
+++ b/digitalocean/resource_digitalocean_vpc.go
@@ -165,7 +165,6 @@ func resourceDigitalOceanVPCDelete(ctx context.Context, d *schema.ResourceData, 
 		resp, err := client.VPCs.Delete(context.Background(), vpcID)
 		if err != nil {
 			// Retry if VPC still contains member resources to prevent race condition
-			// with database cluster deletion.
 			if resp.StatusCode == 403 {
 				return resource.RetryableError(err)
 			} else {


### PR DESCRIPTION
Implements fix for https://github.com/digitalocean/terraform-provider-digitalocean/issues/906 by adding more permissive retry logic in two places:

- Call to `client.Databases.CreateReplica` in `resourceDigitalOceanDatabaseReplicaCreate` now allows 412 as a  retryable error.
- Call to `GetReplica` in `waitForDatabaseReplica` allows 404 while replica creates. Same logic as currently used in `resourceDigitalOceanDatabaseClusterCreate`.

With the change, one can run a plan that creates a DB and replica as shown below without running into race condition on replica create:

```
resource "digitalocean_database_replica" "read-replica" {
  cluster_id = digitalocean_database_cluster.postgres-example.id
  name       = "test-postgres-cluster-replica"
  size       = "db-s-1vcpu-1gb"
  region     = "nyc1"
}

resource "digitalocean_database_cluster" "postgres-example" {
  name       = "test-postgres-cluster"
  engine     = "pg"
  version    = "11"
  size       = "db-s-1vcpu-1gb"
  region     = "nyc1"
  node_count = 1
}
```

Result from apply:

```bash
digitalocean_database_cluster.postgres-example: Creating...
...
digitalocean_database_cluster.postgres-example: Creation complete after 3m34s [id=4201c593-eeef-4cac-9465-fade75eaeaee]
digitalocean_database_replica.read-replica: Creating...
...
digitalocean_database_replica.read-replica: Creation complete after 3m53s [id=4201c593-eeef-4cac-9465-fade75eaeaee/replicas/test-postgres-cluster-replica]