### PR TITLE
Use consistent naming for all volumes created in tests.

### DIFF
--- a/digitalocean/volume/datasource_volume_test.go
+++ b/digitalocean/volume/datasource_volume_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccDataSourceDigitalOceanVolume_Basic(t *testing.T) {
 	var volume godo.Volume
-	testName := acceptance.RandomTestName()
+	testName := acceptance.RandomTestName("volume")
 	resourceConfig := testAccCheckDataSourceDigitalOceanVolumeConfig_basic(testName)
 	dataSourceConfig := `
 data "digitalocean_volume" "foobar" {
@@ -36,7 +36,7 @@ data "digitalocean_volume" "foobar" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanVolumeExists("data.digitalocean_volume.foobar", &volume),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_volume.foobar", "name", fmt.Sprintf("%s-volume", testName)),
+						"data.digitalocean_volume.foobar", "name", testName),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_volume.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -54,8 +54,8 @@ data "digitalocean_volume" "foobar" {
 
 func TestAccDataSourceDigitalOceanVolume_RegionScoped(t *testing.T) {
 	var volume godo.Volume
-	testName := acceptance.RandomTestName()
-	resourceConfig := testAccCheckDataSourceDigitalOceanVolumeConfig_region_scoped(testName)
+	name := acceptance.RandomTestName()
+	resourceConfig := testAccCheckDataSourceDigitalOceanVolumeConfig_region_scoped(name)
 	dataSourceConfig := `
 data "digitalocean_volume" "foobar" {
   name   = digitalocean_volume.foo.name
@@ -74,7 +74,7 @@ data "digitalocean_volume" "foobar" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanVolumeExists("data.digitalocean_volume.foobar", &volume),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_volume.foobar", "name", fmt.Sprintf("%s-volume", testName)),
+						"data.digitalocean_volume.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_volume.foobar", "region", "lon1"),
 					resource.TestCheckResourceAttr(
@@ -123,24 +123,24 @@ func testAccCheckDataSourceDigitalOceanVolumeConfig_basic(testName string) strin
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foo" {
   region = "nyc3"
-  name   = "%s-volume"
+  name   = "%s"
   size   = 10
   tags   = ["foo", "bar"]
 }`, testName)
 }
 
-func testAccCheckDataSourceDigitalOceanVolumeConfig_region_scoped(testName string) string {
+func testAccCheckDataSourceDigitalOceanVolumeConfig_region_scoped(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foo" {
   region = "nyc3"
-  name   = "%s-volume"
+  name   = "%s"
   size   = 10
   tags   = ["foo", "bar"]
 }
 
 resource "digitalocean_volume" "bar" {
   region = "lon1"
-  name   = "%s-volume"
+  name   = "%s"
   size   = 20
-}`, testName, testName)
+}`, name, name)
 }

--- a/digitalocean/volume/import_volume_test.go
+++ b/digitalocean/volume/import_volume_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanVolume_importBasic(t *testing.T) {
 	resourceName := "digitalocean_volume.foobar"
-	volumeName := fmt.Sprintf("volume-%s", acctest.RandString(10))
+	volumeName := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },

--- a/digitalocean/volume/resource_volume_attachment_test.go
+++ b/digitalocean/volume/resource_volume_attachment_test.go
@@ -9,14 +9,13 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDigitalOceanVolumeAttachment_Basic(t *testing.T) {
 	var (
-		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
+		volume  = godo.Volume{Name: acceptance.RandomTestName()}
 		dName   = acceptance.RandomTestName()
 		droplet godo.Droplet
 	)
@@ -46,8 +45,8 @@ func TestAccDigitalOceanVolumeAttachment_Basic(t *testing.T) {
 
 func TestAccDigitalOceanVolumeAttachment_Update(t *testing.T) {
 	var (
-		firstVolume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
-		secondVolume = godo.Volume{Name: fmt.Sprintf("volume-s-%s", acctest.RandString(10))}
+		firstVolume  = godo.Volume{Name: acceptance.RandomTestName()}
+		secondVolume = godo.Volume{Name: acceptance.RandomTestName()}
 		dName        = acceptance.RandomTestName()
 		droplet      godo.Droplet
 	)
@@ -91,8 +90,8 @@ func TestAccDigitalOceanVolumeAttachment_Update(t *testing.T) {
 
 func TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume(t *testing.T) {
 	var (
-		firstVolume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
-		secondVolume = godo.Volume{Name: fmt.Sprintf("volume-s-%s", acctest.RandString(10))}
+		firstVolume  = godo.Volume{Name: acceptance.RandomTestName()}
+		secondVolume = godo.Volume{Name: acceptance.RandomTestName()}
 		dName        = acceptance.RandomTestName()
 		droplet      godo.Droplet
 	)
@@ -138,8 +137,8 @@ func TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume(t *testing.T) {
 
 func TestAccDigitalOceanVolumeAttachment_Multiple(t *testing.T) {
 	var (
-		firstVolume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
-		secondVolume = godo.Volume{Name: fmt.Sprintf("volume-s-%s", acctest.RandString(10))}
+		firstVolume  = godo.Volume{Name: acceptance.RandomTestName()}
+		secondVolume = godo.Volume{Name: acceptance.RandomTestName()}
 		dName        = acceptance.RandomTestName()
 		droplet      godo.Droplet
 	)

--- a/digitalocean/volume/resource_volume_test.go
+++ b/digitalocean/volume/resource_volume_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDigitalOceanVolume_Basic(t *testing.T) {
-	name := fmt.Sprintf("volume-%s", acctest.RandString(10))
+	name := acceptance.RandomTestName("volume")
 
 	expectedURNRegEx, _ := regexp.Compile(`do:volume:[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
 
@@ -104,7 +103,7 @@ func testAccCheckDigitalOceanVolumeDestroy(s *terraform.State) error {
 
 func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 	var (
-		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
+		volume  = godo.Volume{Name: acceptance.RandomTestName()}
 		dName   = acceptance.RandomTestName()
 		droplet godo.Droplet
 	)
@@ -149,7 +148,7 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 func TestAccDigitalOceanVolume_LegacyFilesystemType(t *testing.T) {
-	name := fmt.Sprintf("volume-%s", acctest.RandString(10))
+	name := acceptance.RandomTestName()
 
 	volume := godo.Volume{
 		Name: name,
@@ -190,7 +189,7 @@ resource "digitalocean_volume" "foobar" {
 }`
 
 func TestAccDigitalOceanVolume_FilesystemType(t *testing.T) {
-	name := fmt.Sprintf("volume-%s", acctest.RandString(10))
+	name := acceptance.RandomTestName()
 
 	volume := godo.Volume{
 		Name: name,
@@ -239,7 +238,7 @@ resource "digitalocean_volume" "foobar" {
 
 func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 	var (
-		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
+		volume  = godo.Volume{Name: acceptance.RandomTestName()}
 		dName   = acceptance.RandomTestName()
 		droplet godo.Droplet
 	)
@@ -273,7 +272,7 @@ func TestAccDigitalOceanVolume_Resize(t *testing.T) {
 	})
 }
 
-func testAccCheckDigitalOceanVolumeConfig_resize(dName string, vName string, vSize int) string {
+func testAccCheckDigitalOceanVolumeConfig_resize(dName, vName string, vSize int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
@@ -294,10 +293,12 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 func TestAccDigitalOceanVolume_CreateFromSnapshot(t *testing.T) {
-	rInt := acctest.RandInt()
+	volName := acceptance.RandomTestName()
+	snapName := acceptance.RandomTestName()
+	restoredName := acceptance.RandomTestName()
 
 	volume := godo.Volume{
-		Name: fmt.Sprintf("volume-snap-%d", rInt),
+		Name: restoredName,
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -306,7 +307,7 @@ func TestAccDigitalOceanVolume_CreateFromSnapshot(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanVolumeConfig_create_from_snapshot(rInt),
+				Config: testAccCheckDigitalOceanVolumeConfig_create_from_snapshot(volName, snapName, restoredName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
 					// the droplet should see an attached volume
@@ -318,30 +319,30 @@ func TestAccDigitalOceanVolume_CreateFromSnapshot(t *testing.T) {
 	})
 }
 
-func testAccCheckDigitalOceanVolumeConfig_create_from_snapshot(rInt int) string {
+func testAccCheckDigitalOceanVolumeConfig_create_from_snapshot(volume, snapshot, restored string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_volume" "foo" {
   region      = "nyc1"
-  name        = "volume-%d"
+  name        = "%s"
   size        = 100
   description = "peace makes plenty"
 }
 
 resource "digitalocean_volume_snapshot" "foo" {
-  name      = "snapshot-%d"
+  name      = "%s"
   volume_id = digitalocean_volume.foo.id
 }
 
 resource "digitalocean_volume" "foobar" {
   region      = "nyc1"
-  name        = "volume-snap-%d"
+  name        = "%s"
   size        = digitalocean_volume_snapshot.foo.min_disk_size
   snapshot_id = digitalocean_volume_snapshot.foo.id
-}`, rInt, rInt, rInt)
+}`, volume, snapshot, restored)
 }
 
 func TestAccDigitalOceanVolume_UpdateTags(t *testing.T) {
-	name := fmt.Sprintf("volume-%s", acctest.RandString(10))
+	name := acceptance.RandomTestName()
 
 	volume := godo.Volume{
 		Name: name,

--- a/digitalocean/volume/sweep.go
+++ b/digitalocean/volume/sweep.go
@@ -38,7 +38,7 @@ func testSweepVolumes(region string) error {
 	}
 
 	for _, v := range volumes {
-		if strings.HasPrefix(v.Name, "volume-") || strings.HasPrefix(v.Name, "tf-acc-test-") {
+		if strings.HasPrefix(v.Name, sweep.TestNamePrefix) {
 
 			if len(v.DropletIDs) > 0 {
 				log.Printf("Detaching volume %v from Droplet %v", v.ID, v.DropletIDs[0])


### PR DESCRIPTION
```
$ make testacc PKG_NAME=digitalocean/volume ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/volume/...  -timeout 120m -parallel=5
=== RUN   TestAccDataSourceDigitalOceanVolume_Basic
=== PAUSE TestAccDataSourceDigitalOceanVolume_Basic
=== RUN   TestAccDataSourceDigitalOceanVolume_RegionScoped
=== PAUSE TestAccDataSourceDigitalOceanVolume_RegionScoped
=== RUN   TestAccDigitalOceanVolume_importBasic
=== PAUSE TestAccDigitalOceanVolume_importBasic
=== RUN   TestAccDigitalOceanVolumeAttachment_Basic
=== PAUSE TestAccDigitalOceanVolumeAttachment_Basic
=== RUN   TestAccDigitalOceanVolumeAttachment_Update
=== PAUSE TestAccDigitalOceanVolumeAttachment_Update
=== RUN   TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume
=== PAUSE TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume
=== RUN   TestAccDigitalOceanVolumeAttachment_Multiple
=== PAUSE TestAccDigitalOceanVolumeAttachment_Multiple
=== RUN   TestAccDigitalOceanVolume_Basic
=== PAUSE TestAccDigitalOceanVolume_Basic
=== RUN   TestAccDigitalOceanVolume_Droplet
=== PAUSE TestAccDigitalOceanVolume_Droplet
=== RUN   TestAccDigitalOceanVolume_LegacyFilesystemType
=== PAUSE TestAccDigitalOceanVolume_LegacyFilesystemType
=== RUN   TestAccDigitalOceanVolume_FilesystemType
=== PAUSE TestAccDigitalOceanVolume_FilesystemType
=== RUN   TestAccDigitalOceanVolume_Resize
=== PAUSE TestAccDigitalOceanVolume_Resize
=== RUN   TestAccDigitalOceanVolume_CreateFromSnapshot
=== PAUSE TestAccDigitalOceanVolume_CreateFromSnapshot
=== RUN   TestAccDigitalOceanVolume_UpdateTags
=== PAUSE TestAccDigitalOceanVolume_UpdateTags
=== CONT  TestAccDataSourceDigitalOceanVolume_Basic
=== CONT  TestAccDigitalOceanVolume_Basic
=== CONT  TestAccDigitalOceanVolume_LegacyFilesystemType
=== CONT  TestAccDigitalOceanVolume_Resize
=== CONT  TestAccDigitalOceanVolume_UpdateTags
--- PASS: TestAccDigitalOceanVolume_Basic (4.14s)
=== CONT  TestAccDigitalOceanVolume_CreateFromSnapshot
--- PASS: TestAccDigitalOceanVolume_LegacyFilesystemType (4.18s)
=== CONT  TestAccDigitalOceanVolumeAttachment_Update
--- PASS: TestAccDigitalOceanVolume_UpdateTags (7.33s)
=== CONT  TestAccDigitalOceanVolumeAttachment_Multiple
--- PASS: TestAccDataSourceDigitalOceanVolume_Basic (8.00s)
=== CONT  TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume
--- PASS: TestAccDigitalOceanVolume_CreateFromSnapshot (7.91s)
=== CONT  TestAccDigitalOceanVolume_Droplet
--- PASS: TestAccDigitalOceanVolume_Droplet (65.11s)
=== CONT  TestAccDigitalOceanVolume_importBasic
--- PASS: TestAccDigitalOceanVolume_importBasic (4.53s)
=== CONT  TestAccDigitalOceanVolumeAttachment_Basic
--- PASS: TestAccDigitalOceanVolumeAttachment_Multiple (75.46s)
=== CONT  TestAccDigitalOceanVolume_FilesystemType
--- PASS: TestAccDigitalOceanVolume_FilesystemType (5.13s)
=== CONT  TestAccDataSourceDigitalOceanVolume_RegionScoped
--- PASS: TestAccDigitalOceanVolume_Resize (90.44s)
--- PASS: TestAccDataSourceDigitalOceanVolume_RegionScoped (6.68s)
--- PASS: TestAccDigitalOceanVolumeAttachment_Update (101.85s)
--- PASS: TestAccDigitalOceanVolumeAttachment_UpdateToSecondVolume (101.28s)
--- PASS: TestAccDigitalOceanVolumeAttachment_Basic (74.19s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/volume     155.893s
```