### PR TITLE
Remove unused const to fix linting.

### DIFF
--- a/digitalocean/monitoring/resource_monitor_alert_test.go
+++ b/digitalocean/monitoring/resource_monitor_alert_test.go
@@ -12,13 +12,6 @@ import (
 )
 
 const (
-	slackChannels = `
-slack {
-	channel = "production-alerts"
-	url		= "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
-}
-	`
-
 	multipleSlackChannel = `
 slack {
 	channel = "production-alerts"


### PR DESCRIPTION
```
digitalocean/monitoring/resource_monitor_alert_test.go:15:2: `slackChannels` is unused (varcheck)
        slackChannels = `
        ^
```

This is failing on push to main. It's not clear why the check didn't pick it up in the PR.

https://github.com/digitalocean/terraform-provider-digitalocean/actions/runs/4117578398/jobs/7109046614#step:5:25