### PR TITLE
Add sweeper for custom images and fix acceptance tests.

### DIFF
--- a/digitalocean/image/resource_custom_image.go
+++ b/digitalocean/image/resource_custom_image.go
@@ -330,5 +330,6 @@ func validImageDistributions() []string {
 		"RancherOS",
 		"Ubuntu",
 		"Unknown",
+		"Unknown OS",
 	}
 }

--- a/digitalocean/image/sweep.go
+++ b/digitalocean/image/sweep.go
@@ -1,0 +1,47 @@
+package image
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sweep"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("digitalocean_custom_image", &resource.Sweeper{
+		Name: "digitalocean_custom_image",
+		F:    sweepCustomImage,
+	})
+
+}
+
+func sweepCustomImage(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opt := &godo.ListOptions{PerPage: 200}
+	images, _, err := client.Images.ListUser(context.Background(), opt)
+	if err != nil {
+		return err
+	}
+
+	for _, i := range images {
+		if strings.HasPrefix(i.Name, sweep.TestNamePrefix) {
+			log.Printf("Destroying image %s", i.Name)
+
+			if _, err := client.Images.Delete(context.Background(), i.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/digitalocean/sweep/sweep_test.go
+++ b/digitalocean/sweep/sweep_test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/domain"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/droplet"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/firewall"
+	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/image"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/reservedip"


### PR DESCRIPTION
```
=== RUN   TestAccDigitalOceanCustomImageFull
=== PAUSE TestAccDigitalOceanCustomImageFull
=== RUN   TestAccDigitalOceanCustomImageMultiRegion
=== PAUSE TestAccDigitalOceanCustomImageMultiRegion
=== CONT  TestAccDigitalOceanCustomImageFull
=== CONT  TestAccDigitalOceanCustomImageMultiRegion
--- PASS: TestAccDigitalOceanCustomImageFull (430.90s)
--- PASS: TestAccDigitalOceanCustomImageMultiRegion (1114.29s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/image      1114.299s
```