### PR TITLE
Use consistent naming for all load balancers created in tests.

### DIFF
--- a/digitalocean/loadbalancer/datasource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/datasource_loadbalancer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -507,10 +506,10 @@ data "digitalocean_loadbalancer" "foobar" {
 func TestAccDataSourceDigitalOceanLoadBalancer_tlsCertByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := acceptance.RandomTestName()
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := acceptance.GenerateTestCertMaterial(t)
 	resourceConfig := testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(
-		testName+"-cert", rInt, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name",
+		testName+"-cert", name, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name",
 	)
 	dataSourceConfig := `
 data "digitalocean_loadbalancer" "foobar" {
@@ -530,7 +529,7 @@ data "digitalocean_loadbalancer" "foobar" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"data.digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -562,10 +561,10 @@ data "digitalocean_loadbalancer" "foobar" {
 func TestAccDataSourceDigitalOceanLoadBalancer_tlsCertById(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	testName := acceptance.RandomTestName()
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := acceptance.GenerateTestCertMaterial(t)
 	resourceConfig := testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(
-		testName+"-cert", rInt, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name",
+		testName+"-cert", name, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name",
 	)
 	dataSourceConfig := `
 data "digitalocean_loadbalancer" "foobar" {
@@ -585,7 +584,7 @@ data "digitalocean_loadbalancer" "foobar" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"data.digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(

--- a/digitalocean/loadbalancer/import_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/import_loadbalancer_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanLoadBalancer_importBasic(t *testing.T) {
 	resourceName := "digitalocean_loadbalancer.foobar"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -18,7 +17,7 @@ func TestAccDigitalOceanLoadBalancer_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(name),
 			},
 
 			{

--- a/digitalocean/loadbalancer/resource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer_test.go
@@ -544,11 +544,7 @@ func TestAccDigitalOceanLoadbalancer_sslCertByName(t *testing.T) {
 	})
 }
 
-// Load balancers can only be resized once an hour. The initial create counts
-// as a "resize" in this context. This test can not perform a resize, but it
-// does ensure that the the PUT includes the expected content by checking for
-// the failure.
-func TestAccDigitalOceanLoadbalancer_resizeExpectedFailure(t *testing.T) {
+func TestAccDigitalOceanLoadbalancer_resize(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
 	name := acceptance.RandomTestName()
 
@@ -587,8 +583,12 @@ func TestAccDigitalOceanLoadbalancer_resizeExpectedFailure(t *testing.T) {
 				),
 			},
 			{
-				Config:      fmt.Sprintf(lbConfig, name, 2),
-				ExpectError: regexp.MustCompile("Load Balancer can only be resized once every hour, last resized at:"),
+				Config: fmt.Sprintf(lbConfig, name, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "size_unit", "2"),
+				),
 			},
 		},
 	})

--- a/digitalocean/loadbalancer/resource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	expectedURNRegEx, _ := regexp.Compile(`do:loadbalancer:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
 
@@ -28,11 +27,11 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -79,7 +78,7 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 
 func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -87,11 +86,11 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -130,11 +129,11 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_updated(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_updated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -178,7 +177,7 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 
 func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -186,11 +185,11 @@ func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_dropletTag(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_dropletTag(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -224,7 +223,7 @@ func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
 
 func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -232,11 +231,11 @@ func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_minimal(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_minimal(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -347,7 +346,7 @@ resource "digitalocean_project" "test" {
 
 func TestAccDigitalOceanLoadbalancer_minimalUDP(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -355,11 +354,11 @@ func TestAccDigitalOceanLoadbalancer_minimalUDP(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -401,7 +400,7 @@ func TestAccDigitalOceanLoadbalancer_minimalUDP(t *testing.T) {
 
 func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -409,11 +408,11 @@ func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(rInt),
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -455,7 +454,7 @@ func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
 
 func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := acceptance.GenerateTestCertMaterial(t)
 	certName := acceptance.RandomTestName()
 
@@ -466,11 +465,11 @@ func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(
-					certName, rInt, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_id"),
+					certName, name, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_id"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -501,7 +500,7 @@ func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
 
 func TestAccDigitalOceanLoadbalancer_sslCertByName(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := acceptance.GenerateTestCertMaterial(t)
 	certName := acceptance.RandomTestName()
 
@@ -512,11 +511,11 @@ func TestAccDigitalOceanLoadbalancer_sslCertByName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(
-					certName, rInt, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name"),
+					certName, name, privateKeyMaterial, leafCertMaterial, certChainMaterial, "certificate_name"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -551,10 +550,10 @@ func TestAccDigitalOceanLoadbalancer_sslCertByName(t *testing.T) {
 // the failure.
 func TestAccDigitalOceanLoadbalancer_resizeExpectedFailure(t *testing.T) {
 	var loadbalancer godo.LoadBalancer
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	lbConfig := `resource "digitalocean_loadbalancer" "foobar" {
-  name      = "loadbalancer-%d"
+  name      = "%s"
   region    = "nyc3"
   size_unit = %d
 
@@ -578,17 +577,17 @@ func TestAccDigitalOceanLoadbalancer_resizeExpectedFailure(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(lbConfig, rInt, 1),
+				Config: fmt.Sprintf(lbConfig, name, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+						"digitalocean_loadbalancer.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "size_unit", "1"),
 				),
 			},
 			{
-				Config:      fmt.Sprintf(lbConfig, rInt, 2),
+				Config:      fmt.Sprintf(lbConfig, name, 2),
 				ExpectError: regexp.MustCompile("Load Balancer can only be resized once every hour, last resized at:"),
 			},
 		},
@@ -781,17 +780,17 @@ func testAccCheckDigitalOceanLoadbalancerExists(n string, loadbalancer *godo.Loa
 	}
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt int) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name   = "loadbalancer-%d"
+  name   = "%s"
   region = "nyc3"
 
   forwarding_rule {
@@ -812,27 +811,27 @@ resource "digitalocean_loadbalancer" "foobar" {
   http_idle_timeout_seconds = 90
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, name, name)
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_updated(rInt int) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_updated(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s-01"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_droplet" "foo" {
-  name   = "foo-%d"
+  name   = "%s-02"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name   = "loadbalancer-%d"
+  name   = "%s"
   region = "nyc3"
 
   forwarding_rule {
@@ -854,17 +853,17 @@ resource "digitalocean_loadbalancer" "foobar" {
   http_idle_timeout_seconds        = 120
 
   droplet_ids = [digitalocean_droplet.foobar.id, digitalocean_droplet.foo.id]
-}`, rInt, rInt, rInt)
+}`, name, name, name)
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_dropletTag(rInt int) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_dropletTag(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_tag" "barbaz" {
   name = "sample"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
@@ -872,7 +871,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name   = "loadbalancer-%d"
+  name   = "%s"
   region = "nyc3"
 
   forwarding_rule {
@@ -891,20 +890,20 @@ resource "digitalocean_loadbalancer" "foobar" {
   droplet_tag = digitalocean_tag.barbaz.name
 
   depends_on = [digitalocean_droplet.foobar]
-}`, rInt, rInt)
+}`, name, name)
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_minimal(rInt int) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_minimal(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name      = "loadbalancer-%d"
+  name      = "%s"
   region    = "nyc3"
   size_unit = 1
 
@@ -917,7 +916,7 @@ resource "digitalocean_loadbalancer" "foobar" {
   }
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, name, name)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_NonDefaultProject(projectName, lbName string) string {
@@ -944,17 +943,17 @@ resource "digitalocean_loadbalancer" "test" {
 }`, projectName, lbName)
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(rInt int) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_minimalUDP(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name   = "loadbalancer-%d"
+  name   = "%s"
   region = "nyc3"
   size   = "lb-small"
 
@@ -967,20 +966,20 @@ resource "digitalocean_loadbalancer" "foobar" {
   }
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, name, name)
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(rInt int) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_stickySessions(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name   = "foo-%d"
+  name   = "%s"
   size   = "s-1vcpu-1gb"
   image  = "ubuntu-22-04-x64"
   region = "nyc3"
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name   = "loadbalancer-%d"
+  name   = "%s"
   region = "nyc3"
   size   = "lb-small"
 
@@ -999,10 +998,10 @@ resource "digitalocean_loadbalancer" "foobar" {
   }
 
   droplet_ids = [digitalocean_droplet.foobar.id]
-}`, rInt, rInt)
+}`, name, name)
 }
 
-func testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(certName string, rInt int, privateKeyMaterial, leafCert, certChain, certAttribute string) string {
+func testAccCheckDigitalOceanLoadbalancerConfig_sslTermination(certName string, name string, privateKeyMaterial, leafCert, certChain, certAttribute string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_certificate" "foobar" {
   name              = "%s"
@@ -1018,7 +1017,7 @@ EOF
 }
 
 resource "digitalocean_loadbalancer" "foobar" {
-  name                   = "loadbalancer-%d"
+  name                   = "%s"
   region                 = "nyc3"
   size                   = "lb-small"
   redirect_http_to_https = true
@@ -1033,7 +1032,7 @@ resource "digitalocean_loadbalancer" "foobar" {
 
     %s = digitalocean_certificate.foobar.id
   }
-}`, certName, privateKeyMaterial, leafCert, certChain, rInt, certAttribute)
+}`, certName, privateKeyMaterial, leafCert, certChain, name, certAttribute)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(rName string) string {

--- a/digitalocean/loadbalancer/sweep.go
+++ b/digitalocean/loadbalancer/sweep.go
@@ -34,7 +34,7 @@ func sweepLoadbalancer(region string) error {
 	}
 
 	for _, l := range lbs {
-		if strings.HasPrefix(l.Name, "loadbalancer-") {
+		if strings.HasPrefix(l.Name, sweep.TestNamePrefix) {
 			log.Printf("Destroying loadbalancer %s", l.Name)
 
 			if _, err := client.LoadBalancers.Delete(context.Background(), l.ID); err != nil {


### PR DESCRIPTION
And now for load balancers... 

This also fixes a test. Previously load balancers could only be resized once an hour. The initial create counted as a "resize." So the resize test was just checking for the error to validate that we at least sent a proper request. This restriction has been changed to once a minute, so we can now test the complete resize.

```
$ make testacc PKG_NAME=digitalocean/loadbalancer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/loadbalancer/...  -timeout 120m -parallel=2
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_BasicByName
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_BasicByName
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_BasicById
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_BasicById
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_LargeByName
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_LargeByName
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_LargeById
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_LargeById
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_Size2ByName
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_Size2ByName
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_Size2ById
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_Size2ById
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesByName
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesByName
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesById
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesById
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_tlsCertByName
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_tlsCertByName
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_tlsCertById
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_tlsCertById
=== RUN   TestAccDigitalOceanLoadBalancer_importBasic
=== PAUSE TestAccDigitalOceanLoadBalancer_importBasic
=== RUN   TestAccDigitalOceanLoadbalancer_Basic
=== PAUSE TestAccDigitalOceanLoadbalancer_Basic
=== RUN   TestAccDigitalOceanLoadbalancer_Updated
=== PAUSE TestAccDigitalOceanLoadbalancer_Updated
=== RUN   TestAccDigitalOceanLoadbalancer_dropletTag
=== PAUSE TestAccDigitalOceanLoadbalancer_dropletTag
=== RUN   TestAccDigitalOceanLoadbalancer_minimal
=== PAUSE TestAccDigitalOceanLoadbalancer_minimal
=== RUN   TestAccDigitalOceanLoadbalancer_NonDefaultProject
=== PAUSE TestAccDigitalOceanLoadbalancer_NonDefaultProject
=== RUN   TestAccDigitalOceanLoadbalancer_minimalUDP
=== PAUSE TestAccDigitalOceanLoadbalancer_minimalUDP
=== RUN   TestAccDigitalOceanLoadbalancer_stickySessions
=== PAUSE TestAccDigitalOceanLoadbalancer_stickySessions
=== RUN   TestAccDigitalOceanLoadbalancer_sslTermination
=== PAUSE TestAccDigitalOceanLoadbalancer_sslTermination
=== RUN   TestAccDigitalOceanLoadbalancer_sslCertByName
=== PAUSE TestAccDigitalOceanLoadbalancer_sslCertByName
=== RUN   TestAccDigitalOceanLoadbalancer_resize
=== PAUSE TestAccDigitalOceanLoadbalancer_resize
=== RUN   TestAccDigitalOceanLoadbalancer_multipleRules
=== PAUSE TestAccDigitalOceanLoadbalancer_multipleRules
=== RUN   TestAccDigitalOceanLoadbalancer_WithVPC
=== PAUSE TestAccDigitalOceanLoadbalancer_WithVPC
=== RUN   TestAccDigitalOceanLoadbalancer_Firewall
=== PAUSE TestAccDigitalOceanLoadbalancer_Firewall
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_BasicByName
=== CONT  TestAccDigitalOceanLoadbalancer_Updated
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_BasicByName (212.33s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesByName
--- PASS: TestAccDigitalOceanLoadbalancer_Updated (250.71s)
=== CONT  TestAccDigitalOceanLoadbalancer_Basic
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesByName (125.47s)
=== CONT  TestAccDigitalOceanLoadBalancer_importBasic
--- PASS: TestAccDigitalOceanLoadbalancer_Basic (173.63s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_tlsCertById
--- PASS: TestAccDigitalOceanLoadBalancer_importBasic (183.83s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_tlsCertByName
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_tlsCertByName (128.87s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesById
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_tlsCertById (297.29s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_LargeById
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_multipleRulesById (124.81s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_Size2ById
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_LargeById (179.13s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_Size2ByName
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_Size2ById (315.46s)
=== CONT  TestAccDigitalOceanLoadbalancer_sslTermination
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_Size2ByName (224.14s)
=== CONT  TestAccDigitalOceanLoadbalancer_Firewall
--- PASS: TestAccDigitalOceanLoadbalancer_sslTermination (155.52s)
=== CONT  TestAccDigitalOceanLoadbalancer_WithVPC
--- PASS: TestAccDigitalOceanLoadbalancer_Firewall (193.41s)
=== CONT  TestAccDigitalOceanLoadbalancer_multipleRules
--- PASS: TestAccDigitalOceanLoadbalancer_multipleRules (146.46s)
=== CONT  TestAccDigitalOceanLoadbalancer_resize
--- PASS: TestAccDigitalOceanLoadbalancer_WithVPC (228.56s)
=== CONT  TestAccDigitalOceanLoadbalancer_sslCertByName
--- PASS: TestAccDigitalOceanLoadbalancer_resize (125.55s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_LargeByName
--- PASS: TestAccDigitalOceanLoadbalancer_sslCertByName (126.26s)
=== CONT  TestAccDigitalOceanLoadbalancer_NonDefaultProject
--- PASS: TestAccDigitalOceanLoadbalancer_NonDefaultProject (151.69s)
=== CONT  TestAccDigitalOceanLoadbalancer_stickySessions
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_LargeByName (227.66s)
=== CONT  TestAccDigitalOceanLoadbalancer_minimalUDP
--- PASS: TestAccDigitalOceanLoadbalancer_stickySessions (211.34s)
=== CONT  TestAccDigitalOceanLoadbalancer_minimal
--- PASS: TestAccDigitalOceanLoadbalancer_minimalUDP (201.57s)
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_BasicById
--- PASS: TestAccDigitalOceanLoadbalancer_minimal (191.97s)
=== CONT  TestAccDigitalOceanLoadbalancer_dropletTag
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_BasicById (244.37s)
--- PASS: TestAccDigitalOceanLoadbalancer_dropletTag (186.60s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer       2342.976s
```