### PR TITLE
Use consistent naming for all Droplets created in tests.

### DIFF
--- a/digitalocean/acceptance/droplets.go
+++ b/digitalocean/acceptance/droplets.go
@@ -77,15 +77,15 @@ func TestAccCheckDigitalOceanDropletExists(n string, droplet *godo.Droplet) reso
 	}
 }
 
-func TestAccCheckDigitalOceanDropletConfig_basic(rInt int) string {
+func TestAccCheckDigitalOceanDropletConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
-}`, rInt)
+}`, name)
 }
 
 func TakeSnapshotsOfDroplet(rInt int, droplet *godo.Droplet, snapshotsId *[]int) resource.TestCheckFunc {

--- a/digitalocean/droplet/datasource_droplet_test.go
+++ b/digitalocean/droplet/datasource_droplet_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -55,7 +54,7 @@ data "digitalocean_droplet" "foobar" {
 
 func TestAccDataSourceDigitalOceanDroplet_BasicById(t *testing.T) {
 	var droplet godo.Droplet
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -85,8 +84,8 @@ func TestAccDataSourceDigitalOceanDroplet_BasicById(t *testing.T) {
 
 func TestAccDataSourceDigitalOceanDroplet_BasicByTag(t *testing.T) {
 	var droplet godo.Droplet
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
-	tagName := fmt.Sprintf("tf-acc-test-tag-%s", acctest.RandString(10))
+	name := acceptance.RandomTestName()
+	tagName := acceptance.RandomTestName("tag")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },

--- a/digitalocean/droplet/datasource_droplets_test.go
+++ b/digitalocean/droplet/datasource_droplets_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanDroplets_Basic(t *testing.T) {
-	name1 := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
-	name2 := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+	name1 := acceptance.RandomTestName("01")
+	name2 := acceptance.RandomTestName("02")
 
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_droplet" "foo" {

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -25,12 +25,12 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
 					resource.TestCheckResourceAttr(
@@ -59,7 +59,7 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	slug := "ubuntu-22-04-x64"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -68,7 +68,7 @@ func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_withID(rInt, slug),
+				Config: testAccCheckDigitalOceanDropletConfig_withID(name, slug),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 				),
@@ -79,7 +79,7 @@ func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)
@@ -91,12 +91,12 @@ func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_withSSH(rInt, publicKeyMaterial),
+				Config: testAccCheckDigitalOceanDropletConfig_withSSH(name, publicKeyMaterial),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
 					resource.TestCheckResourceAttr(
@@ -113,7 +113,8 @@ func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
+	newName := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -121,22 +122,22 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_RenameAndResize(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_RenameAndResize(newName),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletRenamedAndResized(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("baz-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", newName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
@@ -149,7 +150,7 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -157,22 +158,22 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletResizeWithOutDisk(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
@@ -185,7 +186,7 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -193,22 +194,22 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 				),
 			},
 			// Test moving to larger plan with resize_disk = false only increases RAM, not disk.
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletResizeWithOutDisk(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
@@ -217,12 +218,12 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 			},
 			// Test that we can downgrade a Droplet plan as long as the disk remains the same
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
 					resource.TestCheckResourceAttr(
@@ -231,12 +232,12 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 			},
 			// Test that resizing resize_disk = true increases the disk
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_resize(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_resize(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletResizeSmaller(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
@@ -249,7 +250,7 @@ func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 	var afterCreate, afterUpdate godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -257,21 +258,21 @@ func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
 					testAccCheckDigitalOceanDropletAttributes(&afterCreate),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_userdata_update(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_userdata_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar",
 						"user_data",
@@ -286,7 +287,7 @@ func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 	var afterCreate, afterUpdate godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -294,21 +295,21 @@ func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
 					testAccCheckDigitalOceanDropletAttributes(&afterCreate),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_tag_update(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_tag_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar",
 						"tags.#",
@@ -321,7 +322,7 @@ func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_VPCAndIpv6(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -329,7 +330,7 @@ func TestAccDigitalOceanDroplet_VPCAndIpv6(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_VPCAndIpv6(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_VPCAndIpv6(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes_PrivateNetworkingIpv6(&droplet),
@@ -345,7 +346,7 @@ func TestAccDigitalOceanDroplet_VPCAndIpv6(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6(t *testing.T) {
 	var afterCreate, afterUpdate godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -353,22 +354,22 @@ func TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
 					testAccCheckDigitalOceanDropletAttributes(&afterCreate),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 				),
 			},
 			// For "private_networking," this is now a effectively a no-opt only updating state.
 			// All Droplets are assigned to a VPC by default. The API should still respond successfully.
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "private_networking", "true"),
 					resource.TestCheckResourceAttr(
@@ -381,7 +382,7 @@ func TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_Monitoring(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -389,7 +390,7 @@ func TestAccDigitalOceanDroplet_Monitoring(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_Monitoring(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_Monitoring(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					resource.TestCheckResourceAttr(
@@ -403,7 +404,7 @@ func TestAccDigitalOceanDroplet_Monitoring(t *testing.T) {
 func TestAccDigitalOceanDroplet_conditionalVolumes(t *testing.T) {
 	var firstDroplet godo.Droplet
 	var secondDroplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -411,7 +412,7 @@ func TestAccDigitalOceanDroplet_conditionalVolumes(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_conditionalVolumes(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_conditionalVolumes(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar.0", &firstDroplet),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar.1", &secondDroplet),
@@ -428,7 +429,7 @@ func TestAccDigitalOceanDroplet_conditionalVolumes(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_EnableAndDisableBackups(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -436,19 +437,19 @@ func TestAccDigitalOceanDroplet_EnableAndDisableBackups(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "backups", "false"),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_EnableBackups(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_EnableBackups(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					resource.TestCheckResourceAttr(
@@ -457,7 +458,7 @@ func TestAccDigitalOceanDroplet_EnableAndDisableBackups(t *testing.T) {
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_DisableBackups(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_DisableBackups(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					resource.TestCheckResourceAttr(
@@ -470,7 +471,7 @@ func TestAccDigitalOceanDroplet_EnableAndDisableBackups(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_EnableAndDisableGracefulShutdown(t *testing.T) {
 	var droplet godo.Droplet
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -478,19 +479,19 @@ func TestAccDigitalOceanDroplet_EnableAndDisableGracefulShutdown(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "graceful_shutdown", "false"),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_EnableGracefulShutdown(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_EnableGracefulShutdown(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					resource.TestCheckResourceAttr(
@@ -499,7 +500,7 @@ func TestAccDigitalOceanDroplet_EnableAndDisableGracefulShutdown(t *testing.T) {
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_DisableGracefulShutdown(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_DisableGracefulShutdown(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					resource.TestCheckResourceAttr(
@@ -821,118 +822,118 @@ func testAccCheckDigitalOceanDropletRecreated(t *testing.T,
 	}
 }
 
-func testAccCheckDigitalOceanDropletConfig_withID(rInt int, slug string) string {
+func testAccCheckDigitalOceanDropletConfig_withID(name string, slug string) string {
 	return fmt.Sprintf(`
 data "digitalocean_image" "foobar" {
   slug = "%s"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = data.digitalocean_image.foobar.id
   region    = "nyc3"
   user_data = "foobar"
-}`, slug, rInt)
+}`, slug, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_withSSH(rInt int, testAccValidPublicKey string) string {
+func testAccCheckDigitalOceanDropletConfig_withSSH(name string, testAccValidPublicKey string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar-%d"
+  name       = "%s-key"
   public_key = "%s"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
   ssh_keys  = [digitalocean_ssh_key.foobar.id]
-}`, rInt, testAccValidPublicKey, rInt)
+}`, name, testAccValidPublicKey, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_tag_update(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_tag_update(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_tag" "barbaz" {
   name = "barbaz"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
   tags      = [digitalocean_tag.barbaz.id]
 }
-`, rInt)
+`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_userdata_update(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_userdata_update(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar foobar"
 }
-`, rInt)
+`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_RenameAndResize(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_RenameAndResize(newName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "baz-%d"
+  name   = "%s"
   size   = "s-1vcpu-2gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
-`, rInt)
+`, newName)
 }
 
-func testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_resize_without_disk(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name        = "foo-%d"
+  name        = "%s"
   size        = "s-1vcpu-2gb"
   image       = "ubuntu-22-04-x64"
   region      = "nyc3"
   user_data   = "foobar"
   resize_disk = false
 }
-`, rInt)
+`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_resize(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_resize(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name        = "foo-%d"
+  name        = "%s"
   size        = "s-1vcpu-2gb"
   image       = "ubuntu-22-04-x64"
   region      = "nyc3"
   user_data   = "foobar"
   resize_disk = true
 }
-`, rInt)
+`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name               = "foo-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
 }
-`, rInt)
+`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_VPCAndIpv6(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_VPCAndIpv6(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_vpc" "foobar" {
   name   = "%s"
@@ -940,77 +941,77 @@ resource "digitalocean_vpc" "foobar" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name     = "foo-%d"
+  name     = "%s"
   size     = "s-1vcpu-1gb"
   image    = "ubuntu-22-04-x64"
   region   = "nyc3"
   ipv6     = true
   vpc_uuid = digitalocean_vpc.foobar.id
 }
-`, acceptance.RandomTestName(), rInt)
+`, acceptance.RandomTestName(), name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_Monitoring(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_Monitoring(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name       = "foo-%d"
+  name       = "%s"
   size       = "s-1vcpu-1gb"
   image      = "ubuntu-22-04-x64"
   region     = "nyc3"
   monitoring = true
 }
- `, rInt)
+ `, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_conditionalVolumes(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_conditionalVolumes(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "myvol-01" {
   region      = "sfo3"
-  name        = "tf-acc-test-1-%d"
+  name        = "%s-01"
   size        = 1
   description = "an example volume"
 }
 
 resource "digitalocean_volume" "myvol-02" {
   region      = "sfo3"
-  name        = "tf-acc-test-2-%d"
+  name        = "%s-02"
   size        = 1
   description = "an example volume"
 }
 
 resource "digitalocean_droplet" "foobar" {
   count      = 2
-  name       = "tf-acc-test-%d-${count.index}"
+  name       = "%s-${count.index}"
   region     = "sfo3"
   image      = "ubuntu-22-04-x64"
   size       = "s-1vcpu-1gb"
   volume_ids = [count.index == 0 ? digitalocean_volume.myvol-01.id : digitalocean_volume.myvol-02.id]
 }
-`, rInt, rInt, rInt)
+`, name, name, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_EnableBackups(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_EnableBackups(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
   backups   = true
-}`, rInt)
+}`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_DisableBackups(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_DisableBackups(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"
   user_data = "foobar"
   backups   = false
-}`, rInt)
+}`, name)
 }
 
 func testAccCheckDigitalOceanDropletConfig_DropletAgent(keyName, testAccValidPublicKey, dropletName, image, agent string) string {
@@ -1030,26 +1031,26 @@ resource "digitalocean_droplet" "foobar" {
 }`, keyName, testAccValidPublicKey, dropletName, image, agent)
 }
 
-func testAccCheckDigitalOceanDropletConfig_EnableGracefulShutdown(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_EnableGracefulShutdown(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name              = "foo-%d"
+  name              = "%s"
   size              = "s-1vcpu-1gb"
   image             = "ubuntu-22-04-x64"
   region            = "nyc3"
   user_data         = "foobar"
   graceful_shutdown = true
-}`, rInt)
+}`, name)
 }
 
-func testAccCheckDigitalOceanDropletConfig_DisableGracefulShutdown(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_DisableGracefulShutdown(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name              = "foo-%d"
+  name              = "%s"
   size              = "s-1vcpu-1gb"
   image             = "ubuntu-22-04-x64"
   region            = "nyc3"
   user_data         = "foobar"
   graceful_shutdown = false
-}`, rInt)
+}`, name)
 }

--- a/digitalocean/droplet/sweep.go
+++ b/digitalocean/droplet/sweep.go
@@ -33,15 +33,18 @@ func sweepDroplets(region string) error {
 	}
 	log.Printf("[DEBUG] Found %d droplets to sweep", len(droplets))
 
+	var swept int
 	for _, d := range droplets {
-		if strings.HasPrefix(d.Name, "foo-") || strings.HasPrefix(d.Name, "bar-") || strings.HasPrefix(d.Name, "baz-") || strings.HasPrefix(d.Name, "tf-acc-test-") || strings.HasPrefix(d.Name, "foobar-") {
+		if strings.HasPrefix(d.Name, sweep.TestNamePrefix) {
 			log.Printf("Destroying Droplet %s", d.Name)
 
 			if _, err := client.Droplets.Delete(context.Background(), d.ID); err != nil {
 				return err
 			}
+			swept++
 		}
 	}
+	log.Printf("[DEBUG] Deleted %d of %d droplets", swept, len(droplets))
 
 	return nil
 }

--- a/digitalocean/image/datasource_image_test.go
+++ b/digitalocean/image/datasource_image_test.go
@@ -15,6 +15,7 @@ func TestAccDigitalOceanImage_Basic(t *testing.T) {
 	var droplet godo.Droplet
 	var snapshotsId []int
 	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccDigitalOceanImage_Basic(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					acceptance.TakeSnapshotsOfDroplet(rInt, &droplet, &snapshotsId),

--- a/digitalocean/loadbalancer/resource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer_test.go
@@ -784,7 +784,7 @@ func testAccCheckDigitalOceanLoadbalancerExists(n string, loadbalancer *godo.Loa
 func testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -812,20 +812,20 @@ resource "digitalocean_loadbalancer" "foobar" {
   http_idle_timeout_seconds = 90
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, acceptance.RandomTestName(), rInt)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_updated(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_droplet" "foo" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -854,7 +854,7 @@ resource "digitalocean_loadbalancer" "foobar" {
   http_idle_timeout_seconds        = 120
 
   droplet_ids = [digitalocean_droplet.foobar.id, digitalocean_droplet.foo.id]
-}`, rInt, rInt, rInt)
+}`, acceptance.RandomTestName(), acceptance.RandomTestName(), rInt)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_dropletTag(rInt int) string {
@@ -864,7 +864,7 @@ resource "digitalocean_tag" "barbaz" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -891,13 +891,13 @@ resource "digitalocean_loadbalancer" "foobar" {
   droplet_tag = digitalocean_tag.barbaz.name
 
   depends_on = [digitalocean_droplet.foobar]
-}`, rInt, rInt)
+}`, acceptance.RandomTestName(), rInt)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_minimal(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -917,7 +917,7 @@ resource "digitalocean_loadbalancer" "foobar" {
   }
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, acceptance.RandomTestName(), rInt)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_NonDefaultProject(projectName, lbName string) string {
@@ -947,7 +947,7 @@ resource "digitalocean_loadbalancer" "test" {
 func testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -967,13 +967,13 @@ resource "digitalocean_loadbalancer" "foobar" {
   }
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, acceptance.RandomTestName(), rInt)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -999,7 +999,7 @@ resource "digitalocean_loadbalancer" "foobar" {
   }
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, acceptance.RandomTestName(), rInt)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(certName string, rInt int, privateKeyMaterial, leafCert, certChain, certAttribute string) string {

--- a/digitalocean/monitoring/import_monitor_alert_test.go
+++ b/digitalocean/monitoring/import_monitor_alert_test.go
@@ -19,7 +19,7 @@ func TestAccDigitalOceanMonitorAlert_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanMonitorAlertDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccAlertPolicy, randName, "", "10m", "v1/insights/droplet/memory_utilization_percent", "Alert about memory usage"),
+				Config: fmt.Sprintf(testAccAlertPolicy, randName, randName, "", "10m", "v1/insights/droplet/memory_utilization_percent", "Alert about memory usage"),
 			},
 			{
 				ResourceName:      resourceName,

--- a/digitalocean/monitoring/resource_monitor_alert_test.go
+++ b/digitalocean/monitoring/resource_monitor_alert_test.go
@@ -27,7 +27,7 @@ slack {
 	testAccAlertPolicy = `
 resource "digitalocean_droplet" "web" {
   image  = "ubuntu-20-04-x64"
-  name   = "web-1"
+  name   = "%s"
   region = "fra1"
   size   = "s-1vcpu-1gb"
 }
@@ -49,7 +49,7 @@ resource "digitalocean_monitor_alert" "%s" {
 	testAccAlertPolicySlackEmailAlerts = `
 resource "digitalocean_droplet" "web" {
   image  = "ubuntu-20-04-x64"
-  name   = "web-1"
+  name   = "%s"
   region = "fra1"
   size   = "s-1vcpu-1gb"
 }
@@ -78,7 +78,7 @@ resource "digitalocean_tag" "test" {
 
 resource "digitalocean_droplet" "web" {
   image  = "ubuntu-20-04-x64"
-  name   = "web-1"
+  name   = "%s"
   region = "fra1"
   size   = "s-1vcpu-1gb"
   tags   = [digitalocean_tag.test.name]
@@ -100,14 +100,14 @@ resource "digitalocean_monitor_alert" "%s" {
 	testAccAlertPolicyAddDroplet = `
 resource "digitalocean_droplet" "web" {
   image  = "ubuntu-20-04-x64"
-  name   = "web-1"
+  name   = "%s"
   region = "fra1"
   size   = "s-1vcpu-1gb"
 }
 
 resource "digitalocean_droplet" "web2" {
   image  = "ubuntu-20-04-x64"
-  name   = "web-2"
+  name   = "%s"
   region = "fra1"
   size   = "s-1vcpu-1gb"
 }
@@ -139,7 +139,7 @@ func TestAccDigitalOceanMonitorAlert(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccAlertPolicy, randName, "", "5m", "v1/insights/droplet/cpu", "Alert about CPU usage"),
+				Config: fmt.Sprintf(testAccAlertPolicy, randName, randName, "", "5m", "v1/insights/droplet/cpu", "Alert about CPU usage"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", "v1/insights/droplet/cpu"),
 					resource.TestCheckResourceAttr(resourceName, "compare", "GreaterThan"),
@@ -162,7 +162,7 @@ func TestAccDigitalOceanMonitorAlertSlackEmailAlerts(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccAlertPolicySlackEmailAlerts, randName),
+				Config: fmt.Sprintf(testAccAlertPolicySlackEmailAlerts, randName, randName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", "v1/insights/droplet/cpu"),
 					resource.TestCheckResourceAttr(resourceName, "compare", "GreaterThan"),
@@ -187,7 +187,7 @@ func TestAccDigitalOceanMonitorAlertUpdate(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccAlertPolicy, randName, "", "10m", "v1/insights/droplet/cpu", "Alert about CPU usage"),
+				Config: fmt.Sprintf(testAccAlertPolicy, randName, randName, "", "10m", "v1/insights/droplet/cpu", "Alert about CPU usage"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "Alert about CPU usage"),
 					resource.TestCheckResourceAttr(resourceName, "type", "v1/insights/droplet/cpu"),
@@ -200,7 +200,7 @@ func TestAccDigitalOceanMonitorAlertUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccAlertPolicyAddDroplet, randName, multipleSlackChannel, "5m", "v1/insights/droplet/memory_utilization_percent", "Alert about memory usage"),
+				Config: fmt.Sprintf(testAccAlertPolicyAddDroplet, randName, randName, randName, multipleSlackChannel, "5m", "v1/insights/droplet/memory_utilization_percent", "Alert about memory usage"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "Alert about memory usage"),
 					resource.TestCheckResourceAttr(resourceName, "type", "v1/insights/droplet/memory_utilization_percent"),
@@ -234,7 +234,7 @@ func TestAccDigitalOceanMonitorAlertWithTag(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccAlertPolicyWithTag, tagName, randName, "5m", "v1/insights/droplet/cpu", "Alert about CPU usage"),
+				Config: fmt.Sprintf(testAccAlertPolicyWithTag, tagName, randName, randName, "5m", "v1/insights/droplet/cpu", "Alert about CPU usage"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", "v1/insights/droplet/cpu"),
 					resource.TestCheckResourceAttr(resourceName, "compare", "GreaterThan"),

--- a/digitalocean/project/resource_project_test.go
+++ b/digitalocean/project/resource_project_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -429,15 +428,15 @@ func testAccCheckDigitalOceanProjectExists(resource string) resource.TestCheckFu
 }
 
 func generateProjectName() string {
-	return fmt.Sprintf("tf-proj-test-%d", acctest.RandInt())
+	return acceptance.RandomTestName("project")
 }
 
 func generateDropletName() string {
-	return fmt.Sprintf("tf-proj-test-rsrc-droplet-%d", acctest.RandInt())
+	return acceptance.RandomTestName("droplet")
 }
 
 func generateSpacesName() string {
-	return fmt.Sprintf("tf-proj-test-rsrc-spaces-%d", acctest.RandInt())
+	return acceptance.RandomTestName("space")
 }
 
 func fixtureCreateWithDefaults(name string) string {

--- a/digitalocean/reservedip/import_floating_ip_test.go
+++ b/digitalocean/reservedip/import_floating_ip_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -31,7 +30,7 @@ func TestAccDigitalOceanFloatingIP_importBasicRegion(t *testing.T) {
 
 func TestAccDigitalOceanFloatingIP_importBasicDroplet(t *testing.T) {
 	resourceName := "digitalocean_floating_ip.foobar"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -39,7 +38,7 @@ func TestAccDigitalOceanFloatingIP_importBasicDroplet(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt),
+				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet(name),
 			},
 
 			{

--- a/digitalocean/reservedip/import_reserved_ip_test.go
+++ b/digitalocean/reservedip/import_reserved_ip_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -31,7 +30,7 @@ func TestAccDigitalOceanReservedIP_importBasicRegion(t *testing.T) {
 
 func TestAccDigitalOceanReservedIP_importBasicDroplet(t *testing.T) {
 	resourceName := "digitalocean_reserved_ip.foobar"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -39,7 +38,7 @@ func TestAccDigitalOceanReservedIP_importBasicDroplet(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanReservedIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanReservedIPConfig_droplet(rInt),
+				Config: testAccCheckDigitalOceanReservedIPConfig_droplet(name),
 			},
 
 			{

--- a/digitalocean/reservedip/resource_floating_ip_assignment_test.go
+++ b/digitalocean/reservedip/resource_floating_ip_assignment_test.go
@@ -177,7 +177,7 @@ resource "digitalocean_droplet" "foobar" {
 var testAccCheckDigitalOceanFloatingIPAssignmentConfig_createBeforeDestroy = `
 resource "digitalocean_droplet" "foobar" {
   image  = "ubuntu-22-04-x64"
-  name   = "tf-acc-test"
+  name   = "tf-acc-test-01"
   region = "nyc3"
   size   = "s-1vcpu-1gb"
 
@@ -203,7 +203,7 @@ resource "digitalocean_floating_ip_assignment" "foobar" {
 var testAccCheckDigitalOceanFloatingIPAssignmentConfig_createBeforeDestroyReassign = `
 resource "digitalocean_droplet" "foobar" {
   image  = "ubuntu-18-04-x64"
-  name   = "tf-acc-test"
+  name   = "tf-acc-test-01"
   region = "nyc3"
   size   = "s-1vcpu-1gb"
 

--- a/digitalocean/reservedip/resource_floating_ip_test.go
+++ b/digitalocean/reservedip/resource_floating_ip_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -39,7 +38,7 @@ func TestAccDigitalOceanFloatingIP_Region(t *testing.T) {
 
 func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 	var floatingIP godo.FloatingIP
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -47,7 +46,7 @@ func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt),
+				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
 					resource.TestCheckResourceAttr(
@@ -55,7 +54,7 @@ func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_Reassign(rInt),
+				Config: testAccCheckDigitalOceanFloatingIPConfig_Reassign(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
 					resource.TestCheckResourceAttr(
@@ -63,7 +62,7 @@ func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_Unassign(rInt),
+				Config: testAccCheckDigitalOceanFloatingIPConfig_Unassign(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
 					resource.TestCheckResourceAttr(
@@ -129,10 +128,10 @@ resource "digitalocean_floating_ip" "foobar" {
   region = "nyc3"
 }`
 
-func testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt int) string {
+func testAccCheckDigitalOceanFloatingIPConfig_droplet(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name               = "tf-acc-test-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
@@ -143,13 +142,13 @@ resource "digitalocean_droplet" "foobar" {
 resource "digitalocean_floating_ip" "foobar" {
   droplet_id = digitalocean_droplet.foobar.id
   region     = digitalocean_droplet.foobar.region
-}`, rInt)
+}`, name)
 }
 
-func testAccCheckDigitalOceanFloatingIPConfig_Reassign(rInt int) string {
+func testAccCheckDigitalOceanFloatingIPConfig_Reassign(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "baz" {
-  name               = "tf-acc-test-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
@@ -160,13 +159,13 @@ resource "digitalocean_droplet" "baz" {
 resource "digitalocean_floating_ip" "foobar" {
   droplet_id = digitalocean_droplet.baz.id
   region     = digitalocean_droplet.baz.region
-}`, rInt)
+}`, name)
 }
 
-func testAccCheckDigitalOceanFloatingIPConfig_Unassign(rInt int) string {
+func testAccCheckDigitalOceanFloatingIPConfig_Unassign(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "baz" {
-  name               = "tf-acc-test-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
@@ -176,5 +175,5 @@ resource "digitalocean_droplet" "baz" {
 
 resource "digitalocean_floating_ip" "foobar" {
   region = "nyc3"
-}`, rInt)
+}`, name)
 }

--- a/digitalocean/reservedip/resource_reserved_ip_assignment_test.go
+++ b/digitalocean/reservedip/resource_reserved_ip_assignment_test.go
@@ -203,7 +203,7 @@ resource "digitalocean_reserved_ip_assignment" "foobar" {
 var testAccCheckDigitalOceanReservedIPAssignmentConfig_createBeforeDestroyReassign = `
 resource "digitalocean_droplet" "foobar" {
   image  = "ubuntu-18-04-x64"
-  name   = "tf-acc-test"
+  name   = "tf-acc-test-01"
   region = "nyc3"
   size   = "s-1vcpu-1gb"
 

--- a/digitalocean/reservedip/resource_reserved_ip_test.go
+++ b/digitalocean/reservedip/resource_reserved_ip_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -39,7 +38,7 @@ func TestAccDigitalOceanReservedIP_Region(t *testing.T) {
 
 func TestAccDigitalOceanReservedIP_Droplet(t *testing.T) {
 	var reservedIP godo.ReservedIP
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -47,7 +46,7 @@ func TestAccDigitalOceanReservedIP_Droplet(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanReservedIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanReservedIPConfig_droplet(rInt),
+				Config: testAccCheckDigitalOceanReservedIPConfig_droplet(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanReservedIPExists("digitalocean_reserved_ip.foobar", &reservedIP),
 					resource.TestCheckResourceAttr(
@@ -55,7 +54,7 @@ func TestAccDigitalOceanReservedIP_Droplet(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanReservedIPConfig_Reassign(rInt),
+				Config: testAccCheckDigitalOceanReservedIPConfig_Reassign(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanReservedIPExists("digitalocean_reserved_ip.foobar", &reservedIP),
 					resource.TestCheckResourceAttr(
@@ -63,7 +62,7 @@ func TestAccDigitalOceanReservedIP_Droplet(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanReservedIPConfig_Unassign(rInt),
+				Config: testAccCheckDigitalOceanReservedIPConfig_Unassign(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanReservedIPExists("digitalocean_reserved_ip.foobar", &reservedIP),
 					resource.TestCheckResourceAttr(
@@ -129,10 +128,10 @@ resource "digitalocean_reserved_ip" "foobar" {
   region = "nyc3"
 }`
 
-func testAccCheckDigitalOceanReservedIPConfig_droplet(rInt int) string {
+func testAccCheckDigitalOceanReservedIPConfig_droplet(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name               = "tf-acc-test-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
@@ -143,13 +142,13 @@ resource "digitalocean_droplet" "foobar" {
 resource "digitalocean_reserved_ip" "foobar" {
   droplet_id = digitalocean_droplet.foobar.id
   region     = digitalocean_droplet.foobar.region
-}`, rInt)
+}`, name)
 }
 
-func testAccCheckDigitalOceanReservedIPConfig_Reassign(rInt int) string {
+func testAccCheckDigitalOceanReservedIPConfig_Reassign(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "baz" {
-  name               = "tf-acc-test-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
@@ -160,13 +159,13 @@ resource "digitalocean_droplet" "baz" {
 resource "digitalocean_reserved_ip" "foobar" {
   droplet_id = digitalocean_droplet.baz.id
   region     = digitalocean_droplet.baz.region
-}`, rInt)
+}`, name)
 }
 
-func testAccCheckDigitalOceanReservedIPConfig_Unassign(rInt int) string {
+func testAccCheckDigitalOceanReservedIPConfig_Unassign(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "baz" {
-  name               = "tf-acc-test-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc3"
@@ -176,5 +175,5 @@ resource "digitalocean_droplet" "baz" {
 
 resource "digitalocean_reserved_ip" "foobar" {
   region = "nyc3"
-}`, rInt)
+}`, name)
 }

--- a/digitalocean/snapshot/import_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/import_droplet_snapshot_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDigitalOceanDropletSnapshot_importBasic(t *testing.T) {
 	resourceName := "digitalocean_droplet_snapshot.foobar"
-	rInt1 := acctest.RandInt()
+	dName := acceptance.RandomTestName()
 	rInt2 := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -20,7 +20,7 @@ func TestAccDigitalOceanDropletSnapshot_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, rInt1, rInt2),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, dName, rInt2),
 			},
 
 			{

--- a/digitalocean/snapshot/resource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/resource_droplet_snapshot_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccDigitalOceanDropletSnapshot_Basic(t *testing.T) {
 	var snapshot godo.Snapshot
-	rInt1 := acctest.RandInt()
+	dName := acceptance.RandomTestName()
 	rInt2 := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,7 +24,7 @@ func TestAccDigitalOceanDropletSnapshot_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanDropletSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, rInt1, rInt2),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, dName, rInt2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletSnapshotExists("digitalocean_droplet_snapshot.foobar", &snapshot),
 					resource.TestCheckResourceAttr(
@@ -85,7 +85,7 @@ func testAccCheckDigitalOceanDropletSnapshotDestroy(s *terraform.State) error {
 
 const testAccCheckDigitalOceanDropletSnapshotConfig_basic = `
 resource "digitalocean_droplet" "foo" {
-  name      = "foo-%d"
+  name      = "%s"
   size      = "s-1vcpu-1gb"
   image     = "ubuntu-22-04-x64"
   region    = "nyc3"

--- a/digitalocean/volume/resource_volume_attachment_test.go
+++ b/digitalocean/volume/resource_volume_attachment_test.go
@@ -17,9 +17,9 @@ import (
 func TestAccDigitalOceanVolumeAttachment_Basic(t *testing.T) {
 	var (
 		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
+		dName   = acceptance.RandomTestName()
 		droplet godo.Droplet
 	)
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -27,7 +27,7 @@ func TestAccDigitalOceanVolumeAttachment_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(rInt, volume.Name),
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(dName, volume.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -48,9 +48,9 @@ func TestAccDigitalOceanVolumeAttachment_Update(t *testing.T) {
 	var (
 		firstVolume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
 		secondVolume = godo.Volume{Name: fmt.Sprintf("volume-s-%s", acctest.RandString(10))}
+		dName        = acceptance.RandomTestName()
 		droplet      godo.Droplet
 	)
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -58,7 +58,7 @@ func TestAccDigitalOceanVolumeAttachment_Update(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(rInt, firstVolume.Name),
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(dName, firstVolume.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &firstVolume),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -72,7 +72,7 @@ func TestAccDigitalOceanVolumeAttachment_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(rInt, secondVolume.Name),
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(dName, secondVolume.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &secondVolume),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -93,9 +93,9 @@ func TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume(t *testing.T) {
 	var (
 		firstVolume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
 		secondVolume = godo.Volume{Name: fmt.Sprintf("volume-s-%s", acctest.RandString(10))}
+		dName        = acceptance.RandomTestName()
 		droplet      godo.Droplet
 	)
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -103,7 +103,7 @@ func TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(rInt, firstVolume.Name, secondVolume.Name, "foobar"),
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(dName, firstVolume.Name, secondVolume.Name, "foobar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &firstVolume),
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar_second", &secondVolume),
@@ -118,7 +118,7 @@ func TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(rInt, firstVolume.Name, secondVolume.Name, "foobar_second"),
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(dName, firstVolume.Name, secondVolume.Name, "foobar_second"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &firstVolume),
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar_second", &secondVolume),
@@ -140,9 +140,9 @@ func TestAccDigitalOceanVolumeAttachment_Multiple(t *testing.T) {
 	var (
 		firstVolume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
 		secondVolume = godo.Volume{Name: fmt.Sprintf("volume-s-%s", acctest.RandString(10))}
+		dName        = acceptance.RandomTestName()
 		droplet      godo.Droplet
 	)
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -150,7 +150,7 @@ func TestAccDigitalOceanVolumeAttachment_Multiple(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_multiple(rInt, firstVolume.Name, secondVolume.Name),
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_multiple(dName, firstVolume.Name, secondVolume.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &firstVolume),
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.barfoo", &secondVolume),
@@ -216,7 +216,7 @@ func testAccCheckDigitalOceanVolumeAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDigitalOceanVolumeAttachmentConfig_basic(rInt int, vName string) string {
+func testAccCheckDigitalOceanVolumeAttachmentConfig_basic(dName, vName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
@@ -226,7 +226,7 @@ resource "digitalocean_volume" "foobar" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name   = "baz-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc1"
@@ -235,10 +235,10 @@ resource "digitalocean_droplet" "foobar" {
 resource "digitalocean_volume_attachment" "foobar" {
   droplet_id = digitalocean_droplet.foobar.id
   volume_id  = digitalocean_volume.foobar.id
-}`, vName, rInt)
+}`, vName, dName)
 }
 
-func testAccCheckDigitalOceanVolumeAttachmentConfig_multiple(rInt int, vName, vSecondName string) string {
+func testAccCheckDigitalOceanVolumeAttachmentConfig_multiple(dName, vName, vSecondName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
@@ -255,7 +255,7 @@ resource "digitalocean_volume" "barfoo" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name   = "baz-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc1"
@@ -269,10 +269,10 @@ resource "digitalocean_volume_attachment" "foobar" {
 resource "digitalocean_volume_attachment" "barfoo" {
   droplet_id = digitalocean_droplet.foobar.id
   volume_id  = digitalocean_volume.barfoo.id
-}`, vName, vSecondName, rInt)
+}`, vName, vSecondName, dName)
 }
 
-func testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(rInt int, vName, vSecondName, activeVolume string) string {
+func testAccCheckDigitalOceanVolumeAttachmentConfig_multiple_volumes(dName, vName, vSecondName, activeVolume string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
@@ -289,7 +289,7 @@ resource "digitalocean_volume" "foobar_second" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name   = "baz-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc1"
@@ -298,5 +298,5 @@ resource "digitalocean_droplet" "foobar" {
 resource "digitalocean_volume_attachment" "foobar" {
   droplet_id = digitalocean_droplet.foobar.id
   volume_id  = digitalocean_volume.%s.id
-}`, vName, vSecondName, rInt, activeVolume)
+}`, vName, vSecondName, dName, activeVolume)
 }

--- a/digitalocean/volume/resource_volume_test.go
+++ b/digitalocean/volume/resource_volume_test.go
@@ -105,9 +105,9 @@ func testAccCheckDigitalOceanVolumeDestroy(s *terraform.State) error {
 func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 	var (
 		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
+		dName   = acceptance.RandomTestName()
 		droplet godo.Droplet
 	)
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -115,7 +115,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeConfig_droplet(rInt, volume.Name),
+				Config: testAccCheckDigitalOceanVolumeConfig_droplet(dName, volume.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -128,7 +128,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 	})
 }
 
-func testAccCheckDigitalOceanVolumeConfig_droplet(rInt int, vName string) string {
+func testAccCheckDigitalOceanVolumeConfig_droplet(dName, vName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
@@ -138,14 +138,14 @@ resource "digitalocean_volume" "foobar" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name               = "baz-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc1"
   ipv6               = true
   private_networking = true
   volume_ids         = [digitalocean_volume.foobar.id]
-}`, vName, rInt)
+}`, vName, dName)
 }
 
 func TestAccDigitalOceanVolume_LegacyFilesystemType(t *testing.T) {
@@ -240,9 +240,9 @@ resource "digitalocean_volume" "foobar" {
 func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 	var (
 		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
+		dName   = acceptance.RandomTestName()
 		droplet godo.Droplet
 	)
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -250,7 +250,7 @@ func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeConfig_resize(rInt, volume.Name, 20),
+				Config: testAccCheckDigitalOceanVolumeConfig_resize(dName, volume.Name, 20),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -260,7 +260,7 @@ func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanVolumeConfig_resize(rInt, volume.Name, 50),
+				Config: testAccCheckDigitalOceanVolumeConfig_resize(dName, volume.Name, 50),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -273,7 +273,7 @@ func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 	})
 }
 
-func testAccCheckDigitalOceanVolumeConfig_resize(rInt int, vName string, vSize int) string {
+func testAccCheckDigitalOceanVolumeConfig_resize(dName string, vName string, vSize int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
@@ -283,14 +283,14 @@ resource "digitalocean_volume" "foobar" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name               = "baz-%d"
+  name               = "%s"
   size               = "s-1vcpu-1gb"
   image              = "ubuntu-22-04-x64"
   region             = "nyc1"
   ipv6               = true
   private_networking = true
   volume_ids         = [digitalocean_volume.foobar.id]
-}`, vName, vSize, rInt)
+}`, vName, vSize, dName)
 }
 
 func TestAccDigitalOceanVolume_CreateFromSnapshot(t *testing.T) {


### PR DESCRIPTION
All resources created by our provider's acceptance tests should use a standard naming structure to make sweeping simpler and reduce risk of running the sweeper for external contributors. This PR ensures we are using a consistent naming for all Droplets created in tests. 

I'll be following this up with PRs for other resource types. As Droplets are used by other resources, this is likely the most invasive PR. Hopefully the others should be easier to review.