### PR TITLE
database replica: Expose Database Replica ID

### DIFF
--- a/digitalocean/resource_digitalocean_database_replica_test.go
+++ b/digitalocean/resource_digitalocean_database_replica_test.go
@@ -60,6 +60,8 @@ func TestAccDigitalOceanDatabaseReplica_Basic(t *testing.T) {
 						"digitalocean_database_replica.read-01", "tags.#", "1"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "private_network_uuid"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_replica.read-01", "uuid"),
 				),
 			},
 		},
@@ -136,6 +138,7 @@ func testAccCheckDigitalOceanDatabaseReplicaExists(n string, database *godo.Data
 		client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 		clusterId := rs.Primary.Attributes["cluster_id"]
 		name := rs.Primary.Attributes["name"]
+		uuid := rs.Primary.Attributes["uuid"]
 
 		foundDatabaseReplica, _, err := client.Databases.GetReplica(context.Background(), clusterId, name)
 
@@ -145,6 +148,10 @@ func testAccCheckDigitalOceanDatabaseReplicaExists(n string, database *godo.Data
 
 		if foundDatabaseReplica.Name != name {
 			return fmt.Errorf("DatabaseReplica not found")
+		}
+
+		if foundDatabaseReplica.ID != uuid {
+			return fmt.Errorf("DatabaseReplica UUID not found")
 		}
 
 		*database = *foundDatabaseReplica

--- a/docs/resources/database_replica.md
+++ b/docs/resources/database_replica.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - The ID of the database replica created by Terraform.
-* `uuid` - The UUID of the database replica. You can reference this uuid as the ID of the target database cluster for other resources. See example firewall "Create firewall rule for database replica" example above.
+* `uuid` - The UUID of the database replica. The uuid can be used to reference the database replica as the target database cluster in other resources. See example  "Create firewall rule for database replica" above.
 * `host` - Database replica's hostname.
 * `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database replica is listening on.

--- a/docs/resources/database_replica.md
+++ b/docs/resources/database_replica.md
@@ -10,11 +10,8 @@ Provides a DigitalOcean database replica resource.
 
 ### Create a new PostgreSQL database replica
 ```hcl
-resource "digitalocean_database_replica" "read-replica" {
-  cluster_id = digitalocean_database_cluster.postgres-example.id
-  name       = "read-replica"
-  size       = "db-s-1vcpu-1gb"
-  region     = "nyc1"
+output "UUID" {
+  value = digitalocean_database_replica.replica-example.uuid
 }
 
 resource "digitalocean_database_cluster" "postgres-example" {
@@ -24,6 +21,23 @@ resource "digitalocean_database_cluster" "postgres-example" {
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
+}
+
+resource "digitalocean_database_replica" "replica-example" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+  name       = "replica-example"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+}
+
+# Create firewall rule for database replica
+resource "digitalocean_database_firewall" "example-fw" {
+  cluster_id = digitalocean_database_replica.replica-example.uuid
+
+  rule {
+    type  = "ip_addr"
+    value = "192.168.1.1"
+  }
 }
 ```
 
@@ -42,7 +56,8 @@ The following arguments are supported:
 
 In addition to the above arguments, the following attributes are exported:
 
-* `id` - The ID of the database replica.
+* `id` - The ID of the database replica created by Terraform.
+* `uuid` - The UUID of the database replica. You can reference this uuid as the ID of the target database cluster for other resources. See example firewall "Create firewall rule for database replica" example above.
 * `host` - Database replica's hostname.
 * `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database replica is listening on.


### PR DESCRIPTION
Addresses #878

Added a `uuid` attribute to allow users who need to reference the database replica as the target database cluster in other resources. 

I looked into creating a [state migration](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/state-migration) to instead try to update the current `id` attribute to reference the db replica's ID fetched from the DO API- verse the currently implemented `id` that is generated in terraform (in `makeReplicaId`). State migrations seem useful for changing the attribute/schema's configuration, not the actual values that are set in the CreateContext. Thus, decided adding a `uuid` attribute would suffice. Updated documentation to reflect this.

The terraform config would look like this:

```
output "UUID" {
  value = digitalocean_database_replica.replica-example.uuid
}

resource "digitalocean_database_cluster" "postgres-example" {
  name       = "example-postgres-cluster"
  engine     = "pg"
  version    = "11"
  size       = "db-s-1vcpu-1gb"
  region     = "nyc1"
  node_count = 1
}

resource "digitalocean_database_replica" "replica-example" {
  cluster_id = digitalocean_database_cluster.postgres-example.id
  name       = "replica-example"
  size       = "db-s-1vcpu-1gb"
  region     = "nyc1"
}

# Create firewall rule for database replica
resource "digitalocean_database_firewall" "example-fw" {
  cluster_id = digitalocean_database_replica.replica-example.uuid

  rule {
    type  = "ip_addr"
    value = "192.168.1.1"
  }
}
```




APICLI-1809