### PR TITLE
Add sweeper for SSH keys.

### DIFF
--- a/digitalocean/sshkey/datasource_ssh_key_test.go
+++ b/digitalocean/sshkey/datasource_ssh_key_test.go
@@ -2,26 +2,23 @@ package sshkey_test
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"golang.org/x/crypto/ssh"
 )
 
 func TestAccDataSourceDigitalOceanSSHKey_Basic(t *testing.T) {
 	var key godo.Key
 	keyName := acceptance.RandomTestName()
 
-	pubKey, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
+	pubKey, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {
 		t.Fatalf("Unable to generate public key: %v", err)
 		return
@@ -92,18 +89,4 @@ func testAccCheckDataSourceDigitalOceanSSHKeyExists(n string, key *godo.Key) res
 
 		return nil
 	}
-}
-
-func testAccGenerateDataSourceDigitalOceanSSHKeyPublic() (string, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return "", fmt.Errorf("Unable to generate key: %v", err)
-	}
-
-	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
-	if err != nil {
-		return "", fmt.Errorf("Unable to generate key: %v", err)
-	}
-
-	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(publicKey))), nil
 }

--- a/digitalocean/sshkey/datasource_ssh_keys_test.go
+++ b/digitalocean/sshkey/datasource_ssh_keys_test.go
@@ -5,18 +5,17 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanSSHKeys_Basic(t *testing.T) {
-	keyName1 := fmt.Sprintf("tf-acc-test1-%s", acctest.RandString(10))
+	keyName1 := acceptance.RandomTestName("datasource1")
 	pubKey1, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
 	if err != nil {
 		t.Fatalf("Unable to generate public key: %v", err)
 		return
 	}
-	keyName2 := fmt.Sprintf("tf-acc-test2-%s", acctest.RandString(10))
+	keyName2 := acceptance.RandomTestName("datasource2")
 	pubKey2, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
 	if err != nil {
 		t.Fatalf("Unable to generate public key: %v", err)
@@ -41,8 +40,13 @@ data "digitalocean_ssh_keys" "result" {
     key       = "name"
     direction = "asc"
   }
+  filter {
+    key    = "name"
+    values = ["%s", "%s"]
+  }
 }
-`)
+`, keyName1, keyName2)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/digitalocean/sshkey/datasource_ssh_keys_test.go
+++ b/digitalocean/sshkey/datasource_ssh_keys_test.go
@@ -5,18 +5,19 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanSSHKeys_Basic(t *testing.T) {
 	keyName1 := acceptance.RandomTestName("datasource1")
-	pubKey1, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
+	pubKey1, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {
 		t.Fatalf("Unable to generate public key: %v", err)
 		return
 	}
 	keyName2 := acceptance.RandomTestName("datasource2")
-	pubKey2, err := testAccGenerateDataSourceDigitalOceanSSHKeyPublic()
+	pubKey2, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {
 		t.Fatalf("Unable to generate public key: %v", err)
 		return

--- a/digitalocean/sshkey/import_ssh_key_test.go
+++ b/digitalocean/sshkey/import_ssh_key_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccDigitalOceanSSHKey_importBasic(t *testing.T) {
 	resourceName := "digitalocean_ssh_key.foobar"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)
@@ -22,7 +22,7 @@ func TestAccDigitalOceanSSHKey_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanSSHKeyConfig_basic(rInt, publicKeyMaterial),
+				Config: testAccCheckDigitalOceanSSHKeyConfig_basic(name, publicKeyMaterial),
 			},
 
 			{

--- a/digitalocean/sshkey/resource_ssh_key_test.go
+++ b/digitalocean/sshkey/resource_ssh_key_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccDigitalOceanSSHKey_Basic(t *testing.T) {
 	var key godo.Key
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)
@@ -28,11 +28,11 @@ func TestAccDigitalOceanSSHKey_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanSSHKeyConfig_basic(rInt, publicKeyMaterial),
+				Config: testAccCheckDigitalOceanSSHKeyConfig_basic(name, publicKeyMaterial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSSHKeyExists("digitalocean_ssh_key.foobar", &key),
 					resource.TestCheckResourceAttr(
-						"digitalocean_ssh_key.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
+						"digitalocean_ssh_key.foobar", "name", name),
 					resource.TestCheckResourceAttr(
 						"digitalocean_ssh_key.foobar", "public_key", publicKeyMaterial),
 				),
@@ -101,10 +101,10 @@ func testAccCheckDigitalOceanSSHKeyExists(n string, key *godo.Key) resource.Test
 	}
 }
 
-func testAccCheckDigitalOceanSSHKeyConfig_basic(rInt int, key string) string {
+func testAccCheckDigitalOceanSSHKeyConfig_basic(name, key string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar-%d"
+  name       = "%s"
   public_key = "%s"
-}`, rInt, key)
+}`, name, key)
 }

--- a/digitalocean/sshkey/sweep.go
+++ b/digitalocean/sshkey/sweep.go
@@ -1,0 +1,47 @@
+package sshkey
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sweep"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("digitalocean_ssh_key", &resource.Sweeper{
+		Name: "digitalocean_ssh_key",
+		F:    sweepSSHKey,
+	})
+
+}
+
+func sweepSSHKey(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opt := &godo.ListOptions{PerPage: 200}
+	keys, _, err := client.Keys.List(context.Background(), opt)
+	if err != nil {
+		return err
+	}
+
+	for _, k := range keys {
+		if strings.HasPrefix(k.Name, sweep.TestNamePrefix) {
+			log.Printf("Destroying SSH key %s", k.Name)
+
+			if _, err := client.Keys.DeleteByID(context.Background(), k.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/digitalocean/sweep/sweep_test.go
+++ b/digitalocean/sweep/sweep_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/reservedip"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/snapshot"
+	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sshkey"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/volume"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"


### PR DESCRIPTION
This adds a sweeper for SSH keys. It also removes a custom helper for generating keys for use in tests. The SDK already provides a helper for this that we use elsewhere. There is no need to duplicate that functionality.

```
$ make testacc PKG_NAME=digitalocean/sshkey 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/sshkey/...  -timeout 120m -parallel=5
=== RUN   TestAccDataSourceDigitalOceanSSHKey_Basic
=== PAUSE TestAccDataSourceDigitalOceanSSHKey_Basic
=== RUN   TestAccDataSourceDigitalOceanSSHKeys_Basic
=== PAUSE TestAccDataSourceDigitalOceanSSHKeys_Basic
=== RUN   TestAccDigitalOceanSSHKey_importBasic
=== PAUSE TestAccDigitalOceanSSHKey_importBasic
=== RUN   TestAccDigitalOceanSSHKey_Basic
=== PAUSE TestAccDigitalOceanSSHKey_Basic
=== CONT  TestAccDataSourceDigitalOceanSSHKey_Basic
=== CONT  TestAccDigitalOceanSSHKey_importBasic
=== CONT  TestAccDigitalOceanSSHKey_Basic
=== CONT  TestAccDataSourceDigitalOceanSSHKeys_Basic
--- PASS: TestAccDigitalOceanSSHKey_Basic (1.85s)
--- PASS: TestAccDigitalOceanSSHKey_importBasic (2.15s)
--- PASS: TestAccDataSourceDigitalOceanSSHKey_Basic (3.36s)
--- PASS: TestAccDataSourceDigitalOceanSSHKeys_Basic (5.21s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sshkey     5.272s
```