### PR TITLE
testing: Find previous K8s release dynamically.

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -17,11 +17,23 @@ import (
 )
 
 const (
-	testClusterVersionPrevious = `data "digitalocean_kubernetes_versions" "test" {
-  version_prefix = "1.21."
+	testClusterVersionPrevious = `data "digitalocean_kubernetes_versions" "latest" {
+}
+
+locals {
+  previous_version = format("%s.",
+    join(".", [
+      split(".",data.digitalocean_kubernetes_versions.latest.latest_version)[0],
+      tostring(parseint(split(".",data.digitalocean_kubernetes_versions.latest.latest_version)[1], 10)-1)
+    ])
+  )
+}
+
+data "digitalocean_kubernetes_versions" "test" {
+  version_prefix = local.previous_version
 }`
+
 	testClusterVersionLatest = `data "digitalocean_kubernetes_versions" "test" {
-  version_prefix = "1.22."
 }`
 )
 


### PR DESCRIPTION
The DOKS acceptance tests are currently failing due to changes in the available Kubernetes versions. 1.21.x and 1.22.x are no longer available:

```
$ doctl kubernetes options versions 
Slug            Kubernetes Version    Supported Features
1.25.4-do.0     1.25.4                cluster-autoscaler, docr-integration, ha-control-plane, token-authentication
1.24.8-do.0     1.24.8                cluster-autoscaler, docr-integration, ha-control-plane, token-authentication
1.23.14-do.0    1.23.14               cluster-autoscaler, docr-integration, ha-control-plane, token-authentication
```

The only reason why we have specific versions referenced is to test the upgrade path, and generally upgrades are only supported from the previous major version. This change calculates the previous version from the latest version. This should allow us to no longer need to update the versions in the test config.

```
$ make testacc TESTARGS='-run TestAccDigitalOceanKubernetesCluster_UpgradeVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDigitalOceanKubernetesCluster_UpgradeVersion -timeout 120m
?       github.com/digitalocean/terraform-provider-digitalocean [no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== CONT  TestAccDigitalOceanKubernetesCluster_UpgradeVersion
--- PASS: TestAccDigitalOceanKubernetesCluster_UpgradeVersion (381.71s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean    381.722s
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/datalist       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/internal/mutexkv        (cached) [no tests to run]
```