### PR TITLE
Use consistent naming for all firewalls created in tests.

### DIFF
--- a/digitalocean/firewall/datasource_firewall_test.go
+++ b/digitalocean/firewall/datasource_firewall_test.go
@@ -34,7 +34,7 @@ data "digitalocean_firewall" "foobar" {
 			{
 				Config: fwCreateConfig + fwDataConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.digitalocean_firewall.foobar", "name", "foobar-"+fwName),
+					resource.TestCheckResourceAttr("data.digitalocean_firewall.foobar", "name", fwName),
 					resource.TestCheckResourceAttrPair("digitalocean_firewall.foobar", "id",
 						"data.digitalocean_firewall.foobar", "firewall_id"),
 					resource.TestCheckResourceAttrPair("digitalocean_firewall.foobar", "droplet_ids",

--- a/digitalocean/firewall/resource_firewall_test.go
+++ b/digitalocean/firewall/resource_firewall_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDigitalOceanFirewall_AllowOnlyInbound(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acceptance.RandomTestName()
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +33,7 @@ func TestAccDigitalOceanFirewall_AllowOnlyInbound(t *testing.T) {
 }
 
 func TestAccDigitalOceanFirewall_AllowMultipleInbound(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acceptance.RandomTestName()
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -54,7 +53,7 @@ func TestAccDigitalOceanFirewall_AllowMultipleInbound(t *testing.T) {
 }
 
 func TestAccDigitalOceanFirewall_AllowOnlyOutbound(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acceptance.RandomTestName()
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -74,7 +73,7 @@ func TestAccDigitalOceanFirewall_AllowOnlyOutbound(t *testing.T) {
 }
 
 func TestAccDigitalOceanFirewall_AllowMultipleOutbound(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acceptance.RandomTestName()
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,8 +93,8 @@ func TestAccDigitalOceanFirewall_AllowMultipleOutbound(t *testing.T) {
 }
 
 func TestAccDigitalOceanFirewall_MultipleInboundAndOutbound(t *testing.T) {
-	rName := acctest.RandString(10)
-	tagName := "tag-" + rName
+	rName := acceptance.RandomTestName()
+	tagName := acceptance.RandomTestName("tag")
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,7 +115,7 @@ func TestAccDigitalOceanFirewall_MultipleInboundAndOutbound(t *testing.T) {
 }
 
 func TestAccDigitalOceanFirewall_fullPortRange(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acceptance.RandomTestName()
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -137,7 +136,7 @@ func TestAccDigitalOceanFirewall_fullPortRange(t *testing.T) {
 }
 
 func TestAccDigitalOceanFirewall_icmp(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acceptance.RandomTestName()
 	var firewall godo.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -159,8 +158,8 @@ func TestAccDigitalOceanFirewall_icmp(t *testing.T) {
 
 func TestAccDigitalOceanFirewall_ImportMultipleRules(t *testing.T) {
 	resourceName := "digitalocean_firewall.foobar"
-	rName := acctest.RandString(10)
-	tagName := "tag-" + rName
+	rName := acceptance.RandomTestName()
+	tagName := acceptance.RandomTestName("tag")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -182,7 +181,7 @@ func TestAccDigitalOceanFirewall_ImportMultipleRules(t *testing.T) {
 func testAccDigitalOceanFirewallConfig_OnlyInbound(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
@@ -196,7 +195,7 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_OnlyOutbound(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   outbound_rule {
     protocol              = "tcp"
     port_range            = "22"
@@ -210,7 +209,7 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_OnlyMultipleInbound(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
@@ -229,7 +228,7 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_OnlyMultipleOutbound(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   outbound_rule {
     protocol              = "tcp"
     port_range            = "22"
@@ -252,7 +251,7 @@ resource "digitalocean_tag" "foobar" {
 }
 
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
@@ -283,7 +282,7 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_fullPortRange(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   inbound_rule {
     protocol         = "tcp"
     port_range       = "all"
@@ -301,7 +300,7 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_icmp(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-  name = "foobar-%s"
+  name = "%s"
   inbound_rule {
     protocol         = "icmp"
     source_addresses = ["192.168.1.1/32"]

--- a/digitalocean/firewall/sweep.go
+++ b/digitalocean/firewall/sweep.go
@@ -34,7 +34,7 @@ func sweepFirewall(region string) error {
 	}
 
 	for _, f := range fws {
-		if strings.HasPrefix(f.Name, "foobar-") {
+		if strings.HasPrefix(f.Name, sweep.TestNamePrefix) {
 			log.Printf("Destroying firewall %s", f.Name)
 
 			if _, err := client.Firewalls.Delete(context.Background(), f.ID); err != nil {


### PR DESCRIPTION
This time for firewalls... 

```
$ make testacc PKG_NAME=digitalocean/firewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/firewall/...  -timeout 120m -parallel=2
=== RUN   TestAccDataSourceDigitalOceanFirewall_Basic
=== PAUSE TestAccDataSourceDigitalOceanFirewall_Basic
=== RUN   TestAccDigitalOceanFirewall_AllowOnlyInbound
=== PAUSE TestAccDigitalOceanFirewall_AllowOnlyInbound
=== RUN   TestAccDigitalOceanFirewall_AllowMultipleInbound
=== PAUSE TestAccDigitalOceanFirewall_AllowMultipleInbound
=== RUN   TestAccDigitalOceanFirewall_AllowOnlyOutbound
=== PAUSE TestAccDigitalOceanFirewall_AllowOnlyOutbound
=== RUN   TestAccDigitalOceanFirewall_AllowMultipleOutbound
=== PAUSE TestAccDigitalOceanFirewall_AllowMultipleOutbound
=== RUN   TestAccDigitalOceanFirewall_MultipleInboundAndOutbound
=== PAUSE TestAccDigitalOceanFirewall_MultipleInboundAndOutbound
=== RUN   TestAccDigitalOceanFirewall_fullPortRange
=== PAUSE TestAccDigitalOceanFirewall_fullPortRange
=== RUN   TestAccDigitalOceanFirewall_icmp
=== PAUSE TestAccDigitalOceanFirewall_icmp
=== RUN   TestAccDigitalOceanFirewall_ImportMultipleRules
=== PAUSE TestAccDigitalOceanFirewall_ImportMultipleRules
=== CONT  TestAccDataSourceDigitalOceanFirewall_Basic
=== CONT  TestAccDigitalOceanFirewall_MultipleInboundAndOutbound
--- PASS: TestAccDigitalOceanFirewall_MultipleInboundAndOutbound (3.38s)
=== CONT  TestAccDigitalOceanFirewall_AllowOnlyOutbound
--- PASS: TestAccDigitalOceanFirewall_AllowOnlyOutbound (1.82s)
=== CONT  TestAccDigitalOceanFirewall_AllowMultipleOutbound
--- PASS: TestAccDigitalOceanFirewall_AllowMultipleOutbound (2.27s)
=== CONT  TestAccDigitalOceanFirewall_AllowMultipleInbound
--- PASS: TestAccDataSourceDigitalOceanFirewall_Basic (8.02s)
=== CONT  TestAccDigitalOceanFirewall_AllowOnlyInbound
--- PASS: TestAccDigitalOceanFirewall_AllowMultipleInbound (1.68s)
=== CONT  TestAccDigitalOceanFirewall_icmp
--- PASS: TestAccDigitalOceanFirewall_AllowOnlyInbound (1.74s)
=== CONT  TestAccDigitalOceanFirewall_ImportMultipleRules
--- PASS: TestAccDigitalOceanFirewall_icmp (1.69s)
=== CONT  TestAccDigitalOceanFirewall_fullPortRange
--- PASS: TestAccDigitalOceanFirewall_ImportMultipleRules (2.40s)
--- PASS: TestAccDigitalOceanFirewall_fullPortRange (1.78s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/firewall   12.636s
```