### PR TITLE
Fix formatting of Terraform configs in tests and enforce in PRs using terrafmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           only-new-issues: true
 
+      - name: Run terrafmt
+        run: make terrafmt-check
+
       - name: make test
         run: make test
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,6 +46,15 @@ fmt:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
+install-terrafmt:
+	@go install github.com/katbyte/terrafmt@latest
+
+terrafmt: install-terrafmt # Formats Terraform configuration blocks in tests.
+	@terrafmt fmt --fmtcompat digitalocean/
+
+terrafmt-check: install-terrafmt # Returns non-0 exit code if terrafmt would make a change.
+	@terrafmt diff --check --fmtcompat digitalocean/
+
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -842,7 +842,7 @@ func testAccCheckDigitalOceanAppExists(n string, app *godo.App) resource.TestChe
 var testAccCheckDigitalOceanAppConfig_basic = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     alert {
@@ -889,7 +889,7 @@ resource "digitalocean_app" "foobar" {
   }
 
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     service {
@@ -907,7 +907,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_addService = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     alert {
@@ -966,7 +966,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_addImage = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     service {
@@ -989,7 +989,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_addInternalPort = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     service {
@@ -1003,7 +1003,7 @@ resource "digitalocean_app" "foobar" {
         branch         = "main"
       }
 
-	  internal_ports = [ 5000 ]
+      internal_ports = [5000]
     }
   }
 }`
@@ -1011,7 +1011,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_addDatabase = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     alert {
@@ -1049,8 +1049,8 @@ resource "digitalocean_app" "foobar" {
     }
 
     database {
-      name = "test-db"
-      engine = "PG"
+      name       = "test-db"
+      engine     = "PG"
       production = false
     }
   }
@@ -1059,7 +1059,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_StaticSite = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     static_site {
@@ -1088,12 +1088,12 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_function = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "nyc"
 
     function {
-      name              = "example"
-	  source_dir        = "/"
+      name       = "example"
+      source_dir = "/"
       git {
         repo_clone_url = "https://github.com/digitalocean/sample-functions-nodejs-helloworld.git"
         branch         = "master"
@@ -1111,7 +1111,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_Envs = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     service {
@@ -1135,7 +1135,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_worker = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     worker {
@@ -1161,15 +1161,15 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_addJob = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     job {
       name               = "example-pre-job"
       instance_count     = 1
       instance_size_slug = "basic-xxs"
-      kind = "PRE_DEPLOY"
-      run_command = "echo 'This is a pre-deploy job.'"
+      kind               = "PRE_DEPLOY"
+      run_command        = "echo 'This is a pre-deploy job.'"
 
       image {
         registry_type = "DOCKER_HUB"
@@ -1199,8 +1199,8 @@ resource "digitalocean_app" "foobar" {
       name               = "example-post-job"
       instance_count     = 1
       instance_size_slug = "basic-xxs"
-      kind = "POST_DEPLOY"
-      run_command = "echo 'This is a post-deploy job.'"
+      kind               = "POST_DEPLOY"
+      run_command        = "echo 'This is a post-deploy job.'"
 
       image {
         registry_type = "DOCKER_HUB"
@@ -1213,7 +1213,7 @@ resource "digitalocean_app" "foobar" {
         name = "JobLogs"
         datadog {
           endpoint = "https://example.com"
-          api_key = "test-api-key"
+          api_key  = "test-api-key"
         }
       }
     }
@@ -1223,7 +1223,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_Domains = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "ams"
 
     %s
@@ -1245,7 +1245,7 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_CORS = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "nyc"
 
     service {

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -200,25 +200,25 @@ func generateBucketName() string {
 
 const testAccCheckDigitalOceanCDNConfig_Create = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "%s"
-	region = "ams3"
-	acl = "public-read"
+  name   = "%s"
+  region = "ams3"
+  acl    = "public-read"
 }
 
 resource "digitalocean_cdn" "foobar" {
-	origin = "${digitalocean_spaces_bucket.bucket.bucket_domain_name}"
+  origin = digitalocean_spaces_bucket.bucket.bucket_domain_name
 }`
 
 const testAccCheckDigitalOceanCDNConfig_Create_with_TTL = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "%s"
-	region = "ams3"
-	acl = "public-read"
+  name   = "%s"
+  region = "ams3"
+  acl    = "public-read"
 }
 
 resource "digitalocean_cdn" "foobar" {
-	origin = "${digitalocean_spaces_bucket.bucket.bucket_domain_name}"
-	ttl = %d
+  origin = digitalocean_spaces_bucket.bucket.bucket_domain_name
+  ttl    = %d
 }`
 
 func testAccCheckDigitalOceanCDNConfig_CustomDomain(domain string, spaceName string, certName string) string {
@@ -231,7 +231,7 @@ resource "tls_private_key" "example" {
 resource "tls_self_signed_cert" "example" {
   key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.example.private_key_pem
-  dns_names = ["foo.%s"]
+  dns_names       = ["foo.%s"]
   subject {
     common_name  = "foo.%s"
     organization = "%s"
@@ -247,15 +247,15 @@ resource "tls_self_signed_cert" "example" {
 }
 
 resource "digitalocean_spaces_bucket" "space" {
-  name = "%s"
+  name   = "%s"
   region = "sfo3"
 }
 
 resource "digitalocean_certificate" "spaces_cert" {
-  name              = "%s"
-  type              = "custom"
-  private_key       = tls_private_key.example.private_key_pem
-  leaf_certificate  = tls_self_signed_cert.example.cert_pem
+  name             = "%s"
+  type             = "custom"
+  private_key      = tls_private_key.example.private_key_pem
+  leaf_certificate = tls_self_signed_cert.example.cert_pem
 
   lifecycle {
     create_before_destroy = true

--- a/digitalocean/certificate/datasource_certificate_test.go
+++ b/digitalocean/certificate/datasource_certificate_test.go
@@ -73,11 +73,11 @@ func testAccCheckDataSourceDigitalOceanCertificateConfig_basic(
 ) string {
 	config := fmt.Sprintf(`
 resource "digitalocean_certificate" "foo" {
-  name = "%s"
-  private_key = <<EOF
+  name              = "%s"
+  private_key       = <<EOF
 %s
 EOF
-  leaf_certificate = <<EOF
+  leaf_certificate  = <<EOF
 %s
 EOF
   certificate_chain = <<EOF

--- a/digitalocean/certificate/resource_certificate_test.go
+++ b/digitalocean/certificate/resource_certificate_test.go
@@ -149,11 +149,11 @@ func testAccCheckDigitalOceanCertificateExists(n string, cert *godo.Certificate)
 func testAccCheckDigitalOceanCertificateConfig_basic(rInt int, privateKeyMaterial, leafCert, certChain string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_certificate" "foobar" {
-  name = "certificate-%d"
-  private_key = <<EOF
+  name              = "certificate-%d"
+  private_key       = <<EOF
 %s
 EOF
-  leaf_certificate = <<EOF
+  leaf_certificate  = <<EOF
 %s
 EOF
   certificate_chain = <<EOF
@@ -165,8 +165,8 @@ EOF
 func testAccCheckDigitalOceanCertificateConfig_customNoLeaf(rInt int, privateKeyMaterial, certChain string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_certificate" "foobar" {
-  name = "certificate-%d"
-  private_key = <<EOF
+  name              = "certificate-%d"
+  private_key       = <<EOF
 %s
 EOF
   certificate_chain = <<EOF
@@ -178,8 +178,8 @@ EOF
 func testAccCheckDigitalOceanCertificateConfig_customNoKey(rInt int, leafCert, certChain string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_certificate" "foobar" {
-  name = "certificate-%d"
-  leaf_certificate = <<EOF
+  name              = "certificate-%d"
+  leaf_certificate  = <<EOF
 %s
 EOF
   certificate_chain = <<EOF

--- a/digitalocean/database/datasource_database_cluster_test.go
+++ b/digitalocean/database/datasource_database_cluster_test.go
@@ -107,6 +107,6 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 data "digitalocean_database_cluster" "foobar" {
-  name = "${digitalocean_database_cluster.foobar.name}"
+  name = digitalocean_database_cluster.foobar.name
 }
 `

--- a/digitalocean/database/datasource_database_cluster_test.go
+++ b/digitalocean/database/datasource_database_cluster_test.go
@@ -85,28 +85,28 @@ func testAccCheckDataSourceDigitalOceanDatabaseClusterExists(n string, databaseC
 
 const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 }
 `
 
 const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigWithDatasource = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 }
 
 data "digitalocean_database_cluster" "foobar" {
-   name = "${digitalocean_database_cluster.foobar.name}"
+  name = "${digitalocean_database_cluster.foobar.name}"
 }
 `

--- a/digitalocean/database/datasource_database_replica_test.go
+++ b/digitalocean/database/datasource_database_replica_test.go
@@ -84,7 +84,7 @@ func TestAccDataSourceDigitalOceanDatabaseReplica_Basic(t *testing.T) {
 const (
 	testAccCheckDigitalOceanDatasourceDatabaseReplicaConfigBasic = `
 data "digitalocean_database_replica" "my_db_replica" {
-	cluster_id = digitalocean_database_cluster.foobar.id
-	name       = "%s"
-	}`
+  cluster_id = digitalocean_database_cluster.foobar.id
+  name       = "%s"
+}`
 )

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -539,188 +539,188 @@ func testAccCheckDigitalOceanDatabaseClusterURIPassword(name string, attributeNa
 
 const testAccCheckDigitalOceanDatabaseClusterConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-2gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-2gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithMigration = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "lon1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "lon1"
+  node_count = 1
+  tags       = ["production"]
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithMaintWindow = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 
-	maintenance_window {
-        day  = "friday"
-        hour = "13:00:00"
-	}
+  maintenance_window {
+    day  = "friday"
+    hour = "13:00:00"
+  }
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithSQLMode = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mysql"
-	version    = "8"
-	size       = "db-s-1vcpu-1gb"
-	region     = "lon1"
-    node_count = 1
-    sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE"
+  name       = "%s"
+  engine     = "mysql"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "lon1"
+  node_count = 1
+  sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE"
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithSQLModeUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mysql"
-	version    = "8"
-	size       = "db-s-1vcpu-1gb"
-	region     = "lon1"
-    node_count = 1
-    sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
+  name       = "%s"
+  engine     = "mysql"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "lon1"
+  node_count = 1
+  sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithRedisSQLModeError = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "redis"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-    sql_mode   = "ANSI"
+  name       = "%s"
+  engine     = "redis"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  sql_mode   = "ANSI"
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterRedisNoVersion = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "redis"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "redis"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterRedis = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "redis"
-	version    = "%s"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production"]
+  name       = "%s"
+  engine     = "redis"
+  version    = "%s"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithEvictionPolicy = `
 resource "digitalocean_database_cluster" "foobar" {
-	name            = "%s"
-	engine          = "redis"
-	version         = "5"
-	size            = "db-s-1vcpu-1gb"
-	region          = "nyc1"
-    node_count      = 1
-	tags            = ["production"]
-	eviction_policy = "volatile_random"
+  name            = "%s"
+  engine          = "redis"
+  version         = "5"
+  size            = "db-s-1vcpu-1gb"
+  region          = "nyc1"
+  node_count      = 1
+  tags            = ["production"]
+  eviction_policy = "volatile_random"
 }
 `
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithEvictionPolicyUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
-	name            = "%s"
-	engine          = "redis"
-	version         = "5"
-	size            = "db-s-1vcpu-1gb"
-	region          = "nyc1"
-    node_count      = 1
-	tags            = ["production"]
-	eviction_policy = "allkeys_lru"
+  name            = "%s"
+  engine          = "redis"
+  version         = "5"
+  size            = "db-s-1vcpu-1gb"
+  region          = "nyc1"
+  node_count      = 1
+  tags            = ["production"]
+  eviction_policy = "allkeys_lru"
 }
 `
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithEvictionPolicyError = `
 resource "digitalocean_database_cluster" "foobar" {
-	name            = "%s"
-	engine          = "pg"
-	version         = "11"
-	size            = "db-s-1vcpu-1gb"
-	region          = "nyc1"
-    node_count      = 1
-	eviction_policy = "allkeys_lru"
+  name            = "%s"
+  engine          = "pg"
+  version         = "11"
+  size            = "db-s-1vcpu-1gb"
+  region          = "nyc1"
+  node_count      = 1
+  eviction_policy = "allkeys_lru"
 }
 `
 
 const testAccCheckDigitalOceanDatabaseClusterConfigTagUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-    node_count = 1
-	tags       = ["production", "foo"]
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production", "foo"]
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigWithVPC = `
 resource "digitalocean_vpc" "foobar" {
-  name        = "%s"
-  region      = "nyc1"
+  name   = "%s"
+  region = "nyc1"
 }
 
 resource "digitalocean_database_cluster" "foobar" {
-	name                 = "%s"
-	engine               = "pg"
-	version              = "11"
-	size                 = "db-s-1vcpu-1gb"
-	region               = "nyc1"
-	node_count           = 1
-	tags                 = ["production"]
-	private_network_uuid = digitalocean_vpc.foobar.id
+  name                 = "%s"
+  engine               = "pg"
+  version              = "11"
+  size                 = "db-s-1vcpu-1gb"
+  region               = "nyc1"
+  node_count           = 1
+  tags                 = ["production"]
+  private_network_uuid = digitalocean_vpc.foobar.id
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigMongoDB = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mongodb"
-	version    = "4"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc3"
-    node_count = 1
+  name       = "%s"
+  engine     = "mongodb"
+  version    = "4"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc3"
+  node_count = 1
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterConfigCustomVersion = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "%s"
-	version    = "%s"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc3"
-    node_count = 1
+  name       = "%s"
+  engine     = "%s"
+  version    = "%s"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc3"
+  node_count = 1
 }`

--- a/digitalocean/database/resource_database_connection_pool_test.go
+++ b/digitalocean/database/resource_database_connection_pool_test.go
@@ -195,12 +195,12 @@ func testAccCheckDigitalOceanDatabaseConnectionPoolAttributes(databaseConnection
 
 const testAccCheckDigitalOceanDatabaseConnectionPoolConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_connection_pool" "pool-01" {
@@ -214,12 +214,12 @@ resource "digitalocean_database_connection_pool" "pool-01" {
 
 const testAccCheckDigitalOceanDatabaseConnectionPoolConfigUpdated = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_connection_pool" "pool-01" {
@@ -232,12 +232,12 @@ resource "digitalocean_database_connection_pool" "pool-01" {
 
 const testAccCheckDigitalOceanDatabaseConnectionPoolConfigBad = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_connection_pool" "pool-01" {
@@ -251,12 +251,12 @@ resource "digitalocean_database_connection_pool" "pool-01" {
 
 const testAccCheckDigitalOceanDatabaseConnectionPoolConfigInboundUser = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_connection_pool" "pool-01" {

--- a/digitalocean/database/resource_database_db_test.go
+++ b/digitalocean/database/resource_database_db_test.go
@@ -143,17 +143,17 @@ func testAccCheckDigitalOceanDatabaseDBAttributes(databaseDB *godo.DatabaseDB, n
 
 const testAccCheckDigitalOceanDatabaseDBConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 
-	maintenance_window {
-        day  = "friday"
-        hour = "13:00:00"
-	}
+  maintenance_window {
+    day  = "friday"
+    hour = "13:00:00"
+  }
 }
 
 resource "digitalocean_database_db" "foobar_db" {

--- a/digitalocean/database/resource_database_db_test.go
+++ b/digitalocean/database/resource_database_db_test.go
@@ -157,6 +157,6 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 resource "digitalocean_database_db" "foobar_db" {
-  cluster_id = "${digitalocean_database_cluster.foobar.id}"
+  cluster_id = digitalocean_database_cluster.foobar.id
   name       = "%s"
 }`

--- a/digitalocean/database/resource_database_firewall_test.go
+++ b/digitalocean/database/resource_database_firewall_test.go
@@ -90,73 +90,73 @@ func testAccCheckDigitalOceanDatabaseFirewallDestroy(s *terraform.State) error {
 
 const testAccCheckDigitalOceanDatabaseFirewallConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_firewall" "example" {
-	cluster_id = digitalocean_database_cluster.foobar.id
+  cluster_id = digitalocean_database_cluster.foobar.id
 
-	rule {
-		type  = "ip_addr"
-		value = "192.168.1.1"
-	}
+  rule {
+    type  = "ip_addr"
+    value = "192.168.1.1"
+  }
 }
 `
 
 const testAccCheckDigitalOceanDatabaseFirewallConfigAddRule = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_firewall" "example" {
-	cluster_id = digitalocean_database_cluster.foobar.id
+  cluster_id = digitalocean_database_cluster.foobar.id
 
-	rule {
-		type  = "ip_addr"
-		value = "192.168.1.1"
-	}
+  rule {
+    type  = "ip_addr"
+    value = "192.168.1.1"
+  }
 
-	rule {
-		type  = "ip_addr"
-		value = "192.0.2.0"
-	}
+  rule {
+    type  = "ip_addr"
+    value = "192.0.2.0"
+  }
 }
 `
 
 const testAccCheckDigitalOceanDatabaseFirewallConfigMultipleResourceTypes = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_droplet" "foobar" {
-	name      = "%s"
-	size      = "s-1vcpu-1gb"
-	image     = "ubuntu-22-04-x64"
-	region    = "nyc3"
+  name   = "%s"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_tag" "foobar" {
-	name = "%s"
+  name = "%s"
 }
 
 resource "digitalocean_app" "foobar" {
   spec {
-    name = "%s"
+    name   = "%s"
     region = "nyc"
 
     service {
@@ -174,26 +174,26 @@ resource "digitalocean_app" "foobar" {
 }
 
 resource "digitalocean_database_firewall" "example" {
-	cluster_id = digitalocean_database_cluster.foobar.id
+  cluster_id = digitalocean_database_cluster.foobar.id
 
-	rule {
-		type  = "ip_addr"
-		value = "192.168.1.1"
-	}
+  rule {
+    type  = "ip_addr"
+    value = "192.168.1.1"
+  }
 
-	rule {
-		type  = "droplet"
-		value = digitalocean_droplet.foobar.id
-	}
+  rule {
+    type  = "droplet"
+    value = digitalocean_droplet.foobar.id
+  }
 
-	rule {
-		type  = "tag"
-		value = digitalocean_tag.foobar.name
-	}
+  rule {
+    type  = "tag"
+    value = digitalocean_tag.foobar.name
+  }
 
-	rule {
-		type  = "app"
-		value = digitalocean_app.foobar.id
-	}
+  rule {
+    type  = "app"
+    value = digitalocean_app.foobar.id
+  }
 }
 `

--- a/digitalocean/database/resource_database_replica_test.go
+++ b/digitalocean/database/resource_database_replica_test.go
@@ -179,16 +179,17 @@ resource "digitalocean_database_replica" "read-01" {
   name       = "%s"
   region     = "nyc3"
   size       = "db-s-2vcpu-4gb"
-  tags       =	["staging"]
+  tags       = ["staging"]
 }`
 
 const testAccCheckDigitalOceanDatabaseReplicaConfigWithVPC = `
 
+
 resource "digitalocean_database_replica" "read-01" {
-  cluster_id = digitalocean_database_cluster.foobar.id
-  name       = "%s"
-  region     = "nyc1"
-  size       = "db-s-2vcpu-4gb"
-  tags       =	["staging"]
+  cluster_id           = digitalocean_database_cluster.foobar.id
+  name                 = "%s"
+  region               = "nyc1"
+  size                 = "db-s-2vcpu-4gb"
+  tags                 = ["staging"]
   private_network_uuid = digitalocean_vpc.foobar.id
 }`

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -232,17 +232,17 @@ func testAccCheckDigitalOceanDatabaseUserAttributes(databaseUser *godo.DatabaseU
 
 const testAccCheckDigitalOceanDatabaseUserConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "pg"
-	version    = "11"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 
-	maintenance_window {
-        day  = "friday"
-        hour = "13:00:00"
-	}
+  maintenance_window {
+    day  = "friday"
+    hour = "13:00:00"
+  }
 }
 
 resource "digitalocean_database_user" "foobar_user" {
@@ -252,17 +252,17 @@ resource "digitalocean_database_user" "foobar_user" {
 
 const testAccCheckDigitalOceanDatabaseUserConfigMongo = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mongodb"
-	version    = "4"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "mongodb"
+  version    = "4"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 
-	maintenance_window {
-        day  = "friday"
-        hour = "13:00:00"
-	}
+  maintenance_window {
+    day  = "friday"
+    hour = "13:00:00"
+  }
 }
 
 resource "digitalocean_database_user" "foobar_user" {
@@ -272,44 +272,44 @@ resource "digitalocean_database_user" "foobar_user" {
 
 const testAccCheckDigitalOceanDatabaseUserConfigMySQLAuth = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mysql"
-	version    = "8"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "mysql"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id = "${digitalocean_database_cluster.foobar.id}"
-  name       = "%s"
+  cluster_id        = "${digitalocean_database_cluster.foobar.id}"
+  name              = "%s"
   mysql_auth_plugin = "mysql_native_password"
 }`
 
 const testAccCheckDigitalOceanDatabaseUserConfigMySQLAuthUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mysql"
-	version    = "8"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "mysql"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id = "${digitalocean_database_cluster.foobar.id}"
-  name       = "%s"
+  cluster_id        = "${digitalocean_database_cluster.foobar.id}"
+  name              = "%s"
   mysql_auth_plugin = "caching_sha2_password"
 }`
 
 const testAccCheckDigitalOceanDatabaseUserConfigMySQLAuthRemoved = `
 resource "digitalocean_database_cluster" "foobar" {
-	name       = "%s"
-	engine     = "mysql"
-	version    = "8"
-	size       = "db-s-1vcpu-1gb"
-	region     = "nyc1"
-	node_count = 1
+  name       = "%s"
+  engine     = "mysql"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
 }
 
 resource "digitalocean_database_user" "foobar_user" {

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -246,7 +246,7 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id = "${digitalocean_database_cluster.foobar.id}"
+  cluster_id = digitalocean_database_cluster.foobar.id
   name       = "%s"
 }`
 
@@ -266,7 +266,7 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id = "${digitalocean_database_cluster.foobar.id}"
+  cluster_id = digitalocean_database_cluster.foobar.id
   name       = "%s"
 }`
 
@@ -281,7 +281,7 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id        = "${digitalocean_database_cluster.foobar.id}"
+  cluster_id        = digitalocean_database_cluster.foobar.id
   name              = "%s"
   mysql_auth_plugin = "mysql_native_password"
 }`
@@ -297,7 +297,7 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id        = "${digitalocean_database_cluster.foobar.id}"
+  cluster_id        = digitalocean_database_cluster.foobar.id
   name              = "%s"
   mysql_auth_plugin = "caching_sha2_password"
 }`
@@ -313,6 +313,6 @@ resource "digitalocean_database_cluster" "foobar" {
 }
 
 resource "digitalocean_database_user" "foobar_user" {
-  cluster_id = "${digitalocean_database_cluster.foobar.id}"
+  cluster_id = digitalocean_database_cluster.foobar.id
   name       = "%s"
 }`

--- a/digitalocean/domain/datasource_domain_test.go
+++ b/digitalocean/domain/datasource_domain_test.go
@@ -26,7 +26,7 @@ resource "digitalocean_domain" "foo" {
 
 	dataSourceConfig := `
 data "digitalocean_domain" "foobar" {
-  name       = digitalocean_domain.foo.name
+  name = digitalocean_domain.foo.name
 }`
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/domain/datasource_domains_test.go
+++ b/digitalocean/domain/datasource_domains_test.go
@@ -14,18 +14,18 @@ func TestAccDataSourceDigitalOceanDomains_Basic(t *testing.T) {
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_domain" "foo" {
-  name     = "%s"
+  name = "%s"
 }
 
 resource "digitalocean_domain" "bar" {
-  name     = "%s"
+  name = "%s"
 }
 `, name1, name2)
 
 	datasourceConfig := fmt.Sprintf(`
 data "digitalocean_domains" "result" {
   filter {
-    key = "name"
+    key    = "name"
     values = ["%s"]
   }
 }

--- a/digitalocean/domain/datasource_record_test.go
+++ b/digitalocean/domain/datasource_record_test.go
@@ -31,8 +31,8 @@ resource "digitalocean_record" "foo" {
 }`, recordDomain, recordName)
 	dataSourceConfig := `
 data "digitalocean_record" "foobar" {
-  name      = digitalocean_record.foo.name
-  domain    = digitalocean_domain.foo.name
+  name   = digitalocean_record.foo.name
+  domain = digitalocean_domain.foo.name
 }`
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/domain/datasource_records_test.go
+++ b/digitalocean/domain/datasource_records_test.go
@@ -17,18 +17,18 @@ resource "digitalocean_domain" "foo" {
 }
 
 resource "digitalocean_record" "mail" {
-  name = "mail"
-  domain = digitalocean_domain.foo.name
-  type = "MX"
+  name     = "mail"
+  domain   = digitalocean_domain.foo.name
+  type     = "MX"
   priority = 10
-  value = "mail.example.com."
+  value    = "mail.example.com."
 }
 
 resource "digitalocean_record" "www" {
-  name = "www"
+  name   = "www"
   domain = digitalocean_domain.foo.name
-  type = "A"
-  value = "192.168.1.1"
+  type   = "A"
+  value  = "192.168.1.1"
 }
 `, name1)
 
@@ -36,7 +36,7 @@ resource "digitalocean_record" "www" {
 data "digitalocean_records" "result" {
   domain = "%s"
   filter {
-    key = "type"
+    key    = "type"
     values = ["A"]
   }
 }

--- a/digitalocean/domain/resource_domain_test.go
+++ b/digitalocean/domain/resource_domain_test.go
@@ -126,11 +126,11 @@ func testAccCheckDigitalOceanDomainExists(n string, domain *godo.Domain) resourc
 
 const testAccCheckDigitalOceanDomainConfig_basic = `
 resource "digitalocean_domain" "foobar" {
-	name       = "%s"
-	ip_address = "192.168.0.10"
+  name       = "%s"
+  ip_address = "192.168.0.10"
 }`
 
 const testAccCheckDigitalOceanDomainConfig_withoutIp = `
 resource "digitalocean_domain" "foobar" {
-	name       = "%s"
+  name = "%s"
 }`

--- a/digitalocean/domain/resource_record_test.go
+++ b/digitalocean/domain/resource_record_test.go
@@ -777,7 +777,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform"
   value = "192.168.0.10"
@@ -791,7 +791,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform.${digitalocean_domain.foobar.name}."
   value = "192.168.0.10"
@@ -805,7 +805,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform"
   value = "192.168.0.11"
@@ -820,7 +820,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform"
   value = "a.foobar-test-terraform.com."
@@ -834,7 +834,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foo_record" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name     = "terraform"
   value    = "${digitalocean_domain.foobar.name}."
@@ -849,7 +849,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foo_record" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name     = "terraform"
   value    = "foobar.${digitalocean_domain.foobar.name}."
@@ -864,7 +864,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform"
   value = "a.foobar-test-terraform.net."
@@ -878,7 +878,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform"
   type  = "CAA"
@@ -894,7 +894,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foo_record" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name     = "_service._protocol"
   value    = "foobar.${digitalocean_domain.foobar.name}."
@@ -911,7 +911,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foobar" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "%s"
   value = "%s"
@@ -926,7 +926,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foo_record" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name     = "terraform"
   value    = "foobar.${digitalocean_domain.foobar.name}."
@@ -941,7 +941,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foo_record" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name     = "_service._protocol"
   value    = "foobar.${digitalocean_domain.foobar.name}."
@@ -958,7 +958,7 @@ resource "digitalocean_domain" "foobar" {
 }
 
 resource "digitalocean_record" "foo_record" {
-  domain = "${digitalocean_domain.foobar.name}"
+  domain = digitalocean_domain.foobar.name
 
   name  = "terraform"
   type  = "CAA"

--- a/digitalocean/domain/resource_record_test.go
+++ b/digitalocean/domain/resource_record_test.go
@@ -590,35 +590,35 @@ func TestAccDigitalOceanRecord_TXT(t *testing.T) {
 func TestAccDigitalOceanRecord_ExpectedErrors(t *testing.T) {
 	var (
 		srvNoPort = `resource "digitalocean_record" "pgsql_default_pub_srv" {
-    domain = "example.com"
+  domain = "example.com"
 
-    type = "SRV"
-    name = "_postgresql_.tcp.example.com"
+  type = "SRV"
+  name = "_postgresql_.tcp.example.com"
 
-    // priority can be 0, but must be set.
-    priority = 0
-    weight = 0
-    value = "srv.example.com"
+  // priority can be 0, but must be set.
+  priority = 0
+  weight   = 0
+  value    = "srv.example.com"
 }`
 		srvNoPrirority = `resource "digitalocean_record" "pgsql_default_pub_srv" {
-    domain = "example.com"
+  domain = "example.com"
 
-    type = "SRV"
-    name = "_postgresql_.tcp.example.com"
+  type = "SRV"
+  name = "_postgresql_.tcp.example.com"
 
-    port   = 3600
-    weight = 0
-    value  = "srv.example.com"
+  port   = 3600
+  weight = 0
+  value  = "srv.example.com"
 }`
 		srvNoWeight = `resource "digitalocean_record" "pgsql_default_pub_srv" {
-    domain = "example.com"
+  domain = "example.com"
 
-    type = "SRV"
-    name = "_postgresql._tcp.example.com"
+  type = "SRV"
+  name = "_postgresql._tcp.example.com"
 
-    port   = 3600
-	priority = 10
-    value  = "srv.example.com"
+  port     = 3600
+  priority = 10
+  value    = "srv.example.com"
 }`
 		mxNoPriority = `resource "digitalocean_record" "foo_record" {
   domain = "example.com"
@@ -641,7 +641,7 @@ func TestAccDigitalOceanRecord_ExpectedErrors(t *testing.T) {
   name  = "cert"
   type  = "CAA"
   value = "letsencrypt.org."
-  flags   = 1
+  flags = 1
 }`
 	)
 
@@ -836,9 +836,9 @@ resource "digitalocean_domain" "foobar" {
 resource "digitalocean_record" "foo_record" {
   domain = "${digitalocean_domain.foobar.name}"
 
-  name  = "terraform"
-  value = "${digitalocean_domain.foobar.name}."
-  type  = "MX"
+  name     = "terraform"
+  value    = "${digitalocean_domain.foobar.name}."
+  type     = "MX"
   priority = "10"
 }`
 
@@ -969,24 +969,24 @@ resource "digitalocean_record" "foo_record" {
 
 const testAccCheckDigitalOceanRecordConfig_iodef = `
 resource "digitalocean_domain" "foobar" {
-  name       = "%s"
+  name = "%s"
 }
 resource "digitalocean_record" "CAA_iodef" {
   domain = digitalocean_domain.foobar.name
-  type  = "CAA"
-  tag   = "iodef"
-  flags = "0"
-  name  = "@"
-  value = "mailto:caa-failures@example.com"
+  type   = "CAA"
+  tag    = "iodef"
+  flags  = "0"
+  name   = "@"
+  value  = "mailto:caa-failures@example.com"
 }`
 
 const testAccCheckDigitalOceanRecordTXT = `
 resource "digitalocean_domain" "foobar" {
-  name       = "%s"
+  name = "%s"
 }
 resource "digitalocean_record" "txt" {
   domain = digitalocean_domain.foobar.name
-  type  = "TXT"
-  name  = "%s."
-  value = "v=spf1 a:smtp01.example.com a:mail.example.com -all"
+  type   = "TXT"
+  name   = "%s."
+  value  = "v=spf1 a:smtp01.example.com a:mail.example.com -all"
 }`

--- a/digitalocean/droplet/datasource_droplet_test.go
+++ b/digitalocean/droplet/datasource_droplet_test.go
@@ -160,8 +160,8 @@ func testAccCheckDataSourceDigitalOceanDropletExists(n string, droplet *godo.Dro
 func testAccCheckDataSourceDigitalOceanDropletConfig_basicByName(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_vpc" "foobar" {
-  name        = "%s"
-  region      = "nyc3"
+  name   = "%s"
+  region = "nyc3"
 }
 
 resource "digitalocean_droplet" "foo" {

--- a/digitalocean/droplet/datasource_droplets_test.go
+++ b/digitalocean/droplet/datasource_droplets_test.go
@@ -15,24 +15,24 @@ func TestAccDataSourceDigitalOceanDroplets_Basic(t *testing.T) {
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_droplet" "foo" {
-  name     = "%s"
-  size     = "s-1vcpu-1gb"
-  image    = "ubuntu-22-04-x64"
-  region   = "nyc3"
+  name   = "%s"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_droplet" "bar" {
-  name     = "%s"
-  size     = "s-1vcpu-1gb"
-  image    = "ubuntu-22-04-x64"
-  region   = "nyc3"
+  name   = "%s"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 `, name1, name2)
 
 	datasourceConfig := fmt.Sprintf(`
 data "digitalocean_droplets" "result" {
   filter {
-    key = "name"
+    key    = "name"
     values = ["%s"]
   }
 }

--- a/digitalocean/droplet/import_droplet_test.go
+++ b/digitalocean/droplet/import_droplet_test.go
@@ -112,7 +112,7 @@ data "digitalocean_image" "snapshot" {
 resource "digitalocean_droplet" "from-snapshot" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "${data.digitalocean_image.snapshot.id}"
+  image     = data.digitalocean_image.snapshot.id
   region    = "nyc3"
   user_data = "foobar"
 }`, rInt, rInt)

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -648,12 +648,12 @@ func TestAccDigitalOceanDroplet_withTimeout(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "digitalocean_droplet" "foobar" {
-  name              = "%s"
-  size              = "s-1vcpu-1gb"
-  image             = "ubuntu-22-04-x64"
-  region            = "nyc3"
+  name   = "%s"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
   timeouts {
-	create = "5s"
+    create = "5s"
   }
 }`, dropletName),
 				ExpectError: regexp.MustCompile(`timeout while waiting for state`),
@@ -674,9 +674,9 @@ func TestAccDigitalOceanDroplet_Regionless(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name              = "%s"
-  size              = "s-1vcpu-1gb"
-  image             = "ubuntu-22-04-x64"
+  name  = "%s"
+  size  = "s-1vcpu-1gb"
+  image = "ubuntu-22-04-x64"
 }`, dropletName),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -856,7 +856,7 @@ resource "digitalocean_droplet" "foobar" {
 func testAccCheckDigitalOceanDropletConfig_tag_update(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_tag" "barbaz" {
-  name       = "barbaz"
+  name = "barbaz"
 }
 
 resource "digitalocean_droplet" "foobar" {
@@ -865,7 +865,7 @@ resource "digitalocean_droplet" "foobar" {
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
-  tags  = ["${digitalocean_tag.barbaz.id}"]
+  tags      = ["${digitalocean_tag.barbaz.id}"]
 }
 `, rInt)
 }
@@ -885,10 +885,10 @@ resource "digitalocean_droplet" "foobar" {
 func testAccCheckDigitalOceanDropletConfig_RenameAndResize(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name     = "baz-%d"
-  size     = "s-1vcpu-2gb"
-  image    = "ubuntu-22-04-x64"
-  region   = "nyc3"
+  name   = "baz-%d"
+  size   = "s-1vcpu-2gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 `, rInt)
 }
@@ -896,11 +896,11 @@ resource "digitalocean_droplet" "foobar" {
 func testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name     = "foo-%d"
-  size     = "s-1vcpu-2gb"
-  image    = "ubuntu-22-04-x64"
-  region   = "nyc3"
-  user_data = "foobar"
+  name        = "foo-%d"
+  size        = "s-1vcpu-2gb"
+  image       = "ubuntu-22-04-x64"
+  region      = "nyc3"
+  user_data   = "foobar"
   resize_disk = false
 }
 `, rInt)
@@ -909,11 +909,11 @@ resource "digitalocean_droplet" "foobar" {
 func testAccCheckDigitalOceanDropletConfig_resize(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name     = "foo-%d"
-  size     = "s-1vcpu-2gb"
-  image    = "ubuntu-22-04-x64"
-  region   = "nyc3"
-  user_data = "foobar"
+  name        = "foo-%d"
+  size        = "s-1vcpu-2gb"
+  image       = "ubuntu-22-04-x64"
+  region      = "nyc3"
+  user_data   = "foobar"
   resize_disk = true
 }
 `, rInt)
@@ -935,8 +935,8 @@ resource "digitalocean_droplet" "foobar" {
 func testAccCheckDigitalOceanDropletConfig_VPCAndIpv6(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_vpc" "foobar" {
-  name        = "%s"
-  region      = "nyc3"
+  name   = "%s"
+  region = "nyc3"
 }
 
 resource "digitalocean_droplet" "foobar" {
@@ -958,32 +958,32 @@ resource "digitalocean_droplet" "foobar" {
   image      = "ubuntu-22-04-x64"
   region     = "nyc3"
   monitoring = true
- }
+}
  `, rInt)
 }
 
 func testAccCheckDigitalOceanDropletConfig_conditionalVolumes(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "myvol-01" {
-    region      = "sfo3"
-    name        = "tf-acc-test-1-%d"
-    size        = 1
-    description = "an example volume"
+  region      = "sfo3"
+  name        = "tf-acc-test-1-%d"
+  size        = 1
+  description = "an example volume"
 }
 
 resource "digitalocean_volume" "myvol-02" {
-    region      = "sfo3"
-    name        = "tf-acc-test-2-%d"
-    size        = 1
-    description = "an example volume"
+  region      = "sfo3"
+  name        = "tf-acc-test-2-%d"
+  size        = 1
+  description = "an example volume"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  count = 2
-  name = "tf-acc-test-%d-${count.index}"
-  region = "sfo3"
-  image = "ubuntu-22-04-x64"
-  size = "s-1vcpu-1gb"
+  count      = 2
+  name       = "tf-acc-test-%d-${count.index}"
+  region     = "sfo3"
+  image      = "ubuntu-22-04-x64"
+  size       = "s-1vcpu-1gb"
   volume_ids = ["${count.index == 0 ? digitalocean_volume.myvol-01.id : digitalocean_volume.myvol-02.id}"]
 }
 `, rInt, rInt, rInt)
@@ -1021,11 +1021,11 @@ resource "digitalocean_ssh_key" "foobar" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "%s"
-  region    = "nyc3"
-  ssh_keys  = [digitalocean_ssh_key.foobar.id]
+  name     = "%s"
+  size     = "s-1vcpu-1gb"
+  image    = "%s"
+  region   = "nyc3"
+  ssh_keys = [digitalocean_ssh_key.foobar.id]
   %s
 }`, keyName, testAccValidPublicKey, dropletName, image, agent)
 }

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -830,7 +830,7 @@ data "digitalocean_image" "foobar" {
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
   size      = "s-1vcpu-1gb"
-  image     = "${data.digitalocean_image.foobar.id}"
+  image     = data.digitalocean_image.foobar.id
   region    = "nyc3"
   user_data = "foobar"
 }`, slug, rInt)
@@ -849,7 +849,7 @@ resource "digitalocean_droplet" "foobar" {
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
-  ssh_keys  = ["${digitalocean_ssh_key.foobar.id}"]
+  ssh_keys  = [digitalocean_ssh_key.foobar.id]
 }`, rInt, testAccValidPublicKey, rInt)
 }
 
@@ -865,7 +865,7 @@ resource "digitalocean_droplet" "foobar" {
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
-  tags      = ["${digitalocean_tag.barbaz.id}"]
+  tags      = [digitalocean_tag.barbaz.id]
 }
 `, rInt)
 }
@@ -984,7 +984,7 @@ resource "digitalocean_droplet" "foobar" {
   region     = "sfo3"
   image      = "ubuntu-22-04-x64"
   size       = "s-1vcpu-1gb"
-  volume_ids = ["${count.index == 0 ? digitalocean_volume.myvol-01.id : digitalocean_volume.myvol-02.id}"]
+  volume_ids = [count.index == 0 ? digitalocean_volume.myvol-01.id : digitalocean_volume.myvol-02.id]
 }
 `, rInt, rInt, rInt)
 }

--- a/digitalocean/firewall/datasource_firewall_test.go
+++ b/digitalocean/firewall/datasource_firewall_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceDigitalOceanFirewall_Basic(t *testing.T) {
 	fwDataConfig := `
 data "digitalocean_firewall" "foobar" {
-	firewall_id = digitalocean_firewall.foobar.id
+  firewall_id = digitalocean_firewall.foobar.id
 }`
 
 	var firewall godo.Firewall

--- a/digitalocean/firewall/resource_firewall_test.go
+++ b/digitalocean/firewall/resource_firewall_test.go
@@ -181,119 +181,119 @@ func TestAccDigitalOceanFirewall_ImportMultipleRules(t *testing.T) {
 
 func testAccDigitalOceanFirewallConfig_OnlyInbound(rName string) string {
 	return fmt.Sprintf(`
-	resource "digitalocean_firewall" "foobar" {
-				name          = "foobar-%s"
-				inbound_rule {
-					protocol         = "tcp"
-					port_range       = "22"
-					source_addresses = ["0.0.0.0/0", "::/0"]
-				}
+resource "digitalocean_firewall" "foobar" {
+  name = "foobar-%s"
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
 
-			}
+}
 	`, rName)
 }
 
 func testAccDigitalOceanFirewallConfig_OnlyOutbound(rName string) string {
 	return fmt.Sprintf(`
-	resource "digitalocean_firewall" "foobar" {
-				name          = "foobar-%s"
-				outbound_rule {
-					protocol              = "tcp"
-					port_range            = "22"
-					destination_addresses = ["0.0.0.0/0", "::/0"]
-				}
+resource "digitalocean_firewall" "foobar" {
+  name = "foobar-%s"
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "22"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
 
-			}
+}
 	`, rName)
 }
 
 func testAccDigitalOceanFirewallConfig_OnlyMultipleInbound(rName string) string {
 	return fmt.Sprintf(`
-	resource "digitalocean_firewall" "foobar" {
-				name          = "foobar-%s"
-				inbound_rule {
-					protocol         = "tcp"
-					port_range       = "22"
-					source_addresses = ["0.0.0.0/0", "::/0"]
-				}
-				inbound_rule {
-					protocol         = "tcp"
-					port_range       = "80"
-					source_addresses = ["1.2.3.0/24", "2002::/16"]
-				}
+resource "digitalocean_firewall" "foobar" {
+  name = "foobar-%s"
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["1.2.3.0/24", "2002::/16"]
+  }
 
-			}
+}
 	`, rName)
 }
 
 func testAccDigitalOceanFirewallConfig_OnlyMultipleOutbound(rName string) string {
 	return fmt.Sprintf(`
-	resource "digitalocean_firewall" "foobar" {
-				name          = "foobar-%s"
-				outbound_rule {
-					protocol              = "tcp"
-					port_range            = "22"
-					destination_addresses = ["192.168.1.0/24", "2002:1001::/48"]
-				}
-				outbound_rule {
-					protocol              = "udp"
-					port_range            = "53"
-					destination_addresses = ["1.2.3.0/24", "2002::/16"]
-				}
+resource "digitalocean_firewall" "foobar" {
+  name = "foobar-%s"
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "22"
+    destination_addresses = ["192.168.1.0/24", "2002:1001::/48"]
+  }
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "53"
+    destination_addresses = ["1.2.3.0/24", "2002::/16"]
+  }
 
-			}
+}
 	`, rName)
 }
 
 func testAccDigitalOceanFirewallConfig_MultipleInboundAndOutbound(tagName string, rName string) string {
 	return fmt.Sprintf(`
-	resource "digitalocean_tag" "foobar" {
-		name = "%s"
-	}
+resource "digitalocean_tag" "foobar" {
+  name = "%s"
+}
 
-	resource "digitalocean_firewall" "foobar" {
-				name          = "foobar-%s"
-				inbound_rule {
-					protocol         = "tcp"
-					port_range       = "22"
-					source_addresses = ["0.0.0.0/0", "::/0"]
-				}
-				inbound_rule {
-					protocol         = "tcp"
-					port_range       = "443"
-					source_addresses = ["192.168.1.0/24", "2002:1001:1:2::/64"]
-					source_tags      = ["%s"]
-				}
-				outbound_rule {
-					protocol              = "tcp"
-					port_range            = "443"
-					destination_addresses = ["192.168.1.0/24", "2002:1001:1:2::/64"]
-					destination_tags      = ["%s"]
-				}
-				outbound_rule {
-					protocol              = "udp"
-					port_range            = "53"
-					destination_addresses = ["0.0.0.0/0", "::/0"]
-				}
+resource "digitalocean_firewall" "foobar" {
+  name = "foobar-%s"
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["192.168.1.0/24", "2002:1001:1:2::/64"]
+    source_tags      = ["%s"]
+  }
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "443"
+    destination_addresses = ["192.168.1.0/24", "2002:1001:1:2::/64"]
+    destination_tags      = ["%s"]
+  }
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "53"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
 
-			}
+}
 	`, tagName, rName, tagName, tagName)
 }
 
 func testAccDigitalOceanFirewallConfig_fullPortRange(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-	name          = "foobar-%s"
-	inbound_rule {
-		protocol         = "tcp"
-		port_range       = "all"
-		source_addresses = ["192.168.1.1/32"]
-	}
-	outbound_rule {
-		protocol              = "tcp"
-		port_range            = "all"
-		destination_addresses = ["192.168.1.2/32"]
-	}
+  name = "foobar-%s"
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "all"
+    source_addresses = ["192.168.1.1/32"]
+  }
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["192.168.1.2/32"]
+  }
 }
 `, rName)
 }
@@ -301,16 +301,16 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_icmp(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-	name          = "foobar-%s"
-	inbound_rule {
-		protocol         = "icmp"
-		source_addresses = ["192.168.1.1/32"]
-	}
-	outbound_rule {
-		protocol              = "icmp"
-		port_range            = "1-65535"
-		destination_addresses = ["192.168.1.2/32"]
-	}
+  name = "foobar-%s"
+  inbound_rule {
+    protocol         = "icmp"
+    source_addresses = ["192.168.1.1/32"]
+  }
+  outbound_rule {
+    protocol              = "icmp"
+    port_range            = "1-65535"
+    destination_addresses = ["192.168.1.2/32"]
+  }
 }
 `, rName)
 }

--- a/digitalocean/image/datasource_image_test.go
+++ b/digitalocean/image/datasource_image_test.go
@@ -88,7 +88,7 @@ func TestAccDigitalOceanImage_PublicSlug(t *testing.T) {
 func testAccCheckDigitalOceanImageConfig_basic(rInt, sInt int) string {
 	return fmt.Sprintf(`
 data "digitalocean_image" "foobar" {
-  name               = "snap-%d-%d"
+  name = "snap-%d-%d"
 }
 `, rInt, sInt)
 }
@@ -96,7 +96,7 @@ data "digitalocean_image" "foobar" {
 func testAccCheckDigitalOceanImageConfig_nonexisting(rInt int) string {
 	return fmt.Sprintf(`
 data "digitalocean_image" "foobar" {
-  name               = "snap-%d-nonexisting"
+  name = "snap-%d-nonexisting"
 }
 `, rInt)
 }
@@ -104,7 +104,7 @@ data "digitalocean_image" "foobar" {
 func testAccCheckDigitalOceanImageConfig_slug(slug string) string {
 	return fmt.Sprintf(`
 data "digitalocean_image" "foobar" {
-  slug               = "%s"
+  slug = "%s"
 }
 `, slug)
 }

--- a/digitalocean/image/datasource_images_test.go
+++ b/digitalocean/image/datasource_images_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceDigitalOceanImages_Basic(t *testing.T) {
 	config := `
 data "digitalocean_images" "ubuntu" {
   filter {
-    key = "distribution"
+    key    = "distribution"
     values = ["Ubuntu"]
   }
 }

--- a/digitalocean/image/resource_custom_image_test.go
+++ b/digitalocean/image/resource_custom_image_test.go
@@ -97,14 +97,14 @@ func TestAccDigitalOceanCustomImageMultiRegion(t *testing.T) {
 func testAccCheckDigitalOceanCustomImageConfig(rName string, name string, regions string, distro string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_custom_image" "%s" {
-	name = "%s-name"
-	url  = "https://stable.release.flatcar-linux.net/amd64-usr/2605.7.0/flatcar_production_digitalocean_image.bin.bz2"
-	regions      = %v
-	description  = "%s-description"
-	distribution = "%s"
-	tags = [
-		"flatcar"
-	]
+  name         = "%s-name"
+  url          = "https://stable.release.flatcar-linux.net/amd64-usr/2605.7.0/flatcar_production_digitalocean_image.bin.bz2"
+  regions      = %s
+  description  = "%s-description"
+  distribution = "%s"
+  tags = [
+    "flatcar"
+  ]
 }
 `, rName, name, regions, name, distro)
 }

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	resourceConfig := testAccDigitalOceanKubernetesConfigForDataSource(testClusterVersionLatest, rName)
 	dataSourceConfig := `
 data "digitalocean_kubernetes_cluster" "foobar" {
-	name = digitalocean_kubernetes_cluster.foo.name
+  name = digitalocean_kubernetes_cluster.foo.name
 }`
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -61,25 +61,25 @@ func testAccDigitalOceanKubernetesConfigForDataSource(version string, rName stri
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foo" {
-	name    	 = "%s"
-	region  	 = "lon1"
-	version 	 = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    	 = ["foo","bar"]
-	auto_upgrade = true
+  name         = "%s"
+  region       = "lon1"
+  version      = data.digitalocean_kubernetes_versions.test.latest_version
+  tags         = ["foo", "bar"]
+  auto_upgrade = true
 
-	node_pool {
-	    name = "default"
-		size  = "s-1vcpu-2gb"
-		node_count = 1
-		tags  = ["one","two"]
-        labels = {
-          priority = "high"
-        }
-	}
-	maintenance_policy {
-		day = "monday"
-		start_time = "00:00"
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+    labels = {
+      priority = "high"
+    }
+  }
+  maintenance_policy {
+    day        = "monday"
+    start_time = "00:00"
+  }
 }`, version, rName)
 }
 

--- a/digitalocean/kubernetes/datasource_kubernetes_versions_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_versions_test.go
@@ -70,7 +70,7 @@ data "digitalocean_kubernetes_versions" "foobar" {}`
 
 const testAccCheckDataSourceDigitalOceanKubernetesVersionsConfig_filtered = `
 data "digitalocean_kubernetes_versions" "foobar" {
-	version_prefix = "1.12." # No longer supported, should be empty
+  version_prefix = "1.12." # No longer supported, should be empty
 }`
 
 const testAccCheckDataSourceDigitalOceanKubernetesVersionsConfig_create = `
@@ -78,13 +78,13 @@ data "digitalocean_kubernetes_versions" "foobar" {
 }
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.foobar.latest_version
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.foobar.latest_version
 
-	node_pool {
-		name = "default"
-		size  = "s-1vcpu-2gb"
-		node_count = 1
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
 }`

--- a/digitalocean/kubernetes/import_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/import_kubernetes_cluster_test.go
@@ -98,21 +98,21 @@ func TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool(t *testing.T)
 	config := fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-  name = "%s"
-  region = "lon1"
+  name    = "%s"
+  region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {
-    name = "default"
-	size = "s-1vcpu-2gb"
-	node_count = 1
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
   }
 }
 
 resource "digitalocean_kubernetes_node_pool" "barfoo" {
   cluster_id = digitalocean_kubernetes_cluster.foobar.id
-  name = "%s"
-  size = "s-1vcpu-2gb"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
   node_count = 1
 }
 `, testClusterVersionLatest, testName1, testName2)

--- a/digitalocean/kubernetes/import_kubernetes_node_pool_test.go
+++ b/digitalocean/kubernetes/import_kubernetes_node_pool_test.go
@@ -16,21 +16,21 @@ func TestAccDigitalOceanKubernetesNodePool_Import(t *testing.T) {
 	config := fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-  name = "%s"
-  region = "lon1"
+  name    = "%s"
+  region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {
-    name = "default"
-	size = "s-1vcpu-2gb"
-	node_count = 1
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
   }
 }
 
 resource "digitalocean_kubernetes_node_pool" "barfoo" {
   cluster_id = digitalocean_kubernetes_cluster.foobar.id
-  name = "%s"
-  size = "s-1vcpu-2gb"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
   node_count = 1
 }
 `, testClusterVersionLatest, testName1, testName2)

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -24,8 +24,8 @@ const (
 locals {
   previous_version = format("%s.",
     join(".", [
-      split(".",data.digitalocean_kubernetes_versions.latest.latest_version)[0],
-      tostring(parseint(split(".",data.digitalocean_kubernetes_versions.latest.latest_version)[1], 10)-1)
+      split(".", data.digitalocean_kubernetes_versions.latest.latest_version)[0],
+      tostring(parseint(split(".", data.digitalocean_kubernetes_versions.latest.latest_version)[1], 10) - 1)
     ])
   )
 }
@@ -100,21 +100,21 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 				Config: fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	surge_upgrade = true
-	tags    = ["foo","bar", "one"]
+  name          = "%s"
+  region        = "lon1"
+  version       = data.digitalocean_kubernetes_versions.test.latest_version
+  surge_upgrade = true
+  tags          = ["foo", "bar", "one"]
 
-	node_pool {
-	  name = "default"
-      size  = "s-1vcpu-2gb"
-      node_count = 1
-      tags  = ["one","two"]
-      labels = {
-        priority = "high"
-      }
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+    labels = {
+      priority = "high"
+    }
+  }
 }`, testClusterVersionLatest, rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -141,18 +141,18 @@ func TestAccDigitalOceanKubernetesCluster_CreateWithHAControlPlane(t *testing.T)
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    	 = "%s"
-						region  	 = "nyc1"
-						ha      	 = true
-						version 	 = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  ha      = true
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -337,25 +337,25 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    	 = "%s"
-						region  	 = "lon1"
-						version 	 = data.digitalocean_kubernetes_versions.test.latest_version
-						auto_upgrade = true
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name         = "%s"
+  region       = "lon1"
+  version      = data.digitalocean_kubernetes_versions.test.latest_version
+  auto_upgrade = true
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 1
-							auto_scale = true
-							min_nodes = 1
-							max_nodes = 3
-						}
-						maintenance_policy {
-							start_time = "05:00"
-							day = "sunday"
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    auto_scale = true
+    min_nodes  = 1
+    max_nodes  = 3
+  }
+  maintenance_policy {
+    start_time = "05:00"
+    day        = "sunday"
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -376,19 +376,19 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    = "%s"
-						region  = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							auto_scale = true
-							min_nodes = 1
-							max_nodes = 3
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    auto_scale = true
+    min_nodes  = 1
+    max_nodes  = 3
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -406,20 +406,20 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    = "%s"
-						region  = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 2
-							auto_scale = true
-							min_nodes = 1
-							max_nodes = 3
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 2
+    auto_scale = true
+    min_nodes  = 1
+    max_nodes  = 3
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -437,17 +437,17 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    = "%s"
-						region  = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 2
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 2
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -478,17 +478,17 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-				resource "digitalocean_kubernetes_cluster" "foobar" {
-					name    = "%s"
-					region  = "lon1"
-					version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-					node_pool {
-						name = "default"
-						size  = "s-1vcpu-2gb"
-						node_count = 1
-					}
-				}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 			`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -506,20 +506,20 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    = "%s"
-						region  = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 1
-							auto_scale = true
-							min_nodes = 1
-							max_nodes = 3
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    auto_scale = true
+    min_nodes  = 1
+    max_nodes  = 3
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -537,19 +537,19 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name    = "%s"
-						region  = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							auto_scale = true
-							min_nodes = 1
-							max_nodes = 3
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    auto_scale = true
+    min_nodes  = 1
+    max_nodes  = 3
+  }
+}
 				`, testClusterVersionLatest, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -627,26 +627,26 @@ func testAccDigitalOceanKubernetesConfigBasic(testClusterVersion string, rName s
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "nyc1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	surge_upgrade = true
-	tags    = ["foo","bar", "one"]
+  name          = "%s"
+  region        = "nyc1"
+  version       = data.digitalocean_kubernetes_versions.test.latest_version
+  surge_upgrade = true
+  tags          = ["foo", "bar", "one"]
 
-	node_pool {
-	  name = "default"
-      size  = "s-1vcpu-2gb"
-      node_count = 1
-      tags  = ["one","two"]
-      labels = {
-        priority = "high"
-      }
-      taint {
-        key = "key1"
-        value = "val1"
-        effect = "PreferNoSchedule"
-      }
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+    labels = {
+      priority = "high"
+    }
+    taint {
+      key    = "key1"
+      value  = "val1"
+      effect = "PreferNoSchedule"
+    }
+  }
 }
 `, testClusterVersion, rName)
 }
@@ -655,28 +655,28 @@ func testAccDigitalOceanKubernetesConfigMaintenancePolicy(testClusterVersion str
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	surge_upgrade = true
-	tags    = ["foo","bar", "one"]
+  name          = "%s"
+  region        = "lon1"
+  version       = data.digitalocean_kubernetes_versions.test.latest_version
+  surge_upgrade = true
+  tags          = ["foo", "bar", "one"]
 
 %s
 
-	node_pool {
-	  name = "default"
-      size  = "s-1vcpu-2gb"
-      node_count = 1
-      tags  = ["one","two"]
-      labels = {
-        priority = "high"
-      }
-      taint {
-        key = "key1"
-        value = "val1"
-        effect = "PreferNoSchedule"
-      }
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+    labels = {
+      priority = "high"
+    }
+    taint {
+      key    = "key1"
+      value  = "val1"
+      effect = "PreferNoSchedule"
+    }
+  }
 }
 `, testClusterVersion, rName, policy)
 }
@@ -685,22 +685,22 @@ func testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion string, rName 
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	surge_upgrade = true
-	tags    = ["foo","bar"]
+  name          = "%s"
+  region        = "lon1"
+  version       = data.digitalocean_kubernetes_versions.test.latest_version
+  surge_upgrade = true
+  tags          = ["foo", "bar"]
 
-	node_pool {
-	  name = "default-rename"
-		size  = "s-1vcpu-2gb"
-		node_count = 2
-		tags  = ["one","two","three"]
-        labels = {
-            priority = "high"
-            purpose = "awesome"
-        }
-	}
+  node_pool {
+    name       = "default-rename"
+    size       = "s-1vcpu-2gb"
+    node_count = 2
+    tags       = ["one", "two", "three"]
+    labels = {
+      priority = "high"
+      purpose  = "awesome"
+    }
+  }
 }
 `, testClusterVersion, rName)
 }
@@ -709,17 +709,17 @@ func testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion string, rName 
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["foo","bar"]
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
 
-	node_pool {
-	  name = "default"
-		size  = "s-2vcpu-4gb"
-		node_count = 1
-		tags  = ["one","two"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-2vcpu-4gb"
+    node_count = 1
+    tags       = ["one", "two"]
+  }
 }
 `, testClusterVersion, rName)
 }
@@ -728,18 +728,18 @@ func testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion string, rName 
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-    surge_upgrade = true
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["one","two"]
+  name          = "%s"
+  region        = "lon1"
+  surge_upgrade = true
+  version       = data.digitalocean_kubernetes_versions.test.latest_version
+  tags          = ["one", "two"]
 
-	node_pool {
-	  name = "default"
-		size  = "s-2vcpu-4gb"
-		node_count = 1
-		tags  = ["foo","bar"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-2vcpu-4gb"
+    node_count = 1
+    tags       = ["foo", "bar"]
+  }
 }
 `, testClusterVersion, rName)
 }
@@ -748,18 +748,17 @@ func testAccDigitalOceanKubernetesConfigBasic5(testClusterVersion string, rName 
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["one","two"]
-	version = true
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["one", "two"]
 
-	node_pool {
-	  name = "default"
-		size  = "s-2vcpu-4gb"
-		node_count = 1
-		tags  = ["foo","bar"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-2vcpu-4gb"
+    node_count = 1
+    tags       = ["foo", "bar"]
+  }
 }
 `, testClusterVersion, rName)
 }
@@ -768,15 +767,15 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(test
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-	node_pool {
-	  name = "default"
-		size  = "s-2vcpu-4gb"
-		node_count = 1
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-2vcpu-4gb"
+    node_count = 1
+  }
 }
 
 provider "kubernetes" {

--- a/digitalocean/kubernetes/resource_kubernetes_node_pool_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_node_pool_test.go
@@ -19,17 +19,17 @@ func TestAccDigitalOceanKubernetesNodePool_Basic(t *testing.T) {
 
 	clusterConfig := fmt.Sprintf(`%s
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["foo","bar"]
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
 
-	node_pool {
-		name = "default"
-		size  = "s-1vcpu-2gb"
-		node_count = 1
-		tags  = ["one","two"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+  }
 }
 `, testClusterVersionLatest, rName)
 
@@ -173,27 +173,27 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						node_count = 1
-						auto_scale = true
-						min_nodes = 1
-						max_nodes = 5
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  node_count = 1
+  auto_scale = true
+  min_nodes  = 1
+  max_nodes  = 5
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -212,26 +212,26 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						auto_scale = true
-						min_nodes = 1
-						max_nodes = 3
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  auto_scale = true
+  min_nodes  = 1
+  max_nodes  = 3
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -250,27 +250,27 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						node_count = 2
-						auto_scale = true
-						min_nodes = 1
-						max_nodes = 3
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  node_count = 2
+  auto_scale = true
+  min_nodes  = 1
+  max_nodes  = 3
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -289,24 +289,24 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						node_count = 2
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  node_count = 2
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -339,24 +339,24 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						node_count = 1
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  node_count = 1
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -375,27 +375,27 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						node_count = 1
-						auto_scale = true
-						min_nodes = 1
-						max_nodes = 3
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  node_count = 1
+  auto_scale = true
+  min_nodes  = 1
+  max_nodes  = 3
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -414,26 +414,26 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`%s
 
-					resource "digitalocean_kubernetes_cluster" "foobar" {
-						name = "%s"
-						region = "lon1"
-						version = data.digitalocean_kubernetes_versions.test.latest_version
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
-						node_pool {
-							name = "default"
-							size  = "s-1vcpu-2gb"
-							node_count = 1
-						}
-					}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
 
-					resource digitalocean_kubernetes_node_pool "barfoo" {
-						cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
-						name = "%s"
-						size = "s-1vcpu-2gb"
-						auto_scale = true
-						min_nodes = 1
-						max_nodes = 3
-					}
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  auto_scale = true
+  min_nodes  = 1
+  max_nodes  = 3
+}
 				`, testClusterVersionLatest, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -456,26 +456,26 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool(rName string) string {
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["foo","bar"]
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
 
-	node_pool {
-		name = "default"
-		size  = "s-1vcpu-2gb"
-		node_count = 1
-		tags  = ["one","two"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+  }
 }
 
 resource digitalocean_kubernetes_node_pool "barfoo" {
   cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
 
-	name    = "%s"
-	size  = "s-1vcpu-2gb"
-	node_count = 1
-	tags  = ["three","four"]
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  node_count = 1
+  tags       = ["three", "four"]
 }
 `, testClusterVersionLatest, rName, rName)
 }
@@ -484,34 +484,34 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePoolTaint(rName string) str
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["foo","bar"]
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
 
-	node_pool {
-		name		= "default"
-		size  		= "s-1vcpu-2gb"
-		node_count 	= 1
-		tags  		= ["one","two"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+  }
 }
 
 resource digitalocean_kubernetes_node_pool "barfoo" {
   cluster_id = digitalocean_kubernetes_cluster.foobar.id
 
-	name		= "%s-tainted"
-	size		= "s-1vcpu-2gb"
-	node_count	= 1
-	tags		= ["three","four"]
-	labels = {
-      priority = "high"
-	}
-	taint {
-		key    = "key1"
-		value  = "val1"
-		effect = "NoSchedule"
-	}
+  name       = "%s-tainted"
+  size       = "s-1vcpu-2gb"
+  node_count = 1
+  tags       = ["three", "four"]
+  labels = {
+    priority = "high"
+  }
+  taint {
+    key    = "key1"
+    value  = "val1"
+    effect = "NoSchedule"
+  }
 }
 `, testClusterVersionLatest, rName, rName)
 }
@@ -520,39 +520,39 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePoolTaint2(rName string) st
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["foo","bar"]
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
 
-	node_pool {
-		name		= "default"
-		size  		= "s-1vcpu-2gb"
-		node_count 	= 1
-		tags  		= ["one","two"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+  }
 }
 
 resource digitalocean_kubernetes_node_pool "barfoo" {
   cluster_id = digitalocean_kubernetes_cluster.foobar.id
 
-	name		= "%s-tainted"
-	size		= "s-1vcpu-2gb"
-	node_count	= 1
-	tags		= ["three","four"]
-	labels = {
-      priority = "high"
-	}
-	taint {
-		key    = "key1"
-		value  = "val1"
-		effect = "NoSchedule"
-	}
-	taint {
-		key    = "key2"
-		value  = "val2"
-		effect = "PreferNoSchedule"
-	}
+  name       = "%s-tainted"
+  size       = "s-1vcpu-2gb"
+  node_count = 1
+  tags       = ["three", "four"]
+  labels = {
+    priority = "high"
+  }
+  taint {
+    key    = "key1"
+    value  = "val1"
+    effect = "NoSchedule"
+  }
+  taint {
+    key    = "key2"
+    value  = "val2"
+    effect = "PreferNoSchedule"
+  }
 }
 `, testClusterVersionLatest, rName, rName)
 }
@@ -561,29 +561,29 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string 
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-	name    = "%s"
-	region  = "lon1"
-	version = data.digitalocean_kubernetes_versions.test.latest_version
-	tags    = ["foo","bar"]
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
 
-	node_pool {
-		name = "default"
-		size  = "s-1vcpu-2gb"
-		node_count = 1
-		tags  = ["one","two"]
-	}
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+  }
 }
 
 resource digitalocean_kubernetes_node_pool "barfoo" {
-	cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
 
-	name    = "%s-updated"
-	size  = "s-1vcpu-2gb"
-	node_count = 2
-	tags  = ["one","two", "three"]
-	labels = {
-      priority = "high"
-	}
+  name       = "%s-updated"
+  size       = "s-1vcpu-2gb"
+  node_count = 2
+  tags       = ["one", "two", "three"]
+  labels = {
+    priority = "high"
+  }
 }
 `, testClusterVersionLatest, rName, rName)
 }

--- a/digitalocean/loadbalancer/datasource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/datasource_loadbalancer_test.go
@@ -666,15 +666,15 @@ resource "digitalocean_loadbalancer" "foo" {
   size   = "%s"
 
   forwarding_rule {
-	entry_port     = 80
-	entry_protocol = "http"
+    entry_port     = 80
+    entry_protocol = "http"
 
-	target_port     = 80
-	target_protocol = "http"
+    target_port     = 80
+    target_protocol = "http"
   }
 
   healthcheck {
-	port     = 22
+    port     = 22
     protocol = "tcp"
   }
 
@@ -700,20 +700,20 @@ resource "digitalocean_droplet" "foo" {
 }
 
 resource "digitalocean_loadbalancer" "foo" {
-  name   = "%s"
-  region = "nyc3"
+  name      = "%s"
+  region    = "nyc3"
   size_unit = "%d"
 
   forwarding_rule {
-	entry_port     = 80
-	entry_protocol = "http"
+    entry_port     = 80
+    entry_protocol = "http"
 
-	target_port     = 80
-	target_protocol = "http"
+    target_port     = 80
+    target_protocol = "http"
   }
 
   healthcheck {
-	port     = 22
+    port     = 22
     protocol = "tcp"
   }
 

--- a/digitalocean/loadbalancer/resource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer_test.go
@@ -285,11 +285,11 @@ func TestAccDigitalOceanLoadbalancer_NonDefaultProject(t *testing.T) {
 
 	projectConfig := `
 
+
 resource "digitalocean_project" "test" {
-  name      = "%s"
+  name = "%s"
 }
 `
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -554,23 +554,23 @@ func TestAccDigitalOceanLoadbalancer_resizeExpectedFailure(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	lbConfig := `resource "digitalocean_loadbalancer" "foobar" {
-		name   = "loadbalancer-%d"
-		region = "nyc3"
-		size_unit = %d
+  name      = "loadbalancer-%d"
+  region    = "nyc3"
+  size_unit = %d
 
-		forwarding_rule {
-			entry_port     = 80
-			entry_protocol = "http"
+  forwarding_rule {
+    entry_port     = 80
+    entry_protocol = "http"
 
-			target_port     = 80
-			target_protocol = "http"
-		}
+    target_port     = 80
+    target_protocol = "http"
+  }
 
-		healthcheck {
-			port     = 22
-			protocol = "tcp"
-		}
-	}`
+  healthcheck {
+    port     = 22
+    protocol = "tcp"
+  }
+}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
@@ -784,31 +784,31 @@ func testAccCheckDigitalOceanLoadbalancerExists(n string, loadbalancer *godo.Loa
 func testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "loadbalancer-%d"
+  name   = "loadbalancer-%d"
   region = "nyc3"
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
   healthcheck {
-    port = 22
+    port     = 22
     protocol = "tcp"
   }
 
-  enable_proxy_protocol    = true
-  enable_backend_keepalive = true
+  enable_proxy_protocol     = true
+  enable_backend_keepalive  = true
   http_idle_timeout_seconds = 90
 
   droplet_ids = [digitalocean_droplet.foobar.id]
@@ -818,40 +818,40 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_updated(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_droplet" "foo" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "loadbalancer-%d"
+  name   = "loadbalancer-%d"
   region = "nyc3"
 
   forwarding_rule {
-    entry_port = 81
+    entry_port     = 81
     entry_protocol = "http"
 
-    target_port = 81
+    target_port     = 81
     target_protocol = "http"
   }
 
   healthcheck {
-    port = 22
+    port     = 22
     protocol = "tcp"
   }
 
   enable_proxy_protocol            = false
   enable_backend_keepalive         = false
   disable_lets_encrypt_dns_records = true
-  http_idle_timeout_seconds = 120
+  http_idle_timeout_seconds        = 120
 
   droplet_ids = [digitalocean_droplet.foobar.id, digitalocean_droplet.foo.id]
 }`, rInt, rInt, rInt)
@@ -864,27 +864,27 @@ resource "digitalocean_tag" "barbaz" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
-  tags = ["${digitalocean_tag.barbaz.id}"]
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
+  tags   = ["${digitalocean_tag.barbaz.id}"]
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "loadbalancer-%d"
+  name   = "loadbalancer-%d"
   region = "nyc3"
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
   healthcheck {
-    port = 22
+    port     = 22
     protocol = "tcp"
   }
 
@@ -897,10 +897,10 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_minimal(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
@@ -909,10 +909,10 @@ resource "digitalocean_loadbalancer" "foobar" {
   size_unit = 1
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
@@ -927,16 +927,16 @@ resource "digitalocean_tag" "test" {
 }
 
 resource "digitalocean_loadbalancer" "test" {
-  name = "%s"
-  region = "nyc3"
-  size = "lb-small"
+  name       = "%s"
+  region     = "nyc3"
+  size       = "lb-small"
   project_id = digitalocean_project.test.id
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
@@ -947,22 +947,22 @@ resource "digitalocean_loadbalancer" "test" {
 func testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "loadbalancer-%d"
+  name   = "loadbalancer-%d"
   region = "nyc3"
-  size = "lb-small"
+  size   = "lb-small"
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "udp"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "udp"
   }
 
@@ -973,29 +973,29 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region    = "nyc3"
+  name   = "foo-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "loadbalancer-%d"
+  name   = "loadbalancer-%d"
   region = "nyc3"
-  size = "lb-small"
+  size   = "lb-small"
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
   sticky_sessions {
-	type = "cookies"
-	cookie_name = "sessioncookie"
-	cookie_ttl_seconds = 1800
+    type               = "cookies"
+    cookie_name        = "sessioncookie"
+    cookie_ttl_seconds = 1800
   }
 
   droplet_ids = ["${digitalocean_droplet.foobar.id}"]
@@ -1005,11 +1005,11 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(certName string, rInt int, privateKeyMaterial, leafCert, certChain, certAttribute string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_certificate" "foobar" {
-  name = "%s"
-  private_key = <<EOF
+  name              = "%s"
+  private_key       = <<EOF
 %s
 EOF
-  leaf_certificate = <<EOF
+  leaf_certificate  = <<EOF
 %s
 EOF
   certificate_chain = <<EOF
@@ -1025,8 +1025,8 @@ resource "digitalocean_loadbalancer" "foobar" {
   enable_proxy_protocol  = true
 
   forwarding_rule {
-    entry_port      = 443
-    entry_protocol  = "https"
+    entry_port     = 443
+    entry_protocol = "https"
 
     target_port     = 80
     target_protocol = "http"
@@ -1039,13 +1039,13 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_loadbalancer" "foobar" {
-  name                   = "%s"
-  region                 = "nyc3"
-  size                 = "lb-small"
+  name   = "%s"
+  region = "nyc3"
+  size   = "lb-small"
 
   forwarding_rule {
-    entry_port      = 443
-    entry_protocol  = "https"
+    entry_port     = 443
+    entry_protocol = "https"
 
     target_port     = 443
     target_protocol = "https"
@@ -1065,13 +1065,13 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_multipleRulesUDP(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_loadbalancer" "foobar" {
-  name                   = "%s"
-  region                 = "nyc3"
-  size                 = "lb-small"
+  name   = "%s"
+  region = "nyc3"
+  size   = "lb-small"
 
   forwarding_rule {
-    entry_port      = 443
-    entry_protocol  = "udp"
+    entry_port     = 443
+    entry_protocol = "udp"
 
     target_port     = 443
     target_protocol = "udp"
@@ -1090,32 +1090,32 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_WithVPC(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_vpc" "foobar" {
-  name        = "%s"
-  region      = "nyc3"
+  name   = "%s"
+  region = "nyc3"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
+  name     = "%s"
+  size     = "s-1vcpu-1gb"
+  image    = "ubuntu-22-04-x64"
   region   = "nyc3"
   vpc_uuid = digitalocean_vpc.foobar.id
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "%s"
+  name   = "%s"
   region = "nyc3"
-  size = "lb-small"
+  size   = "lb-small"
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
-  vpc_uuid = digitalocean_vpc.foobar.id
+  vpc_uuid    = digitalocean_vpc.foobar.id
   droplet_ids = [digitalocean_droplet.foobar.id]
 }`, acceptance.RandomTestName(), acceptance.RandomTestName(), name)
 }
@@ -1123,27 +1123,27 @@ resource "digitalocean_loadbalancer" "foobar" {
 func testAccCheckDigitalOceanLoadbalancerConfig_Firewall(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
-  region   = "nyc3"
+  name   = "%s"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name = "%s"
+  name   = "%s"
   region = "nyc3"
-  size = "lb-small"
+  size   = "lb-small"
 
   forwarding_rule {
-    entry_port = 80
+    entry_port     = 80
     entry_protocol = "http"
 
-    target_port = 80
+    target_port     = 80
     target_protocol = "http"
   }
 
   firewall {
-    deny = ["cidr:1.2.0.0/16", "ip:2.3.4.5"]
+    deny  = ["cidr:1.2.0.0/16", "ip:2.3.4.5"]
     allow = ["ip:1.2.3.4", "cidr:2.3.4.0/24"]
   }
 

--- a/digitalocean/loadbalancer/resource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer_test.go
@@ -868,7 +868,7 @@ resource "digitalocean_droplet" "foobar" {
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
-  tags   = ["${digitalocean_tag.barbaz.id}"]
+  tags   = [digitalocean_tag.barbaz.id]
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
@@ -888,9 +888,9 @@ resource "digitalocean_loadbalancer" "foobar" {
     protocol = "tcp"
   }
 
-  droplet_tag = "${digitalocean_tag.barbaz.name}"
+  droplet_tag = digitalocean_tag.barbaz.name
 
-  depends_on = ["digitalocean_droplet.foobar"]
+  depends_on = [digitalocean_droplet.foobar]
 }`, rInt, rInt)
 }
 
@@ -916,7 +916,7 @@ resource "digitalocean_loadbalancer" "foobar" {
     target_protocol = "http"
   }
 
-  droplet_ids = ["${digitalocean_droplet.foobar.id}"]
+  droplet_ids = [digitalocean_droplet.foobar.id]
 }`, rInt, rInt)
 }
 
@@ -966,7 +966,7 @@ resource "digitalocean_loadbalancer" "foobar" {
     target_protocol = "udp"
   }
 
-  droplet_ids = ["${digitalocean_droplet.foobar.id}"]
+  droplet_ids = [digitalocean_droplet.foobar.id]
 }`, rInt, rInt)
 }
 
@@ -998,7 +998,7 @@ resource "digitalocean_loadbalancer" "foobar" {
     cookie_ttl_seconds = 1800
   }
 
-  droplet_ids = ["${digitalocean_droplet.foobar.id}"]
+  droplet_ids = [digitalocean_droplet.foobar.id]
 }`, rInt, rInt)
 }
 
@@ -1075,7 +1075,6 @@ resource "digitalocean_loadbalancer" "foobar" {
 
     target_port     = 443
     target_protocol = "udp"
-
   }
 
   forwarding_rule {

--- a/digitalocean/monitoring/resource_monitor_alert_test.go
+++ b/digitalocean/monitoring/resource_monitor_alert_test.go
@@ -26,105 +26,105 @@ slack {
 
 	testAccAlertPolicy = `
 resource "digitalocean_droplet" "web" {
-	image  = "ubuntu-20-04-x64"
-	name   = "web-1"
-	region = "fra1"
-	size   = "s-1vcpu-1gb"
-  }
+  image  = "ubuntu-20-04-x64"
+  name   = "web-1"
+  region = "fra1"
+  size   = "s-1vcpu-1gb"
+}
 
-  resource "digitalocean_monitor_alert" "%s" {
-	alerts  {
-	  email 	= ["benny@digitalocean.com"]
+resource "digitalocean_monitor_alert" "%s" {
+  alerts {
+    email = ["benny@digitalocean.com"]
       %s
-	}
-	window      = "%s"
-	type        = "%s"
-	compare     = "GreaterThan"
-	value       = 95
-	entities    = [digitalocean_droplet.web.id]
-	description = "%s"
   }
+  window      = "%s"
+  type        = "%s"
+  compare     = "GreaterThan"
+  value       = 95
+  entities    = [digitalocean_droplet.web.id]
+  description = "%s"
+}
 `
 
 	testAccAlertPolicySlackEmailAlerts = `
 resource "digitalocean_droplet" "web" {
-	image  = "ubuntu-20-04-x64"
-	name   = "web-1"
-	region = "fra1"
-	size   = "s-1vcpu-1gb"
-  }
+  image  = "ubuntu-20-04-x64"
+  name   = "web-1"
+  region = "fra1"
+  size   = "s-1vcpu-1gb"
+}
 
-  resource "digitalocean_monitor_alert" "%s" {
-	alerts {
-	  email 	= ["benny@digitalocean.com"]
-	  slack {
-		channel = "production-alerts"
-		url		= "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
-	  }
-	}
-	window      = "5m"
-	type        = "v1/insights/droplet/cpu"
-	compare     = "GreaterThan"
-	value       = 95
-	entities    = [digitalocean_droplet.web.id]
-	description = "Alert about CPU usage"
+resource "digitalocean_monitor_alert" "%s" {
+  alerts {
+    email = ["benny@digitalocean.com"]
+    slack {
+      channel = "production-alerts"
+      url     = "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
+    }
   }
+  window      = "5m"
+  type        = "v1/insights/droplet/cpu"
+  compare     = "GreaterThan"
+  value       = 95
+  entities    = [digitalocean_droplet.web.id]
+  description = "Alert about CPU usage"
+}
 `
 
 	testAccAlertPolicyWithTag = `
 resource "digitalocean_tag" "test" {
-    name = "%s"
+  name = "%s"
 }
 
 resource "digitalocean_droplet" "web" {
-	image  = "ubuntu-20-04-x64"
-	name   = "web-1"
-	region = "fra1"
-	size   = "s-1vcpu-1gb"
-	tags    = [digitalocean_tag.test.name]
-  }
+  image  = "ubuntu-20-04-x64"
+  name   = "web-1"
+  region = "fra1"
+  size   = "s-1vcpu-1gb"
+  tags   = [digitalocean_tag.test.name]
+}
 
-  resource "digitalocean_monitor_alert" "%s" {
-	alerts  {
-	  email 	= ["benny@digitalocean.com"]
-	}
-	window      = "%s"
-	type        = "%s"
-	compare     = "GreaterThan"
-	value       = 95
-	tags        = [digitalocean_tag.test.name]
-	description = "%s"
+resource "digitalocean_monitor_alert" "%s" {
+  alerts {
+    email = ["benny@digitalocean.com"]
+  }
+  window      = "%s"
+  type        = "%s"
+  compare     = "GreaterThan"
+  value       = 95
+  tags        = [digitalocean_tag.test.name]
+  description = "%s"
 }
 `
 
 	testAccAlertPolicyAddDroplet = `
 resource "digitalocean_droplet" "web" {
-	image  = "ubuntu-20-04-x64"
-	name   = "web-1"
-	region = "fra1"
-	size   = "s-1vcpu-1gb"
-  }
+  image  = "ubuntu-20-04-x64"
+  name   = "web-1"
+  region = "fra1"
+  size   = "s-1vcpu-1gb"
+}
 
 resource "digitalocean_droplet" "web2" {
-	image  = "ubuntu-20-04-x64"
-	name   = "web-2"
-	region = "fra1"
-	size   = "s-1vcpu-1gb"
+  image  = "ubuntu-20-04-x64"
+  name   = "web-2"
+  region = "fra1"
+  size   = "s-1vcpu-1gb"
 }
 
 
 resource "digitalocean_monitor_alert" "%s" {
-	alerts  {
-	  email 	= ["benny@digitalocean.com"]
+  alerts {
+    email = ["benny@digitalocean.com"]
       %s
-	}
-	window      = "%s"
-	type        = "%s"
-	compare     = "GreaterThan"
-	value       = 95
-	entities    = [digitalocean_droplet.web.id, digitalocean_droplet.web2.id]
-	description = "%s"
   }
+  window      = "%s"
+  type        = "%s"
+  compare     = "GreaterThan"
+  value       = 95
+  entities    = [digitalocean_droplet.web.id, digitalocean_droplet.web2.id]
+  description = "%s"
+}
 `
 )
 

--- a/digitalocean/project/datasource_projects_test.go
+++ b/digitalocean/project/datasource_projects_test.go
@@ -14,48 +14,48 @@ func TestAccDataSourceDigitalOceanProjects_Basic(t *testing.T) {
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_project" "prod" {
-	name = "%s"
-	environment = "Production"
+  name        = "%s"
+  environment = "Production"
 }
 
 resource "digitalocean_project" "staging" {
-	name = "%s"
-	environment = "Staging"
+  name        = "%s"
+  environment = "Staging"
 }
 `, prodProjectName, stagingProjectName)
 
 	datasourcesConfig := fmt.Sprintf(`
 data "digitalocean_projects" "prod" {
-	filter {
-      key = "environment"
-      values = ["Production"]
-    }
-    filter {
-      key = "is_default"
-      values = ["false"]
-    }
+  filter {
+    key    = "environment"
+    values = ["Production"]
+  }
+  filter {
+    key    = "is_default"
+    values = ["false"]
+  }
 }
 
 data "digitalocean_projects" "staging" {
-	filter {
-      key = "name"
-      values = ["%s"]
-    }
-    filter {
-      key = "is_default"
-      values = ["false"]
-    }
+  filter {
+    key    = "name"
+    values = ["%s"]
+  }
+  filter {
+    key    = "is_default"
+    values = ["false"]
+  }
 }
 
 data "digitalocean_projects" "both" {
-	filter {
-      key = "environment"
-      values = ["Production"]
-    }
-	filter {
-      key = "name"
-      values = ["%s"]
-    }
+  filter {
+    key    = "environment"
+    values = ["Production"]
+  }
+  filter {
+    key    = "name"
+    values = ["%s"]
+  }
 }
 `, stagingProjectName, stagingProjectName)
 	resource.Test(t, resource.TestCase{

--- a/digitalocean/project/resource_project_resources_test.go
+++ b/digitalocean/project/resource_project_resources_test.go
@@ -33,14 +33,14 @@ resource "digitalocean_droplet" "foobar" {
 
 	projectResourcesConfigEmpty := `
 resource "digitalocean_project_resources" "barfoo" {
-  project = digitalocean_project.foo.id
+  project   = digitalocean_project.foo.id
   resources = []
 }
 `
 
 	projectResourcesConfigWithDroplet := `
 resource "digitalocean_project_resources" "barfoo" {
-  project = digitalocean_project.foo.id
+  project   = digitalocean_project.foo.id
   resources = [digitalocean_droplet.foobar.urn]
 }
 `

--- a/digitalocean/project/resource_project_test.go
+++ b/digitalocean/project/resource_project_test.go
@@ -473,7 +473,7 @@ resource "digitalocean_droplet" "foobar" {
 
 resource "digitalocean_project" "myproj" {
   name      = "%s"
-  resources = ["${digitalocean_droplet.foobar.urn}"]
+  resources = [digitalocean_droplet.foobar.urn]
 }`, dropletName, name)
 
 }
@@ -488,7 +488,7 @@ resource "digitalocean_spaces_bucket" "foobar" {
 
 resource "digitalocean_project" "myproj" {
   name      = "%s"
-  resources = ["${digitalocean_spaces_bucket.foobar.urn}"]
+  resources = [digitalocean_spaces_bucket.foobar.urn]
 }`, spacesBucketName, name)
 
 }

--- a/digitalocean/project/resource_project_test.go
+++ b/digitalocean/project/resource_project_test.go
@@ -442,9 +442,9 @@ func generateSpacesName() string {
 
 func fixtureCreateWithDefaults(name string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_project" "myproj" {
-			name = "%s"
-		}`, name)
+resource "digitalocean_project" "myproj" {
+  name = "%s"
+}`, name)
 }
 
 func fixtureUpdateWithValues(name, description, purpose, environment string) string {
@@ -453,71 +453,71 @@ func fixtureUpdateWithValues(name, description, purpose, environment string) str
 
 func fixtureCreateWithInitialValues(name, description, purpose, environment string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_project" "myproj" {
-			name = "%s"
-			description = "%s"
-			purpose = "%s"
-			environment = "%s"
-		}`, name, description, purpose, environment)
+resource "digitalocean_project" "myproj" {
+  name        = "%s"
+  description = "%s"
+  purpose     = "%s"
+  environment = "%s"
+}`, name, description, purpose, environment)
 }
 
 func fixtureCreateWithDropletResource(dropletName, name string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_droplet" "foobar" {
-		  name      = "%s"
-		  size      = "s-1vcpu-1gb"
-		  image     = "ubuntu-22-04-x64"
-		  region    = "nyc3"
-		  user_data = "foobar"
-		}
+resource "digitalocean_droplet" "foobar" {
+  name      = "%s"
+  size      = "s-1vcpu-1gb"
+  image     = "ubuntu-22-04-x64"
+  region    = "nyc3"
+  user_data = "foobar"
+}
 
-		resource "digitalocean_project" "myproj" {
-			name = "%s"
-			resources = ["${digitalocean_droplet.foobar.urn}"]
-		}`, dropletName, name)
+resource "digitalocean_project" "myproj" {
+  name      = "%s"
+  resources = ["${digitalocean_droplet.foobar.urn}"]
+}`, dropletName, name)
 
 }
 
 func fixtureCreateWithSpacesResource(spacesBucketName, name string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_spaces_bucket" "foobar" {
-			name = "%s"
-			acl = "public-read"
-			region = "ams3"
-		}
+resource "digitalocean_spaces_bucket" "foobar" {
+  name   = "%s"
+  acl    = "public-read"
+  region = "ams3"
+}
 
-		resource "digitalocean_project" "myproj" {
-			name = "%s"
-			resources = ["${digitalocean_spaces_bucket.foobar.urn}"]
-		}`, spacesBucketName, name)
+resource "digitalocean_project" "myproj" {
+  name      = "%s"
+  resources = ["${digitalocean_spaces_bucket.foobar.urn}"]
+}`, spacesBucketName, name)
 
 }
 
 func fixtureCreateDomainResources(domainBase string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_domain" "foobar" {
-			count = 30
-			name  = "%s-${count.index}.com"
-		}`, domainBase)
+resource "digitalocean_domain" "foobar" {
+  count = 30
+  name  = "%s-${count.index}.com"
+}`, domainBase)
 }
 
 func fixtureWithManyResources(domainBase string, name string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_domain" "foobar" {
-			count = 30
-			name  = "%s-${count.index}.com"
-		}
+resource "digitalocean_domain" "foobar" {
+  count = 30
+  name  = "%s-${count.index}.com"
+}
 
-		resource "digitalocean_project" "myproj" {
-			name = "%s"
-			resources = digitalocean_domain.foobar[*].urn
-		}`, domainBase, name)
+resource "digitalocean_project" "myproj" {
+  name      = "%s"
+  resources = digitalocean_domain.foobar[*].urn
+}`, domainBase, name)
 }
 
 func fixtureCreateWithIsDefault(name string, is_default string) string {
 	return fmt.Sprintf(`
-		resource "digitalocean_project" "myproj" {
-			name = "%s"
-			is_default = "%s"
-		}`, name, is_default)
+resource "digitalocean_project" "myproj" {
+  name       = "%s"
+  is_default = "%s"
+}`, name, is_default)
 }

--- a/digitalocean/region/datasource_region_test.go
+++ b/digitalocean/region/datasource_region_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDigitalOceanRegion_Basic(t *testing.T) {
 	config := `
 data "digitalocean_region" "lon1" {
-	slug = "lon1"
+  slug = "lon1"
 }
 `
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,7 +35,7 @@ data "digitalocean_region" "lon1" {
 func TestAccDigitalOceanRegion_MissingSlug(t *testing.T) {
 	config := `
 data "digitalocean_region" "xyz5" {
-	slug = "xyz5"
+  slug = "xyz5"
 }
 `
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/region/datasource_regions_test.go
+++ b/digitalocean/region/datasource_regions_test.go
@@ -17,39 +17,39 @@ data "digitalocean_regions" "all" {
 `
 	configAvailableFilter := `
 data "digitalocean_regions" "filtered" {
-	filter {
-        key = "available"
-        values = ["true"]
-    }
-    sort {
-		key = "slug"
-    }
+  filter {
+    key    = "available"
+    values = ["true"]
+  }
+  sort {
+    key = "slug"
+  }
 }
 `
 
 	configFeaturesFilter := `
 data "digitalocean_regions" "filtered" {
-	filter {
-        key = "features"
-        values = ["private_networking", "backups"]
-    }
-    sort {
-		key = "available"
-		direction = "desc"
-    }
+  filter {
+    key    = "features"
+    values = ["private_networking", "backups"]
+  }
+  sort {
+    key       = "available"
+    direction = "desc"
+  }
 }
 `
 
 	configAllFilters := `
 data "digitalocean_regions" "filtered" {
-	filter {
-        key = "available"
-        values = ["true"]
-    }
-	filter {
-        key = "features"
-        values = ["private_networking", "backups"]
-    }
+  filter {
+    key    = "available"
+    values = ["true"]
+  }
+  filter {
+    key    = "features"
+    values = ["private_networking", "backups"]
+  }
 }
 `
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/registry/resource_container_registry_docker_credentials_test.go
+++ b/digitalocean/registry/resource_container_registry_docker_credentials_test.go
@@ -129,23 +129,23 @@ func testAccCheckDigitalOceanContainerRegistryDockerCredentialsExists(n string, 
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_basic = `
 resource "digitalocean_container_registry" "foobar" {
-	name                   = "%s"
-	subscription_tier_slug = "basic"
+  name                   = "%s"
+  subscription_tier_slug = "basic"
 }
 
 resource "digitalocean_container_registry_docker_credentials" "foobar" {
-	registry_name = digitalocean_container_registry.foobar.name
-	write = true
+  registry_name = digitalocean_container_registry.foobar.name
+  write         = true
 }`
 
 var testAccCheckDigitalOceanContainerRegistryDockerCredentialsConfig_withExpiry = `
 resource "digitalocean_container_registry" "foobar" {
-	name                   = "%s"
-	subscription_tier_slug = "basic"
+  name                   = "%s"
+  subscription_tier_slug = "basic"
 }
 
 resource "digitalocean_container_registry_docker_credentials" "foobar" {
-	registry_name = digitalocean_container_registry.foobar.name
-	write = true
-	expiry_seconds = 3600
+  registry_name  = digitalocean_container_registry.foobar.name
+  write          = true
+  expiry_seconds = 3600
 }`

--- a/digitalocean/reservedip/datasource_floating_ip_test.go
+++ b/digitalocean/reservedip/datasource_floating_ip_test.go
@@ -73,5 +73,5 @@ resource "digitalocean_floating_ip" "foo" {
 }
 
 data "digitalocean_floating_ip" "foobar" {
-  ip_address = "${digitalocean_floating_ip.foo.ip_address}"
+  ip_address = digitalocean_floating_ip.foo.ip_address
 }`

--- a/digitalocean/reservedip/resource_floating_ip_assignment_test.go
+++ b/digitalocean/reservedip/resource_floating_ip_assignment_test.go
@@ -132,8 +132,8 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_floating_ip_assignment" "foobar" {
-  ip_address = "${digitalocean_floating_ip.foobar.ip_address}"
-  droplet_id = "${digitalocean_droplet.foobar.0.id}"
+  ip_address = digitalocean_floating_ip.foobar.ip_address
+  droplet_id = digitalocean_droplet.foobar[0].id
 }
 `
 
@@ -153,8 +153,8 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_floating_ip_assignment" "foobar" {
-  ip_address = "${digitalocean_floating_ip.foobar.ip_address}"
-  droplet_id = "${digitalocean_droplet.foobar.1.id}"
+  ip_address = digitalocean_floating_ip.foobar.ip_address
+  droplet_id = digitalocean_droplet.foobar[1].id
 }
 `
 
@@ -191,8 +191,8 @@ resource "digitalocean_floating_ip" "foobar" {
 }
 
 resource "digitalocean_floating_ip_assignment" "foobar" {
-  ip_address = "${digitalocean_floating_ip.foobar.id}"
-  droplet_id = "${digitalocean_droplet.foobar.id}"
+  ip_address = digitalocean_floating_ip.foobar.id
+  droplet_id = digitalocean_droplet.foobar.id
 
   lifecycle {
     create_before_destroy = true
@@ -217,8 +217,8 @@ resource "digitalocean_floating_ip" "foobar" {
 }
 
 resource "digitalocean_floating_ip_assignment" "foobar" {
-  ip_address = "${digitalocean_floating_ip.foobar.id}"
-  droplet_id = "${digitalocean_droplet.foobar.id}"
+  ip_address = digitalocean_floating_ip.foobar.id
+  droplet_id = digitalocean_droplet.foobar.id
 
   lifecycle {
     create_before_destroy = true

--- a/digitalocean/reservedip/resource_floating_ip_assignment_test.go
+++ b/digitalocean/reservedip/resource_floating_ip_assignment_test.go
@@ -176,10 +176,10 @@ resource "digitalocean_droplet" "foobar" {
 
 var testAccCheckDigitalOceanFloatingIPAssignmentConfig_createBeforeDestroy = `
 resource "digitalocean_droplet" "foobar" {
-  image = "ubuntu-22-04-x64"
-  name = "tf-acc-test"
+  image  = "ubuntu-22-04-x64"
+  name   = "tf-acc-test"
   region = "nyc3"
-  size = "s-1vcpu-1gb"
+  size   = "s-1vcpu-1gb"
 
   lifecycle {
     create_before_destroy = true
@@ -187,7 +187,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_floating_ip" "foobar" {
-  region     = "nyc3"
+  region = "nyc3"
 }
 
 resource "digitalocean_floating_ip_assignment" "foobar" {
@@ -202,10 +202,10 @@ resource "digitalocean_floating_ip_assignment" "foobar" {
 
 var testAccCheckDigitalOceanFloatingIPAssignmentConfig_createBeforeDestroyReassign = `
 resource "digitalocean_droplet" "foobar" {
-  image = "ubuntu-18-04-x64"
-  name = "tf-acc-test"
+  image  = "ubuntu-18-04-x64"
+  name   = "tf-acc-test"
   region = "nyc3"
-  size = "s-1vcpu-1gb"
+  size   = "s-1vcpu-1gb"
 
   lifecycle {
     create_before_destroy = true
@@ -213,7 +213,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_floating_ip" "foobar" {
-  region     = "nyc3"
+  region = "nyc3"
 }
 
 resource "digitalocean_floating_ip_assignment" "foobar" {

--- a/digitalocean/reservedip/resource_floating_ip_test.go
+++ b/digitalocean/reservedip/resource_floating_ip_test.go
@@ -175,6 +175,6 @@ resource "digitalocean_droplet" "baz" {
 }
 
 resource "digitalocean_floating_ip" "foobar" {
-  region     = "nyc3"
+  region = "nyc3"
 }`, rInt)
 }

--- a/digitalocean/reservedip/resource_floating_ip_test.go
+++ b/digitalocean/reservedip/resource_floating_ip_test.go
@@ -141,8 +141,8 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_floating_ip" "foobar" {
-  droplet_id = "${digitalocean_droplet.foobar.id}"
-  region     = "${digitalocean_droplet.foobar.region}"
+  droplet_id = digitalocean_droplet.foobar.id
+  region     = digitalocean_droplet.foobar.region
 }`, rInt)
 }
 
@@ -158,8 +158,8 @@ resource "digitalocean_droplet" "baz" {
 }
 
 resource "digitalocean_floating_ip" "foobar" {
-  droplet_id = "${digitalocean_droplet.baz.id}"
-  region     = "${digitalocean_droplet.baz.region}"
+  droplet_id = digitalocean_droplet.baz.id
+  region     = digitalocean_droplet.baz.region
 }`, rInt)
 }
 

--- a/digitalocean/reservedip/resource_reserved_ip_assignment_test.go
+++ b/digitalocean/reservedip/resource_reserved_ip_assignment_test.go
@@ -176,10 +176,10 @@ resource "digitalocean_droplet" "foobar" {
 
 var testAccCheckDigitalOceanReservedIPAssignmentConfig_createBeforeDestroy = `
 resource "digitalocean_droplet" "foobar" {
-  image = "ubuntu-22-04-x64"
-  name = "tf-acc-test"
+  image  = "ubuntu-22-04-x64"
+  name   = "tf-acc-test"
   region = "nyc3"
-  size = "s-1vcpu-1gb"
+  size   = "s-1vcpu-1gb"
 
   lifecycle {
     create_before_destroy = true
@@ -187,7 +187,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_reserved_ip" "foobar" {
-  region     = "nyc3"
+  region = "nyc3"
 }
 
 resource "digitalocean_reserved_ip_assignment" "foobar" {
@@ -202,10 +202,10 @@ resource "digitalocean_reserved_ip_assignment" "foobar" {
 
 var testAccCheckDigitalOceanReservedIPAssignmentConfig_createBeforeDestroyReassign = `
 resource "digitalocean_droplet" "foobar" {
-  image = "ubuntu-18-04-x64"
-  name = "tf-acc-test"
+  image  = "ubuntu-18-04-x64"
+  name   = "tf-acc-test"
   region = "nyc3"
-  size = "s-1vcpu-1gb"
+  size   = "s-1vcpu-1gb"
 
   lifecycle {
     create_before_destroy = true
@@ -213,7 +213,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_reserved_ip" "foobar" {
-  region     = "nyc3"
+  region = "nyc3"
 }
 
 resource "digitalocean_reserved_ip_assignment" "foobar" {

--- a/digitalocean/reservedip/resource_reserved_ip_test.go
+++ b/digitalocean/reservedip/resource_reserved_ip_test.go
@@ -175,6 +175,6 @@ resource "digitalocean_droplet" "baz" {
 }
 
 resource "digitalocean_reserved_ip" "foobar" {
-  region     = "nyc3"
+  region = "nyc3"
 }`, rInt)
 }

--- a/digitalocean/size/datasource_sizes_test.go
+++ b/digitalocean/size/datasource_sizes_test.go
@@ -124,23 +124,23 @@ data "digitalocean_sizes" "foobar" {
 
 const testAccCheckDataSourceDigitalOceanSizesConfigWithFilterAndSort = `
 data "digitalocean_sizes" "foobar" {
-	filter {
-		key 	= "slug"
-		values 	= ["s-1vcpu-1gb", "s-1vcpu-2gb", "s-2vcpu-2gb", "s-3vcpu-1gb"]
-	}
+  filter {
+    key    = "slug"
+    values = ["s-1vcpu-1gb", "s-1vcpu-2gb", "s-2vcpu-2gb", "s-3vcpu-1gb"]
+  }
 
-	filter {
-		key 	= "vcpus"
-		values 	= ["1", "2"]
-	}
+  filter {
+    key    = "vcpus"
+    values = ["1", "2"]
+  }
 
-	sort {
-		key 		= "price_monthly"
-		direction 	= "desc"
-	}
+  sort {
+    key       = "price_monthly"
+    direction = "desc"
+  }
 
-	sort {
-		key 		= "slug"
-		direction 	= "desc"
-	}
+  sort {
+    key       = "slug"
+    direction = "desc"
+  }
 }`

--- a/digitalocean/snapshot/datasource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/datasource_droplet_snapshot_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceDigitalOceanDropletSnapshot_basic(t *testing.T) {
 	dataSourceConfig := `
 data "digitalocean_droplet_snapshot" "foobar" {
   most_recent = true
-  name = digitalocean_droplet_snapshot.foo.name
+  name        = digitalocean_droplet_snapshot.foo.name
 }`
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -50,7 +50,7 @@ func TestAccDataSourceDigitalOceanDropletSnapshot_regex(t *testing.T) {
 	dataSourceConfig := fmt.Sprintf(`
 data "digitalocean_droplet_snapshot" "foobar" {
   most_recent = true
-  name_regex = "^%s"
+  name_regex  = "^%s"
 }`, testName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -87,12 +87,12 @@ resource "digitalocean_droplet" "bar" {
 }
 
 resource "digitalocean_droplet_snapshot" "bar" {
-  name = "%s-snapshot"
+  name       = "%s-snapshot"
   droplet_id = "${digitalocean_droplet.bar.id}"
 }`, testName, testName)
 	dataSourceConfig := `
 data "digitalocean_droplet_snapshot" "foobar" {
-  name = digitalocean_droplet_snapshot.bar.name
+  name   = digitalocean_droplet_snapshot.bar.name
   region = "lon1"
 }`
 
@@ -155,7 +155,7 @@ resource "digitalocean_droplet" "foo" {
 }
 
 resource "digitalocean_droplet_snapshot" "foo" {
-  name = "%s-snapshot"
+  name       = "%s-snapshot"
   droplet_id = digitalocean_droplet.foo.id
 }
 `

--- a/digitalocean/snapshot/datasource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/datasource_droplet_snapshot_test.go
@@ -88,7 +88,7 @@ resource "digitalocean_droplet" "bar" {
 
 resource "digitalocean_droplet_snapshot" "bar" {
   name       = "%s-snapshot"
-  droplet_id = "${digitalocean_droplet.bar.id}"
+  droplet_id = digitalocean_droplet.bar.id
 }`, testName, testName)
 	dataSourceConfig := `
 data "digitalocean_droplet_snapshot" "foobar" {

--- a/digitalocean/snapshot/datasource_volume_snapshot_test.go
+++ b/digitalocean/snapshot/datasource_volume_snapshot_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceDigitalOceanVolumeSnapshot_basic(t *testing.T) {
 	dataSourceConfig := `
 data "digitalocean_volume_snapshot" "foobar" {
   most_recent = true
-  name = digitalocean_volume_snapshot.foo.name
+  name        = digitalocean_volume_snapshot.foo.name
 }`
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,7 +52,7 @@ func TestAccDataSourceDigitalOceanVolumeSnapshot_regex(t *testing.T) {
 	dataSourceConfig := `
 data "digitalocean_volume_snapshot" "foobar" {
   most_recent = true
-  name_regex = "^${digitalocean_volume_snapshot.foo.name}"
+  name_regex  = "^${digitalocean_volume_snapshot.foo.name}"
 }`
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -161,8 +161,8 @@ resource "digitalocean_volume" "foo" {
 }
 
 resource "digitalocean_volume_snapshot" "foo" {
-  name = "%s-snapshot"
+  name      = "%s-snapshot"
   volume_id = digitalocean_volume.foo.id
-  tags = ["foo","bar"]
+  tags      = ["foo", "bar"]
 }
 `

--- a/digitalocean/snapshot/resource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/resource_droplet_snapshot_test.go
@@ -85,14 +85,14 @@ func testAccCheckDigitalOceanDropletSnapshotDestroy(s *terraform.State) error {
 
 const testAccCheckDigitalOceanDropletSnapshotConfig_basic = `
 resource "digitalocean_droplet" "foo" {
-	name      = "foo-%d"
-	size      = "s-1vcpu-1gb"
-	image     = "ubuntu-22-04-x64"
-	region    = "nyc3"
-	user_data = "foobar"
-  }
-  resource "digitalocean_droplet_snapshot" "foobar" {
-	droplet_id = "${digitalocean_droplet.foo.id}"
-	name = "snapshot-one-%d"
-  }
+  name      = "foo-%d"
+  size      = "s-1vcpu-1gb"
+  image     = "ubuntu-22-04-x64"
+  region    = "nyc3"
+  user_data = "foobar"
+}
+resource "digitalocean_droplet_snapshot" "foobar" {
+  droplet_id = "${digitalocean_droplet.foo.id}"
+  name       = "snapshot-one-%d"
+}
   `

--- a/digitalocean/snapshot/resource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/resource_droplet_snapshot_test.go
@@ -91,8 +91,9 @@ resource "digitalocean_droplet" "foo" {
   region    = "nyc3"
   user_data = "foobar"
 }
+
 resource "digitalocean_droplet_snapshot" "foobar" {
-  droplet_id = "${digitalocean_droplet.foo.id}"
+  droplet_id = digitalocean_droplet.foo.id
   name       = "snapshot-one-%d"
 }
   `

--- a/digitalocean/snapshot/resource_volume_snapshot_test.go
+++ b/digitalocean/snapshot/resource_volume_snapshot_test.go
@@ -101,9 +101,9 @@ resource "digitalocean_volume" "foo" {
 }
 
 resource "digitalocean_volume_snapshot" "foobar" {
-  name = "snapshot-%d"
+  name      = "snapshot-%d"
   volume_id = "${digitalocean_volume.foo.id}"
-  tags = ["foo","bar"]
+  tags      = ["foo", "bar"]
 }`
 
 func TestAccDigitalOceanVolumeSnapshot_UpdateTags(t *testing.T) {
@@ -142,7 +142,7 @@ resource "digitalocean_volume" "foo" {
 }
 
 resource "digitalocean_volume_snapshot" "foobar" {
-  name = "snapshot-%d"
+  name      = "snapshot-%d"
   volume_id = "${digitalocean_volume.foo.id}"
-  tags = ["foo","bar","baz"]
+  tags      = ["foo", "bar", "baz"]
 }`

--- a/digitalocean/snapshot/resource_volume_snapshot_test.go
+++ b/digitalocean/snapshot/resource_volume_snapshot_test.go
@@ -102,7 +102,7 @@ resource "digitalocean_volume" "foo" {
 
 resource "digitalocean_volume_snapshot" "foobar" {
   name      = "snapshot-%d"
-  volume_id = "${digitalocean_volume.foo.id}"
+  volume_id = digitalocean_volume.foo.id
   tags      = ["foo", "bar"]
 }`
 
@@ -143,6 +143,6 @@ resource "digitalocean_volume" "foo" {
 
 resource "digitalocean_volume_snapshot" "foobar" {
   name      = "snapshot-%d"
-  volume_id = "${digitalocean_volume.foo.id}"
+  volume_id = digitalocean_volume.foo.id
   tags      = ["foo", "bar", "baz"]
 }`

--- a/digitalocean/spaces/datasource_spaces_bucket_object_test.go
+++ b/digitalocean/spaces/datasource_spaces_bucket_object_test.go
@@ -231,10 +231,10 @@ func TestAccDataSourceDigitalOceanSpacesBucketObject_RegionError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`data "digitalocean_spaces_bucket_object" "object" {
-										region = "%s"
-										bucket = "foo.digitaloceanspaces.com"
-										key = "test-key"
-									}`, badRegion),
+  region = "%s"
+  bucket = "foo.digitaloceanspaces.com"
+  key    = "test-key"
+}`, badRegion),
 				ExpectError: regexp.MustCompile(`expected region to be one of`),
 			},
 		},
@@ -276,22 +276,22 @@ func testAccCheckDigitalOceanSpacesObjectDataSourceExists(n string, obj *s3.GetO
 func testAccDataSourceDigitalOceanSpacesObjectConfig_basic(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-	name   = "tf-object-test-bucket-%d"
-	region = "nyc3"
+  name   = "tf-object-test-bucket-%d"
+  region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object" {
-	bucket = digitalocean_spaces_bucket.object_bucket.name
-	region = digitalocean_spaces_bucket.object_bucket.region
-	key = "tf-testing-obj-%d"
-	content = "Hello World"
+  bucket  = digitalocean_spaces_bucket.object_bucket.name
+  region  = digitalocean_spaces_bucket.object_bucket.region
+  key     = "tf-testing-obj-%d"
+  content = "Hello World"
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-    region = "nyc3"
-	key = "tf-testing-obj-%d"
+  bucket = "tf-object-test-bucket-%d"
+  region = "nyc3"
+  key    = "tf-testing-obj-%d"
 }
 `, resources, randInt, randInt)
 
@@ -301,23 +301,23 @@ data "digitalocean_spaces_bucket_object" "obj" {
 func testAccDataSourceDigitalOceanSpacesObjectConfig_readableBody(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-	name = "tf-object-test-bucket-%d"
-    region = "nyc3"
+  name   = "tf-object-test-bucket-%d"
+  region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object" {
-	bucket = digitalocean_spaces_bucket.object_bucket.name
-	region = digitalocean_spaces_bucket.object_bucket.region
-	key = "tf-testing-obj-%d-readable"
-	content = "yes"
-	content_type = "text/plain"
+  bucket       = digitalocean_spaces_bucket.object_bucket.name
+  region       = digitalocean_spaces_bucket.object_bucket.region
+  key          = "tf-testing-obj-%d-readable"
+  content      = "yes"
+  content_type = "text/plain"
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-    region = "nyc3"
-	key = "tf-testing-obj-%d-readable"
+  bucket = "tf-object-test-bucket-%d"
+  region = "nyc3"
+  key    = "tf-testing-obj-%d-readable"
 }
 `, resources, randInt, randInt)
 
@@ -327,33 +327,33 @@ data "digitalocean_spaces_bucket_object" "obj" {
 func testAccDataSourceDigitalOceanSpacesObjectConfig_allParams(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-	name   = "tf-object-test-bucket-%d"
-	region = "nyc3"
-	versioning {
-		enabled = true
-	}
+  name   = "tf-object-test-bucket-%d"
+  region = "nyc3"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "digitalocean_spaces_bucket_object" "object" {
-	bucket = digitalocean_spaces_bucket.object_bucket.name
-	region = digitalocean_spaces_bucket.object_bucket.region
-	key = "tf-testing-obj-%d-all-params"
-	content = <<CONTENT
+  bucket              = digitalocean_spaces_bucket.object_bucket.name
+  region              = digitalocean_spaces_bucket.object_bucket.region
+  key                 = "tf-testing-obj-%d-all-params"
+  content             = <<CONTENT
 {"msg": "Hi there!"}
 CONTENT
-	content_type = "application/unknown"
-	cache_control = "no-cache"
-	content_disposition = "attachment"
-	content_encoding = "identity"
-	content_language = "en-GB"
+  content_type        = "application/unknown"
+  cache_control       = "no-cache"
+  content_disposition = "attachment"
+  content_encoding    = "identity"
+  content_language    = "en-GB"
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-    region = "nyc3"
-	key = "tf-testing-obj-%d-all-params"
+  bucket = "tf-object-test-bucket-%d"
+  region = "nyc3"
+  key    = "tf-testing-obj-%d-all-params"
 }
 `, resources, randInt, randInt)
 
@@ -363,14 +363,14 @@ data "digitalocean_spaces_bucket_object" "obj" {
 func testAccDataSourceDigitalOceanSpacesObjectConfig_leadingSlash(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name = "tf-object-test-bucket-%d"
+  name   = "tf-object-test-bucket-%d"
   region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object" {
-  bucket = digitalocean_spaces_bucket.object_bucket.name
-  region = digitalocean_spaces_bucket.object_bucket.region
-  key = "//tf-testing-obj-%d-readable"
-  content = "yes"
+  bucket       = digitalocean_spaces_bucket.object_bucket.name
+  region       = digitalocean_spaces_bucket.object_bucket.region
+  key          = "//tf-testing-obj-%d-readable"
+  content      = "yes"
   content_type = "text/plain"
 }
 `, randInt, randInt)
@@ -379,17 +379,17 @@ resource "digitalocean_spaces_bucket_object" "object" {
 data "digitalocean_spaces_bucket_object" "obj1" {
   bucket = "tf-object-test-bucket-%d"
   region = "nyc3"
-  key = "tf-testing-obj-%d-readable"
+  key    = "tf-testing-obj-%d-readable"
 }
 data "digitalocean_spaces_bucket_object" "obj2" {
   bucket = "tf-object-test-bucket-%d"
   region = "nyc3"
-  key = "/tf-testing-obj-%d-readable"
+  key    = "/tf-testing-obj-%d-readable"
 }
 data "digitalocean_spaces_bucket_object" "obj3" {
   bucket = "tf-object-test-bucket-%d"
   region = "nyc3"
-  key = "//tf-testing-obj-%d-readable"
+  key    = "//tf-testing-obj-%d-readable"
 }
 `, resources, randInt, randInt, randInt, randInt, randInt, randInt)
 
@@ -399,22 +399,22 @@ data "digitalocean_spaces_bucket_object" "obj3" {
 func testAccDataSourceDigitalOceanSpacesObjectConfig_multipleSlashes(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name = "tf-object-test-bucket-%d"
+  name   = "tf-object-test-bucket-%d"
   region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object1" {
-  bucket = digitalocean_spaces_bucket.object_bucket.name
-  region = digitalocean_spaces_bucket.object_bucket.region
-  key = "first//second///third//"
-  content = "yes"
+  bucket       = digitalocean_spaces_bucket.object_bucket.name
+  region       = digitalocean_spaces_bucket.object_bucket.region
+  key          = "first//second///third//"
+  content      = "yes"
   content_type = "text/plain"
 }
 # Without a trailing slash.
 resource "digitalocean_spaces_bucket_object" "object2" {
-  bucket = digitalocean_spaces_bucket.object_bucket.name
-  region = digitalocean_spaces_bucket.object_bucket.region
-  key = "/first////second/third"
-  content = "no"
+  bucket       = digitalocean_spaces_bucket.object_bucket.name
+  region       = digitalocean_spaces_bucket.object_bucket.region
+  key          = "/first////second/third"
+  content      = "no"
   content_type = "text/plain"
 }
 `, randInt)
@@ -423,17 +423,17 @@ resource "digitalocean_spaces_bucket_object" "object2" {
 data "digitalocean_spaces_bucket_object" "obj1" {
   bucket = "tf-object-test-bucket-%d"
   region = "nyc3"
-  key = "first/second/third/"
+  key    = "first/second/third/"
 }
 data "digitalocean_spaces_bucket_object" "obj2" {
   bucket = "tf-object-test-bucket-%d"
   region = "nyc3"
-  key = "first//second///third//"
+  key    = "first//second///third//"
 }
 data "digitalocean_spaces_bucket_object" "obj3" {
   bucket = "tf-object-test-bucket-%d"
   region = "nyc3"
-  key = "first/second/third"
+  key    = "first/second/third"
 }
 `, resources, randInt, randInt, randInt)
 

--- a/digitalocean/spaces/datasource_spaces_bucket_test.go
+++ b/digitalocean/spaces/datasource_spaces_bucket_test.go
@@ -18,15 +18,15 @@ func TestAccDataSourceDigitalOceanSpacesBucket_Basic(t *testing.T) {
 
 	resourceConfig := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "%s"
-	region = "%s"
+  name   = "%s"
+  region = "%s"
 }
 `, bucketName, bucketRegion)
 
 	datasourceConfig := fmt.Sprintf(`
 data "digitalocean_spaces_bucket" "bucket" {
-    name = "%s"
-    region = "%s"
+  name   = "%s"
+  region = "%s"
 }
 `, bucketName, bucketRegion)
 
@@ -64,8 +64,8 @@ data "digitalocean_spaces_bucket" "bucket" {
 func TestAccDataSourceDigitalOceanSpacesBucket_NotFound(t *testing.T) {
 	datasourceConfig := `
 data "digitalocean_spaces_bucket" "bucket" {
-    name = "no-such-bucket"
-    region = "nyc3"
+  name   = "no-such-bucket"
+  region = "nyc3"
 }
 `
 
@@ -91,10 +91,10 @@ func TestAccDataSourceDigitalOceanSpacesBucket_RegionError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-					data "digitalocean_spaces_bucket" "bucket" {
-						name   = "tf-test-bucket"
-						region = "%s"
-					}`, badRegion),
+data "digitalocean_spaces_bucket" "bucket" {
+  name   = "tf-test-bucket"
+  region = "%s"
+}`, badRegion),
 				ExpectError: regexp.MustCompile(`expected region to be one of`),
 			},
 		},

--- a/digitalocean/spaces/datasource_spaces_buckets_test.go
+++ b/digitalocean/spaces/datasource_spaces_buckets_test.go
@@ -19,12 +19,12 @@ func TestAccDataSourceDigitalOceanSpacesBuckets_Basic(t *testing.T) {
 
 	bucketsConfig := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket1" {
-  name = "%s"
+  name   = "%s"
   region = "%s"
 }
 
 resource "digitalocean_spaces_bucket" "bucket2" {
-  name = "%s"
+  name   = "%s"
   region = "%s"
 }
 `, bucketName1, bucketRegion1, bucketName2, bucketRegion2)
@@ -32,7 +32,7 @@ resource "digitalocean_spaces_bucket" "bucket2" {
 	datasourceConfig := fmt.Sprintf(`
 data "digitalocean_spaces_buckets" "result" {
   filter {
-    key = "name"
+    key    = "name"
     values = ["%s"]
   }
 }

--- a/digitalocean/spaces/resource_spaces_bucket_object_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_object_test.go
@@ -393,10 +393,10 @@ func TestAccDigitalOceanSpacesBucketObject_RegionError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "digitalocean_spaces_bucket_object" "object" {
-										region = "%s"
-										bucket = "foo.digitaloceanspaces.com"
-										key = "test-key"
-									}`, badRegion),
+  region = "%s"
+  bucket = "foo.digitaloceanspaces.com"
+  key    = "test-key"
+}`, badRegion),
 				ExpectError: regexp.MustCompile(`expected region to be one of`),
 			},
 		},
@@ -584,7 +584,7 @@ func testAccDigitalOceanSpacesBucketObjectConfigBasic(bucket, key string) string
 resource "digitalocean_spaces_bucket_object" "object" {
   region = "%s"
   bucket = "%s"
-  key = "%s"
+  key    = "%s"
 }
 `, testAccDigitalOceanSpacesBucketObject_TestRegion, bucket, key)
 }
@@ -592,15 +592,15 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfigEmpty(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 
 resource "digitalocean_spaces_bucket_object" "object" {
   region = digitalocean_spaces_bucket.object_bucket.region
   bucket = digitalocean_spaces_bucket.object_bucket.name
-  key = "test-key"
+  key    = "test-key"
 }
 `, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt)
 }
@@ -608,8 +608,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfigSource(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 
@@ -626,8 +626,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfig_withContentCharacteristics(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 
@@ -646,8 +646,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfigContent(randInt int, content string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 
@@ -663,8 +663,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfigContentBase64(randInt int, contentBase64 string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 
@@ -680,8 +680,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfig_updateable(randInt int, bucketVersioning bool, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket_3" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 
   versioning {
@@ -702,8 +702,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfig_acl(randInt int, content, acl string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 
   versioning {
@@ -724,15 +724,15 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(randInt int, metadataKey1, metadataValue1, metadataKey2, metadataValue2 string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 
 resource "digitalocean_spaces_bucket_object" "object" {
   region = digitalocean_spaces_bucket.object_bucket.region
-  bucket  = digitalocean_spaces_bucket.object_bucket.name
-  key     = "test-key"
+  bucket = digitalocean_spaces_bucket.object_bucket.name
+  key    = "test-key"
 
   metadata = {
     %[3]s = %[4]q
@@ -745,8 +745,8 @@ resource "digitalocean_spaces_bucket_object" "object" {
 func testAccDigitalOceanSpacesBucketObjectConfig_NonVersioned(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket_3" {
-  region = "%s"
-  name   = "tf-object-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-object-test-bucket-%d"
   force_destroy = true
 }
 

--- a/digitalocean/spaces/resource_spaces_bucket_policy_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_policy_test.go
@@ -202,8 +202,8 @@ func testAccCheckDigitalOceanSpacesBucketPolicyDestroy(s *terraform.State) error
 func testAccDigitalOceanSpacesBucketPolicy(randInt int, policy string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "policy_bucket" {
-  region = "%s"
-  name   = "tf-policy-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-policy-test-bucket-%d"
   force_destroy = true
 }
 
@@ -215,14 +215,15 @@ resource "digitalocean_spaces_bucket_policy" "policy" {
 EOF
 }
 
+
 `, testAccDigitalOceanSpacesBucketPolicy_TestRegion, randInt, policy)
 }
 
 func testAccDigitalOceanSpacesBucketEmptyPolicy(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "policy_bucket" {
-  region = "%s"
-  name   = "tf-policy-test-bucket-%d"
+  region        = "%s"
+  name          = "tf-policy-test-bucket-%d"
   force_destroy = true
 }
 
@@ -231,6 +232,7 @@ resource "digitalocean_spaces_bucket_policy" "policy" {
   bucket = digitalocean_spaces_bucket.policy_bucket.name
   policy = ""
 }
+
 
 `, testAccDigitalOceanSpacesBucketPolicy_TestRegion, randInt)
 }

--- a/digitalocean/spaces/resource_spaces_bucket_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_test.go
@@ -239,7 +239,7 @@ func TestAccDigitalOceanBucket_Versioning(t *testing.T) {
 		}
 		return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name   = "tf-test-bucket-%d"
   region = "ams3"
 %s
 }
@@ -432,10 +432,10 @@ func TestAccDigitalOceanSpacesBucket_RegionError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-					resource "digitalocean_spaces_bucket" "bucket" {
-						name   = "tf-test-bucket"
-						region = "%s"
-					}`, badRegion),
+resource "digitalocean_spaces_bucket" "bucket" {
+  name   = "tf-test-bucket"
+  region = "%s"
+}`, badRegion),
 				ExpectError: regexp.MustCompile(`expected region to be one of`),
 			},
 		},
@@ -639,9 +639,9 @@ func testAccBucketName(randInt int) string {
 func testAccDigitalOceanBucketConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
-	acl = "public-read"
-	region = "ams3"
+  name   = "tf-test-bucket-%d"
+  acl    = "public-read"
+  region = "ams3"
 }
 `, randInt)
 }
@@ -649,8 +649,8 @@ resource "digitalocean_spaces_bucket" "bucket" {
 func testAccDigitalOceanBucketDestroyedConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
-	acl = "public-read"
+  name = "tf-test-bucket-%d"
+  acl  = "public-read"
 }
 `, randInt)
 }
@@ -658,8 +658,8 @@ resource "digitalocean_spaces_bucket" "bucket" {
 func testAccDigitalOceanBucketConfigWithRegion(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
-	region = "ams3"
+  name   = "tf-test-bucket-%d"
+  region = "ams3"
 }
 `, randInt)
 }
@@ -667,69 +667,69 @@ resource "digitalocean_spaces_bucket" "bucket" {
 func testAccDigitalOceanBucketConfigImport(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-	name   = "tf-test-bucket-%d"
-	region = "sfo2"
+  name   = "tf-test-bucket-%d"
+  region = "sfo2"
 }
 `, randInt)
 }
 
 var testAccDigitalOceanBucketConfigWithACL = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
-	acl = "public-read"
+  name = "tf-test-bucket-%d"
+  acl  = "public-read"
 }
 `
 
 var testAccDigitalOceanBucketConfigWithACLUpdate = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
-	acl = "private"
+  name = "tf-test-bucket-%d"
+  acl  = "private"
 }
 `
 
 var testAccDigitalOceanBucketConfigWithCORS = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
+  name = "tf-test-bucket-%d"
 }
 `
 
 var testAccDigitalOceanBucketConfigWithCORSUpdate = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
-	cors_rule {
-			allowed_headers = ["*"]
-			allowed_methods = ["PUT","POST"]
-			allowed_origins = ["https://www.example.com"]
-			max_age_seconds = 3000
-	}
+  name = "tf-test-bucket-%d"
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "POST"]
+    allowed_origins = ["https://www.example.com"]
+    max_age_seconds = 3000
+  }
 }
 `
 
 var testAccDigitalOceanBucketConfigWithMultiCORS = `
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
+  name = "tf-test-bucket-%d"
 
-	cors_rule {
-			allowed_headers = ["*"]
-			allowed_methods = ["GET"]
-			allowed_origins = ["*"]
-			max_age_seconds = 3000
-	}
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
 
-	cors_rule {
-			allowed_headers = ["*"]
-			allowed_methods = ["PUT", "DELETE", "POST"]
-			allowed_origins = ["https://www.example.com"]
-			max_age_seconds = 3000
-	}
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "DELETE", "POST"]
+    allowed_origins = ["https://www.example.com"]
+    max_age_seconds = 3000
+  }
 }
 `
 
 func testAccDigitalOceanSpacesBucketConfigWithLifecycle(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
-  acl  = "private"
+  name   = "tf-test-bucket-%d"
+  acl    = "private"
   region = "ams3"
 
   lifecycle_rule {
@@ -753,8 +753,8 @@ resource "digitalocean_spaces_bucket" "bucket" {
   }
 
   lifecycle_rule {
-    id     = "id3"
-    prefix = "path3/"
+    id      = "id3"
+    prefix  = "path3/"
     enabled = true
 
     abort_incomplete_multipart_upload_days = 30
@@ -766,8 +766,8 @@ resource "digitalocean_spaces_bucket" "bucket" {
 func testAccDigitalOceanSpacesBucketConfigWithLifecycleExpireMarker(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
-  acl  = "private"
+  name   = "tf-test-bucket-%d"
+  acl    = "private"
   region = "ams3"
 
   lifecycle_rule {
@@ -786,8 +786,8 @@ resource "digitalocean_spaces_bucket" "bucket" {
 func testAccDigitalOceanSpacesBucketConfigWithVersioningLifecycle(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
-  acl  = "private"
+  name   = "tf-test-bucket-%d"
+  acl    = "private"
   region = "ams3"
 
   versioning {
@@ -802,7 +802,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
     noncurrent_version_expiration {
       days = 365
     }
- }
+  }
 
   lifecycle_rule {
     id      = "id2"

--- a/digitalocean/sshkey/datasource_ssh_key_test.go
+++ b/digitalocean/sshkey/datasource_ssh_key_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceDigitalOceanSSHKey_Basic(t *testing.T) {
 
 	resourceConfig := fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foo" {
-  name = "%s"
+  name       = "%s"
   public_key = "%s"
 }`, keyName, pubKey)
 

--- a/digitalocean/sshkey/datasource_ssh_keys_test.go
+++ b/digitalocean/sshkey/datasource_ssh_keys_test.go
@@ -25,12 +25,12 @@ func TestAccDataSourceDigitalOceanSSHKeys_Basic(t *testing.T) {
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foo" {
-  name = "%s"
+  name       = "%s"
   public_key = "%s"
 }
 
 resource "digitalocean_ssh_key" "bar" {
-  name = "%s"
+  name       = "%s"
   public_key = "%s"
 }
 `, keyName1, pubKey1, keyName2, pubKey2)

--- a/digitalocean/sshkey/resource_ssh_key_test.go
+++ b/digitalocean/sshkey/resource_ssh_key_test.go
@@ -104,7 +104,7 @@ func testAccCheckDigitalOceanSSHKeyExists(n string, key *godo.Key) resource.Test
 func testAccCheckDigitalOceanSSHKeyConfig_basic(rInt int, key string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foobar" {
-    name = "foobar-%d"
-    public_key = "%s"
+  name       = "foobar-%d"
+  public_key = "%s"
 }`, rInt, key)
 }

--- a/digitalocean/tag/datasource_tag_test.go
+++ b/digitalocean/tag/datasource_tag_test.go
@@ -21,7 +21,7 @@ resource "digitalocean_tag" "foo" {
 }`, tagName)
 	dataSourceConfig := `
 data "digitalocean_tag" "foobar" {
-  name = "${digitalocean_tag.foo.name}"
+  name = digitalocean_tag.foo.name
 }`
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/digitalocean/tag/resource_tag_test.go
+++ b/digitalocean/tag/resource_tag_test.go
@@ -104,5 +104,5 @@ func testAccCheckDigitalOceanTagExists(n string, tag *godo.Tag) resource.TestChe
 
 var testAccCheckDigitalOceanTagConfig_basic = fmt.Sprintf(`
 resource "digitalocean_tag" "foobar" {
-    name = "foobar"
+  name = "foobar"
 }`)

--- a/digitalocean/uptime/resource_uptime_alert_test.go
+++ b/digitalocean/uptime/resource_uptime_alert_test.go
@@ -16,22 +16,22 @@ data "digitalocean_account" "test" {
 }
 
 resource "digitalocean_uptime_check" "test" {
-	name  = "terraform-test"
-	target = "https://www.landingpage.com"
-	regions = ["us_east", "eu_west"]
+  name    = "terraform-test"
+  target  = "https://www.landingpage.com"
+  regions = ["us_east", "eu_west"]
+}
+resource "digitalocean_uptime_alert" "foobar" {
+  check_id   = digitalocean_uptime_check.test.id
+  name       = "%s"
+  type       = "latency"
+  threshold  = "%s"
+  comparison = "greater_than"
+  notifications {
+    email = [data.digitalocean_account.test.email]
   }
-  resource "digitalocean_uptime_alert" "foobar"  {
-	check_id = "${digitalocean_uptime_check.test.id}"
-	name = "%s"
-  	type = "latency"
-	threshold = %s
-	comparison = "greater_than"
-	notifications {
-		email = [data.digitalocean_account.test.email]
-	}
-	period = "2m"
-  }
-  `
+  period = "2m"
+}
+`
 
 func TestAccDigitalOceanUptimeAlert_Basic(t *testing.T) {
 	originalAlertName := acceptance.RandomTestName()

--- a/digitalocean/uptime/resource_uptime_check_test.go
+++ b/digitalocean/uptime/resource_uptime_check_test.go
@@ -13,9 +13,9 @@ import (
 
 const testAccCheckDigitalOceanUptimeCheckConfig_Basic = `
 resource "digitalocean_uptime_check" "foobar" {
-	name        = "%s"
-	target      = "%s"
-	regions     = ["%s"]
+  name    = "%s"
+  target  = "%s"
+  regions = ["%s"]
 }
 `
 

--- a/digitalocean/volume/datasource_volume_test.go
+++ b/digitalocean/volume/datasource_volume_test.go
@@ -125,7 +125,7 @@ resource "digitalocean_volume" "foo" {
   region = "nyc3"
   name   = "%s-volume"
   size   = 10
-  tags   = ["foo","bar"]
+  tags   = ["foo", "bar"]
 }`, testName)
 }
 
@@ -135,7 +135,7 @@ resource "digitalocean_volume" "foo" {
   region = "nyc3"
   name   = "%s-volume"
   size   = 10
-  tags   = ["foo","bar"]
+  tags   = ["foo", "bar"]
 }
 
 resource "digitalocean_volume" "bar" {

--- a/digitalocean/volume/resource_volume_attachment_test.go
+++ b/digitalocean/volume/resource_volume_attachment_test.go
@@ -219,84 +219,84 @@ func testAccCheckDigitalOceanVolumeAttachmentDestroy(s *terraform.State) error {
 func testAccCheckDigitalOceanVolumeAttachmentConfig_basic(rInt int, vName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 5
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = 5
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_droplet" "foobar" {
-	name               = "baz-%d"
-	size               = "s-1vcpu-1gb"
-	image              = "ubuntu-22-04-x64"
-	region             = "nyc1"
+  name   = "baz-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc1"
 }
 
 resource "digitalocean_volume_attachment" "foobar" {
-	droplet_id = "${digitalocean_droplet.foobar.id}"
-	volume_id = "${digitalocean_volume.foobar.id}"
+  droplet_id = "${digitalocean_droplet.foobar.id}"
+  volume_id  = "${digitalocean_volume.foobar.id}"
 }`, vName, rInt)
 }
 
 func testAccCheckDigitalOceanVolumeAttachmentConfig_multiple(rInt int, vName, vSecondName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 5
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = 5
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_volume" "barfoo" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 5
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = 5
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_droplet" "foobar" {
-	name               = "baz-%d"
-	size               = "s-1vcpu-1gb"
-	image              = "ubuntu-22-04-x64"
-	region             = "nyc1"
+  name   = "baz-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc1"
 }
 
 resource "digitalocean_volume_attachment" "foobar" {
-	droplet_id = "${digitalocean_droplet.foobar.id}"
-	volume_id = "${digitalocean_volume.foobar.id}"
+  droplet_id = "${digitalocean_droplet.foobar.id}"
+  volume_id  = "${digitalocean_volume.foobar.id}"
 }
 
 resource "digitalocean_volume_attachment" "barfoo" {
-	droplet_id = "${digitalocean_droplet.foobar.id}"
-	volume_id = "${digitalocean_volume.barfoo.id}"
+  droplet_id = "${digitalocean_droplet.foobar.id}"
+  volume_id  = "${digitalocean_volume.barfoo.id}"
 }`, vName, vSecondName, rInt)
 }
 
 func testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(rInt int, vName, vSecondName, activeVolume string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 5
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = 5
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_volume" "foobar_second" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 5
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = 5
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_droplet" "foobar" {
-	name               = "baz-%d"
-	size               = "s-1vcpu-1gb"
-	image              = "ubuntu-22-04-x64"
-	region             = "nyc1"
+  name   = "baz-%d"
+  size   = "s-1vcpu-1gb"
+  image  = "ubuntu-22-04-x64"
+  region = "nyc1"
 }
 
 resource "digitalocean_volume_attachment" "foobar" {
-	droplet_id = "${digitalocean_droplet.foobar.id}"
-	volume_id = "${digitalocean_volume.%s.id}"
+  droplet_id = digitalocean_droplet.foobar.id
+  volume_id  = digitalocean_volume.%s.id
 }`, vName, vSecondName, rInt, activeVolume)
 }

--- a/digitalocean/volume/resource_volume_attachment_test.go
+++ b/digitalocean/volume/resource_volume_attachment_test.go
@@ -233,8 +233,8 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_volume_attachment" "foobar" {
-  droplet_id = "${digitalocean_droplet.foobar.id}"
-  volume_id  = "${digitalocean_volume.foobar.id}"
+  droplet_id = digitalocean_droplet.foobar.id
+  volume_id  = digitalocean_volume.foobar.id
 }`, vName, rInt)
 }
 
@@ -262,13 +262,13 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_volume_attachment" "foobar" {
-  droplet_id = "${digitalocean_droplet.foobar.id}"
-  volume_id  = "${digitalocean_volume.foobar.id}"
+  droplet_id = digitalocean_droplet.foobar.id
+  volume_id  = digitalocean_volume.foobar.id
 }
 
 resource "digitalocean_volume_attachment" "barfoo" {
-  droplet_id = "${digitalocean_droplet.foobar.id}"
-  volume_id  = "${digitalocean_volume.barfoo.id}"
+  droplet_id = digitalocean_droplet.foobar.id
+  volume_id  = digitalocean_volume.barfoo.id
 }`, vName, vSecondName, rInt)
 }
 

--- a/digitalocean/volume/resource_volume_test.go
+++ b/digitalocean/volume/resource_volume_test.go
@@ -144,7 +144,7 @@ resource "digitalocean_droplet" "foobar" {
   region             = "nyc1"
   ipv6               = true
   private_networking = true
-  volume_ids         = ["${digitalocean_volume.foobar.id}"]
+  volume_ids         = [digitalocean_volume.foobar.id]
 }`, vName, rInt)
 }
 
@@ -289,7 +289,7 @@ resource "digitalocean_droplet" "foobar" {
   region             = "nyc1"
   ipv6               = true
   private_networking = true
-  volume_ids         = ["${digitalocean_volume.foobar.id}"]
+  volume_ids         = [digitalocean_volume.foobar.id]
 }`, vName, vSize, rInt)
 }
 
@@ -329,14 +329,14 @@ resource "digitalocean_volume" "foo" {
 
 resource "digitalocean_volume_snapshot" "foo" {
   name      = "snapshot-%d"
-  volume_id = "${digitalocean_volume.foo.id}"
+  volume_id = digitalocean_volume.foo.id
 }
 
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
   name        = "volume-snap-%d"
-  size        = "${digitalocean_volume_snapshot.foo.min_disk_size}"
-  snapshot_id = "${digitalocean_volume_snapshot.foo.id}"
+  size        = digitalocean_volume_snapshot.foo.min_disk_size
+  snapshot_id = digitalocean_volume_snapshot.foo.id
 }`, rInt, rInt, rInt)
 }
 

--- a/digitalocean/volume/resource_volume_test.go
+++ b/digitalocean/volume/resource_volume_test.go
@@ -51,11 +51,11 @@ func TestAccDigitalOceanVolume_Basic(t *testing.T) {
 
 const testAccCheckDigitalOceanVolumeConfig_basic = `
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 100
-	description = "peace makes plenty"
-	tags        = ["foo","bar"]
+  region      = "nyc1"
+  name        = "%s"
+  size        = 100
+  description = "peace makes plenty"
+  tags        = ["foo", "bar"]
 }`
 
 func testAccCheckDigitalOceanVolumeExists(rn string, volume *godo.Volume) resource.TestCheckFunc {
@@ -131,10 +131,10 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 func testAccCheckDigitalOceanVolumeConfig_droplet(rInt int, vName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 100
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = 100
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_droplet" "foobar" {
@@ -182,11 +182,11 @@ func TestAccDigitalOceanVolume_LegacyFilesystemType(t *testing.T) {
 
 const testAccCheckDigitalOceanVolumeConfig_legacy_filesystem_type = `
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 100
-	description = "peace makes plenty"
-	filesystem_type = "xfs"
+  region          = "nyc1"
+  name            = "%s"
+  size            = 100
+  description     = "peace makes plenty"
+  filesystem_type = "xfs"
 }`
 
 func TestAccDigitalOceanVolume_FilesystemType(t *testing.T) {
@@ -229,12 +229,12 @@ func TestAccDigitalOceanVolume_FilesystemType(t *testing.T) {
 
 const testAccCheckDigitalOceanVolumeConfig_filesystem_type = `
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 100
-	description = "peace makes plenty"
-	initial_filesystem_type = "xfs"
-	initial_filesystem_label = "label"
+  region                   = "nyc1"
+  name                     = "%s"
+  size                     = 100
+  description              = "peace makes plenty"
+  initial_filesystem_type  = "xfs"
+  initial_filesystem_label = "label"
 }`
 
 func TestAccDigitalOceanVolume_Resize(t *testing.T) {
@@ -276,10 +276,10 @@ func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 func testAccCheckDigitalOceanVolumeConfig_resize(rInt int, vName string, vSize int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = %d
-	description = "peace makes plenty"
+  region      = "nyc1"
+  name        = "%s"
+  size        = %d
+  description = "peace makes plenty"
 }
 
 resource "digitalocean_droplet" "foobar" {
@@ -328,7 +328,7 @@ resource "digitalocean_volume" "foo" {
 }
 
 resource "digitalocean_volume_snapshot" "foo" {
-  name = "snapshot-%d"
+  name      = "snapshot-%d"
   volume_id = "${digitalocean_volume.foo.id}"
 }
 
@@ -374,9 +374,9 @@ func TestAccDigitalOceanVolume_UpdateTags(t *testing.T) {
 
 const testAccCheckDigitalOceanVolumeConfig_basic_tag_update = `
 resource "digitalocean_volume" "foobar" {
-	region      = "nyc1"
-	name        = "%s"
-	size        = 100
-	description = "peace makes plenty"
-	tags        = ["foo","bar","baz"]
+  region      = "nyc1"
+  name        = "%s"
+  size        = 100
+  description = "peace makes plenty"
+  tags        = ["foo", "bar", "baz"]
 }`

--- a/digitalocean/vpc/datasource_vpc_test.go
+++ b/digitalocean/vpc/datasource_vpc_test.go
@@ -93,34 +93,34 @@ func TestAccDataSourceDigitalOceanVPC_ExpectErrors(t *testing.T) {
 
 const testAccCheckDataSourceDigitalOceanVPCConfig_Basic = `
 resource "digitalocean_vpc" "foobar" {
-	name        = "%s"
-	description = "%s"
-	region      = "nyc3"
+  name        = "%s"
+  description = "%s"
+  region      = "nyc3"
 }`
 
 const testAccCheckDataSourceDigitalOceanVPCConfig_RegionDefault = `
 // Create Droplet to ensure default VPC exists
 resource "digitalocean_droplet" "foo" {
-	image  = "ubuntu-18-04-x64"
-	name   = "%s"
-	region = "nyc3"
-	size   = "s-1vcpu-1gb"
-	private_networking = "true"
+  image              = "ubuntu-18-04-x64"
+  name               = "%s"
+  region             = "nyc3"
+  size               = "s-1vcpu-1gb"
+  private_networking = "true"
 }
 
 data "digitalocean_vpc" "foobar" {
-	region = "nyc3"
+  region = "nyc3"
 }
 `
 
 const testAccCheckDataSourceDigitalOceanVPCConfig_MissingRegionDefault = `
 data "digitalocean_vpc" "foobar" {
-	region = "foo"
+  region = "foo"
 }
 `
 
 const testAccCheckDataSourceDigitalOceanVPCConfig_DoesNotExist = `
 data "digitalocean_vpc" "foobar" {
-	name = "%s"
+  name = "%s"
 }
 `

--- a/digitalocean/vpc/resource_vpc_test.go
+++ b/digitalocean/vpc/resource_vpc_test.go
@@ -162,27 +162,27 @@ func testAccCheckDigitalOceanVPCExists(resource string) resource.TestCheckFunc {
 
 const testAccCheckDigitalOceanVPCConfig_Basic = `
 resource "digitalocean_vpc" "foobar" {
-	name        = "%s"
-	description = "%s"
-	region      = "nyc3"
+  name        = "%s"
+  description = "%s"
+  region      = "nyc3"
 }
 `
 const testAccCheckDigitalOceanVPCConfig_IPRange = `
 resource "digitalocean_vpc" "foobar" {
-	name     = "%s"
-	region   = "nyc3"
-	ip_range = "10.10.10.0/24"
+  name     = "%s"
+  region   = "nyc3"
+  ip_range = "10.10.10.0/24"
 }
 `
 
 const testAccCheckDigitalOceanVPCConfig_IPRangeRace = `
 resource "digitalocean_vpc" "foo" {
-	name        = "%s"
-	region      = "nyc3"
+  name   = "%s"
+  region = "nyc3"
 }
 
 resource "digitalocean_vpc" "bar" {
-	name        = "%s"
-	region      = "nyc3"
+  name   = "%s"
+  region = "nyc3"
 }
 `


### PR DESCRIPTION
Another big PR, but it is mostly composed of format changes. So hopefully not too bad to review. It does a few related things:

- Adds targets to install and run `github.com/katbyte/terrafmt` to the makefile
- Adds a step to add run it in check mode to the PR testing workflow
- Re-formats all existing Terraform configs in our tests to pass the check
-  Removes usage of the deprecated interpolation format in test configs, e.g.  changes `"${digitalocean_tag.foo.name}"`
to simply `digitalocean_tag.foo.name`