### PR TITLE
images: use correct pending statuses for custom images

### DIFF
--- a/digitalocean/image/resource_custom_image.go
+++ b/digitalocean/image/resource_custom_image.go
@@ -312,7 +312,7 @@ func distributeImageToRegions(client *godo.Client, imageId int, regions []interf
 
 // Ref: https://developers.digitalocean.com/documentation/v2/#retrieve-an-existing-image-by-id
 func imagePendingStatuses() []string {
-	return []string{"new", "pending"}
+	return []string{"NEW", "pending"}
 }
 
 // Ref:https://developers.digitalocean.com/documentation/v2/#create-a-custom-image


### PR DESCRIPTION
This PR changes the pending status of custom images from `new` to `NEW`. According to the API docs, this uppercase value is correct and I was receiving the following failure previously:

```
digitalocean_custom_image.talos-linux: Creating...
╷
│ Error: Error waiting for image (126518466) to become ready: unexpected state 'NEW', wanted target 'available'. last error: %!s(<nil>)
│
│   with digitalocean_custom_image.talos-linux,
│   on main.tf line 1, in resource "digitalocean_custom_image" "talos-linux":
│    1: resource "digitalocean_custom_image" "talos-linux" {
│
╵
```

I'm assuming the value changed in the API some time ago, but it's unclear to me from the docs when that might have been.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>