### PR TITLE
Use consistent naming for all snapshots created in tests.

### DIFF
--- a/digitalocean/acceptance/droplets.go
+++ b/digitalocean/acceptance/droplets.go
@@ -88,11 +88,12 @@ resource "digitalocean_droplet" "foobar" {
 }`, name)
 }
 
-func TakeSnapshotsOfDroplet(rInt int, droplet *godo.Droplet, snapshotsId *[]int) resource.TestCheckFunc {
+// TakeSnapshotsOfDroplet takes three snapshots of the given Droplet. One will have the suffix -1 and two will have -0.
+func TakeSnapshotsOfDroplet(snapName string, droplet *godo.Droplet, snapshotsIDs *[]int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
 		for i := 0; i < 3; i++ {
-			err := takeSnapshotOfDroplet(rInt, i%2, droplet)
+			err := takeSnapshotOfDroplet(snapName, i%2, droplet)
 			if err != nil {
 				return err
 			}
@@ -101,14 +102,14 @@ func TakeSnapshotsOfDroplet(rInt int, droplet *godo.Droplet, snapshotsId *[]int)
 		if err != nil {
 			return err
 		}
-		*snapshotsId = retrieveDroplet.SnapshotIDs
+		*snapshotsIDs = retrieveDroplet.SnapshotIDs
 		return nil
 	}
 }
 
-func takeSnapshotOfDroplet(rInt, sInt int, droplet *godo.Droplet) error {
+func takeSnapshotOfDroplet(snapName string, intSuffix int, droplet *godo.Droplet) error {
 	client := TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
-	action, _, err := client.DropletActions.Snapshot(context.Background(), (*droplet).ID, fmt.Sprintf("snap-%d-%d", rInt, sInt))
+	action, _, err := client.DropletActions.Snapshot(context.Background(), (*droplet).ID, fmt.Sprintf("%s-%d", snapName, intSuffix))
 	if err != nil {
 		return err
 	}

--- a/digitalocean/snapshot/datasource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/datasource_droplet_snapshot_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestAccDataSourceDigitalOceanDropletSnapshot_basic(t *testing.T) {
 	var snapshot godo.Snapshot
-	testName := acceptance.RandomTestName()
-	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanDropletSnapshot_basic, testName, testName)
+	dropletName := acceptance.RandomTestName()
+	snapName := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanDropletSnapshot_basic, dropletName, snapName)
 	dataSourceConfig := `
 data "digitalocean_droplet_snapshot" "foobar" {
   most_recent = true
@@ -33,7 +34,7 @@ data "digitalocean_droplet_snapshot" "foobar" {
 				Config: resourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanDropletSnapshotExists("data.digitalocean_droplet_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "name", fmt.Sprintf("%s-snapshot", testName)),
+					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "min_disk_size", "25"),
 					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "regions.#", "1"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_droplet_snapshot.foobar", "droplet_id"),
@@ -45,13 +46,14 @@ data "digitalocean_droplet_snapshot" "foobar" {
 
 func TestAccDataSourceDigitalOceanDropletSnapshot_regex(t *testing.T) {
 	var snapshot godo.Snapshot
-	testName := acceptance.RandomTestName()
-	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanDropletSnapshot_basic, testName, testName)
+	dropletName := acceptance.RandomTestName()
+	snapName := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanDropletSnapshot_basic, dropletName, snapName)
 	dataSourceConfig := fmt.Sprintf(`
 data "digitalocean_droplet_snapshot" "foobar" {
   most_recent = true
   name_regex  = "^%s"
-}`, testName)
+}`, snapName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -64,7 +66,7 @@ data "digitalocean_droplet_snapshot" "foobar" {
 				Config: resourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanDropletSnapshotExists("data.digitalocean_droplet_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "name", fmt.Sprintf("%s-snapshot", testName)),
+					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "min_disk_size", "25"),
 					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "regions.#", "1"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_droplet_snapshot.foobar", "droplet_id"),
@@ -76,8 +78,9 @@ data "digitalocean_droplet_snapshot" "foobar" {
 
 func TestAccDataSourceDigitalOceanDropletSnapshot_region(t *testing.T) {
 	var snapshot godo.Snapshot
-	testName := acceptance.RandomTestName()
-	nycResourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanDropletSnapshot_basic, testName, testName)
+	dropletName := acceptance.RandomTestName()
+	snapName := acceptance.RandomTestName()
+	nycResourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanDropletSnapshot_basic, dropletName, snapName)
 	lonResourceConfig := fmt.Sprintf(`
 resource "digitalocean_droplet" "bar" {
   region = "lon1"
@@ -87,9 +90,9 @@ resource "digitalocean_droplet" "bar" {
 }
 
 resource "digitalocean_droplet_snapshot" "bar" {
-  name       = "%s-snapshot"
+  name       = "%s"
   droplet_id = digitalocean_droplet.bar.id
-}`, testName, testName)
+}`, dropletName, snapName)
 	dataSourceConfig := `
 data "digitalocean_droplet_snapshot" "foobar" {
   name   = digitalocean_droplet_snapshot.bar.name
@@ -107,7 +110,7 @@ data "digitalocean_droplet_snapshot" "foobar" {
 				Config: nycResourceConfig + lonResourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanDropletSnapshotExists("data.digitalocean_droplet_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "name", fmt.Sprintf("%s-snapshot", testName)),
+					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "min_disk_size", "25"),
 					resource.TestCheckResourceAttr("data.digitalocean_droplet_snapshot.foobar", "regions.#", "1"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_droplet_snapshot.foobar", "droplet_id"),
@@ -155,7 +158,7 @@ resource "digitalocean_droplet" "foo" {
 }
 
 resource "digitalocean_droplet_snapshot" "foo" {
-  name       = "%s-snapshot"
+  name       = "%s"
   droplet_id = digitalocean_droplet.foo.id
 }
 `

--- a/digitalocean/snapshot/datasource_volume_snapshot_test.go
+++ b/digitalocean/snapshot/datasource_volume_snapshot_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestAccDataSourceDigitalOceanVolumeSnapshot_basic(t *testing.T) {
 	var snapshot godo.Snapshot
-	testName := acceptance.RandomTestName()
-	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, testName, testName)
+	volName := acceptance.RandomTestName("volume")
+	snapName := acceptance.RandomTestName("snapshot")
+	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, volName, snapName)
 	dataSourceConfig := `
 data "digitalocean_volume_snapshot" "foobar" {
   most_recent = true
@@ -33,7 +34,7 @@ data "digitalocean_volume_snapshot" "foobar" {
 				Config: resourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanVolumeSnapshotExists("data.digitalocean_volume_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", fmt.Sprintf("%s-snapshot", testName)),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),
@@ -47,8 +48,9 @@ data "digitalocean_volume_snapshot" "foobar" {
 
 func TestAccDataSourceDigitalOceanVolumeSnapshot_regex(t *testing.T) {
 	var snapshot godo.Snapshot
-	testName := acceptance.RandomTestName()
-	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, testName, testName)
+	volName := acceptance.RandomTestName("volume")
+	snapName := acceptance.RandomTestName("snapshot")
+	resourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, volName, snapName)
 	dataSourceConfig := `
 data "digitalocean_volume_snapshot" "foobar" {
   most_recent = true
@@ -66,7 +68,7 @@ data "digitalocean_volume_snapshot" "foobar" {
 				Config: resourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanVolumeSnapshotExists("data.digitalocean_volume_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", fmt.Sprintf("%s-snapshot", testName)),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),
@@ -80,20 +82,21 @@ data "digitalocean_volume_snapshot" "foobar" {
 
 func TestAccDataSourceDigitalOceanVolumeSnapshot_region(t *testing.T) {
 	var snapshot godo.Snapshot
-	testName := acceptance.RandomTestName()
-	nycResourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, testName, testName)
+	nyName := acceptance.RandomTestName("ny")
+	lonName := acceptance.RandomTestName("lon")
+	nycResourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, nyName, nyName)
 	lonResourceConfig := fmt.Sprintf(`
 resource "digitalocean_volume" "bar" {
   region      = "lon1"
-  name        = "volume-lon-%s"
+  name        = "%s"
   size        = 100
   description = "peace makes plenty"
 }
 
 resource "digitalocean_volume_snapshot" "bar" {
-  name      = "%s-snapshot"
+  name      = "%s"
   volume_id = digitalocean_volume.bar.id
-}`, testName, testName)
+}`, lonName, lonName)
 	dataSourceConfig := `
 data "digitalocean_volume_snapshot" "foobar" {
   name   = digitalocean_volume_snapshot.bar.name
@@ -111,7 +114,7 @@ data "digitalocean_volume_snapshot" "foobar" {
 				Config: nycResourceConfig + lonResourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanVolumeSnapshotExists("data.digitalocean_volume_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", fmt.Sprintf("%s-snapshot", testName)),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", lonName),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),
@@ -155,13 +158,13 @@ func testAccCheckDataSourceDigitalOceanVolumeSnapshotExists(n string, snapshot *
 const testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic = `
 resource "digitalocean_volume" "foo" {
   region      = "nyc1"
-  name        = "%s-volume"
+  name        = "%s"
   size        = 100
   description = "peace makes plenty"
 }
 
 resource "digitalocean_volume_snapshot" "foo" {
-  name      = "%s-snapshot"
+  name      = "%s"
   volume_id = digitalocean_volume.foo.id
   tags      = ["foo", "bar"]
 }

--- a/digitalocean/snapshot/datasource_volume_snapshot_test.go
+++ b/digitalocean/snapshot/datasource_volume_snapshot_test.go
@@ -82,9 +82,9 @@ data "digitalocean_volume_snapshot" "foobar" {
 
 func TestAccDataSourceDigitalOceanVolumeSnapshot_region(t *testing.T) {
 	var snapshot godo.Snapshot
-	nyName := acceptance.RandomTestName("ny")
-	lonName := acceptance.RandomTestName("lon")
-	nycResourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, nyName, nyName)
+	dropletName := acceptance.RandomTestName()
+	snapName := acceptance.RandomTestName()
+	nycResourceConfig := fmt.Sprintf(testAccCheckDataSourceDigitalOceanVolumeSnapshot_basic, dropletName, snapName)
 	lonResourceConfig := fmt.Sprintf(`
 resource "digitalocean_volume" "bar" {
   region      = "lon1"
@@ -96,7 +96,7 @@ resource "digitalocean_volume" "bar" {
 resource "digitalocean_volume_snapshot" "bar" {
   name      = "%s"
   volume_id = digitalocean_volume.bar.id
-}`, lonName, lonName)
+}`, dropletName, snapName)
 	dataSourceConfig := `
 data "digitalocean_volume_snapshot" "foobar" {
   name   = digitalocean_volume_snapshot.bar.name
@@ -114,7 +114,7 @@ data "digitalocean_volume_snapshot" "foobar" {
 				Config: nycResourceConfig + lonResourceConfig + dataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanVolumeSnapshotExists("data.digitalocean_volume_snapshot.foobar", &snapshot),
-					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", lonName),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),

--- a/digitalocean/snapshot/import_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/import_droplet_snapshot_test.go
@@ -5,14 +5,13 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanDropletSnapshot_importBasic(t *testing.T) {
 	resourceName := "digitalocean_droplet_snapshot.foobar"
 	dName := acceptance.RandomTestName()
-	rInt2 := acctest.RandInt()
+	snapName := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,7 +19,7 @@ func TestAccDigitalOceanDropletSnapshot_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, dName, rInt2),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, dName, snapName),
 			},
 
 			{

--- a/digitalocean/snapshot/import_volume_snapshot_test.go
+++ b/digitalocean/snapshot/import_volume_snapshot_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanVolumeSnapshot_importBasic(t *testing.T) {
 	resourceName := "digitalocean_volume_snapshot.foobar"
-	rInt := acctest.RandInt()
+	volName := acceptance.RandomTestName("volume")
+	snapName := acceptance.RandomTestName("snapshot")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -19,7 +19,7 @@ func TestAccDigitalOceanVolumeSnapshot_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic, rInt, rInt),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic, volName, snapName),
 			},
 
 			{

--- a/digitalocean/snapshot/resource_droplet_snapshot_test.go
+++ b/digitalocean/snapshot/resource_droplet_snapshot_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -16,7 +15,7 @@ import (
 func TestAccDigitalOceanDropletSnapshot_Basic(t *testing.T) {
 	var snapshot godo.Snapshot
 	dName := acceptance.RandomTestName()
-	rInt2 := acctest.RandInt()
+	snapName := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -24,11 +23,11 @@ func TestAccDigitalOceanDropletSnapshot_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanDropletSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, dName, rInt2),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDropletSnapshotConfig_basic, dName, snapName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletSnapshotExists("digitalocean_droplet_snapshot.foobar", &snapshot),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet_snapshot.foobar", "name", fmt.Sprintf("snapshot-one-%d", rInt2)),
+						"digitalocean_droplet_snapshot.foobar", "name", snapName),
 				),
 			},
 		},
@@ -94,6 +93,5 @@ resource "digitalocean_droplet" "foo" {
 
 resource "digitalocean_droplet_snapshot" "foobar" {
   droplet_id = digitalocean_droplet.foo.id
-  name       = "snapshot-one-%d"
-}
-  `
+  name       = "%s"
+}`

--- a/digitalocean/snapshot/resource_volume_snapshot_test.go
+++ b/digitalocean/snapshot/resource_volume_snapshot_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDigitalOceanVolumeSnapshot_Basic(t *testing.T) {
 	var snapshot godo.Snapshot
-	rInt := acctest.RandInt()
+	volName := acceptance.RandomTestName("volume")
+	snapName := acceptance.RandomTestName("snapshot")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -23,11 +23,11 @@ func TestAccDigitalOceanVolumeSnapshot_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic, rInt, rInt),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic, volName, snapName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeSnapshotExists("digitalocean_volume_snapshot.foobar", &snapshot),
 					resource.TestCheckResourceAttr(
-						"digitalocean_volume_snapshot.foobar", "name", fmt.Sprintf("snapshot-%d", rInt)),
+						"digitalocean_volume_snapshot.foobar", "name", snapName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr(
@@ -95,20 +95,21 @@ func testAccCheckDigitalOceanVolumeSnapshotDestroy(s *terraform.State) error {
 const testAccCheckDigitalOceanVolumeSnapshotConfig_basic = `
 resource "digitalocean_volume" "foo" {
   region      = "nyc1"
-  name        = "volume-%d"
+  name        = "%s"
   size        = 100
   description = "peace makes plenty"
 }
 
 resource "digitalocean_volume_snapshot" "foobar" {
-  name      = "snapshot-%d"
+  name      = "%s"
   volume_id = digitalocean_volume.foo.id
   tags      = ["foo", "bar"]
 }`
 
 func TestAccDigitalOceanVolumeSnapshot_UpdateTags(t *testing.T) {
 	var snapshot godo.Snapshot
-	rInt := acctest.RandInt()
+	volName := acceptance.RandomTestName("volume")
+	snapName := acceptance.RandomTestName("snapshot")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -116,14 +117,14 @@ func TestAccDigitalOceanVolumeSnapshot_UpdateTags(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic, rInt, rInt),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic, volName, snapName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeSnapshotExists("digitalocean_volume_snapshot.foobar", &snapshot),
 					resource.TestCheckResourceAttr("digitalocean_volume_snapshot.foobar", "tags.#", "2"),
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic_tag_update, rInt, rInt),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeSnapshotConfig_basic_tag_update, volName, snapName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeSnapshotExists("digitalocean_volume_snapshot.foobar", &snapshot),
 					resource.TestCheckResourceAttr("digitalocean_volume_snapshot.foobar", "tags.#", "3"),
@@ -136,13 +137,13 @@ func TestAccDigitalOceanVolumeSnapshot_UpdateTags(t *testing.T) {
 const testAccCheckDigitalOceanVolumeSnapshotConfig_basic_tag_update = `
 resource "digitalocean_volume" "foo" {
   region      = "nyc1"
-  name        = "volume-%d"
+  name        = "%s"
   size        = 100
   description = "peace makes plenty"
 }
 
 resource "digitalocean_volume_snapshot" "foobar" {
-  name      = "snapshot-%d"
+  name      = "%s"
   volume_id = digitalocean_volume.foo.id
   tags      = ["foo", "bar", "baz"]
 }`

--- a/digitalocean/snapshot/sweep.go
+++ b/digitalocean/snapshot/sweep.go
@@ -40,7 +40,7 @@ func testSweepDropletSnapshots(region string) error {
 	}
 
 	for _, s := range snapshots {
-		if strings.HasPrefix(s.Name, "snapshot-") || strings.HasPrefix(s.Name, "snap-") {
+		if strings.HasPrefix(s.Name, sweep.TestNamePrefix) {
 			log.Printf("Destroying Droplet Snapshot %s", s.Name)
 
 			if _, err := client.Snapshots.Delete(context.Background(), s.ID); err != nil {
@@ -67,7 +67,7 @@ func testSweepVolumeSnapshots(region string) error {
 	}
 
 	for _, s := range snapshots {
-		if strings.HasPrefix(s.Name, "snapshot-") {
+		if strings.HasPrefix(s.Name, sweep.TestNamePrefix) {
 			log.Printf("Destroying Volume Snapshot %s", s.Name)
 
 			if _, err := client.Snapshots.Delete(context.Background(), s.ID); err != nil {


### PR DESCRIPTION

```
$ make testacc PKG_NAME=digitalocean/snapshot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/snapshot/...  -timeout 120m -parallel=2
=== RUN   TestAccDataSourceDigitalOceanDropletSnapshot_basic
=== PAUSE TestAccDataSourceDigitalOceanDropletSnapshot_basic
=== RUN   TestAccDataSourceDigitalOceanDropletSnapshot_regex
=== PAUSE TestAccDataSourceDigitalOceanDropletSnapshot_regex
=== RUN   TestAccDataSourceDigitalOceanDropletSnapshot_region
=== PAUSE TestAccDataSourceDigitalOceanDropletSnapshot_region
=== RUN   TestAccDataSourceDigitalOceanVolumeSnapshot_basic
=== PAUSE TestAccDataSourceDigitalOceanVolumeSnapshot_basic
=== RUN   TestAccDataSourceDigitalOceanVolumeSnapshot_regex
=== PAUSE TestAccDataSourceDigitalOceanVolumeSnapshot_regex
=== RUN   TestAccDataSourceDigitalOceanVolumeSnapshot_region
=== PAUSE TestAccDataSourceDigitalOceanVolumeSnapshot_region
=== RUN   TestAccDigitalOceanDropletSnapshot_importBasic
=== PAUSE TestAccDigitalOceanDropletSnapshot_importBasic
=== RUN   TestAccDigitalOceanVolumeSnapshot_importBasic
=== PAUSE TestAccDigitalOceanVolumeSnapshot_importBasic
=== RUN   TestAccDigitalOceanDropletSnapshot_Basic
=== PAUSE TestAccDigitalOceanDropletSnapshot_Basic
=== RUN   TestAccDigitalOceanVolumeSnapshot_Basic
=== PAUSE TestAccDigitalOceanVolumeSnapshot_Basic
=== RUN   TestAccDigitalOceanVolumeSnapshot_UpdateTags
=== PAUSE TestAccDigitalOceanVolumeSnapshot_UpdateTags
=== CONT  TestAccDataSourceDigitalOceanDropletSnapshot_basic
=== CONT  TestAccDigitalOceanVolumeSnapshot_Basic
--- PASS: TestAccDigitalOceanVolumeSnapshot_Basic (12.57s)
=== CONT  TestAccDigitalOceanVolumeSnapshot_UpdateTags
--- PASS: TestAccDigitalOceanVolumeSnapshot_UpdateTags (12.39s)
=== CONT  TestAccDataSourceDigitalOceanVolumeSnapshot_region
--- PASS: TestAccDataSourceDigitalOceanVolumeSnapshot_region (53.86s)
=== CONT  TestAccDigitalOceanDropletSnapshot_Basic
--- PASS: TestAccDigitalOceanDropletSnapshot_Basic (404.26s)
=== CONT  TestAccDigitalOceanVolumeSnapshot_importBasic
--- PASS: TestAccDataSourceDigitalOceanDropletSnapshot_basic (492.13s)
=== CONT  TestAccDigitalOceanDropletSnapshot_importBasic
--- PASS: TestAccDigitalOceanVolumeSnapshot_importBasic (10.54s)
=== CONT  TestAccDataSourceDigitalOceanVolumeSnapshot_basic
--- PASS: TestAccDataSourceDigitalOceanVolumeSnapshot_basic (35.07s)
=== CONT  TestAccDataSourceDigitalOceanVolumeSnapshot_regex
--- PASS: TestAccDataSourceDigitalOceanVolumeSnapshot_regex (29.92s)
=== CONT  TestAccDataSourceDigitalOceanDropletSnapshot_region
--- PASS: TestAccDigitalOceanDropletSnapshot_importBasic (175.80s)
=== CONT  TestAccDataSourceDigitalOceanDropletSnapshot_regex
--- PASS: TestAccDataSourceDigitalOceanDropletSnapshot_regex (182.53s)
--- PASS: TestAccDataSourceDigitalOceanDropletSnapshot_region (415.14s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/snapshot   973.761s
```