### PR TITLE
Add sweeper for projects and add retry for project deletion.

### DIFF
--- a/digitalocean/project/resource_project_test.go
+++ b/digitalocean/project/resource_project_test.go
@@ -208,6 +208,7 @@ func TestAccDigitalOceanProject_CreateWithDropletResource(t *testing.T) {
 	expectedDropletName := generateDropletName()
 
 	createConfig := fixtureCreateWithDropletResource(expectedDropletName, expectedName)
+	destroyConfig := fixtureCreateWithDefaults(expectedName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -221,6 +222,18 @@ func TestAccDigitalOceanProject_CreateWithDropletResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_project.myproj", "name", expectedName),
 					resource.TestCheckResourceAttr("digitalocean_project.myproj", "resources.#", "1"),
+				),
+			},
+			{
+				Config: destroyConfig,
+			},
+			{
+				Config: destroyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "name", expectedName),
+					resource.TestCheckResourceAttr("digitalocean_project.myproj", "resources.#", "0"),
 				),
 			},
 		},

--- a/digitalocean/project/resource_project_test.go
+++ b/digitalocean/project/resource_project_test.go
@@ -267,13 +267,11 @@ func TestAccDigitalOceanProject_UpdateWithDropletResource(t *testing.T) {
 }
 
 func TestAccDigitalOceanProject_UpdateFromDropletToSpacesResource(t *testing.T) {
-
 	expectedName := generateProjectName()
 	expectedDropletName := generateDropletName()
 	expectedSpacesName := generateSpacesName()
 
 	createConfig := fixtureCreateWithDropletResource(expectedDropletName, expectedName)
-
 	updateConfig := fixtureCreateWithSpacesResource(expectedSpacesName, expectedName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -315,7 +313,6 @@ func TestAccDigitalOceanProject_WithManyResources(t *testing.T) {
 
 	createConfig := fixtureCreateDomainResources(domainBase)
 	updateConfig := fixtureWithManyResources(domainBase, projectName)
-	destroyConfig := fixtureCreateWithDefaults(projectName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -331,19 +328,7 @@ func TestAccDigitalOceanProject_WithManyResources(t *testing.T) {
 					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_project.myproj", "name", projectName),
-					resource.TestCheckResourceAttr("digitalocean_project.myproj", "resources.#", "30"),
-				),
-			},
-			{
-				Config: destroyConfig,
-			},
-			{
-				Config: destroyConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_project.myproj", "name", projectName),
-					resource.TestCheckResourceAttr("digitalocean_project.myproj", "resources.#", "0"),
+					resource.TestCheckResourceAttr("digitalocean_project.myproj", "resources.#", "10"),
 				),
 			},
 		},
@@ -366,7 +351,7 @@ func testAccCheckDigitalOceanProjectResourceURNIsPresent(resource, expectedURN s
 
 		projectResources, _, err := client.Projects.ListResources(context.Background(), rs.Primary.ID, nil)
 		if err != nil {
-			return fmt.Errorf("Error Retrieving project resources to confrim.")
+			return fmt.Errorf("Error Retrieving project resources to confirm.")
 		}
 
 		for _, v := range projectResources {
@@ -495,7 +480,7 @@ resource "digitalocean_project" "myproj" {
 func fixtureCreateDomainResources(domainBase string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_domain" "foobar" {
-  count = 30
+  count = 10
   name  = "%s-${count.index}.com"
 }`, domainBase)
 }
@@ -503,7 +488,7 @@ resource "digitalocean_domain" "foobar" {
 func fixtureWithManyResources(domainBase string, name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_domain" "foobar" {
-  count = 30
+  count = 10
   name  = "%s-${count.index}.com"
 }
 

--- a/digitalocean/project/sweep.go
+++ b/digitalocean/project/sweep.go
@@ -1,0 +1,58 @@
+package project
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sweep"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("digitalocean_project", &resource.Sweeper{
+		Name: "digitalocean_project",
+		F:    sweepProjects,
+		Dependencies: []string{
+			//	"digitalocean_spaces_bucket", TODO: Add when Spaces sweeper exists.
+			"digitalocean_droplet",
+			"digitalocean_domain",
+		},
+	})
+}
+
+func sweepProjects(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opt := &godo.ListOptions{PerPage: 200}
+	projects, _, err := client.Projects.List(context.Background(), opt)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range projects {
+		if strings.HasPrefix(p.Name, sweep.TestNamePrefix) {
+			log.Printf("[DEBUG] Destroying project %s", p.Name)
+
+			resp, err := client.Projects.Delete(context.Background(), p.ID)
+			if err != nil {
+				// Projects with resources can not be deleted.
+				if resp.StatusCode == http.StatusPreconditionFailed {
+					log.Printf("[DEBUG] Skipping project %s: %s", p.Name, err.Error())
+				} else {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/digitalocean/sweep/sweep_test.go
+++ b/digitalocean/sweep/sweep_test.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/firewall"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer"
+	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/project"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/reservedip"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/snapshot"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sshkey"


### PR DESCRIPTION
This adds a sweeper for projects. Additionally it adds a retry for project deletion. Projects must be empty to be deleted. We handle reassigning resources to the default project, but this is an async process. Retrying deletion resolves some flaky tests.

```
$ make testacc PKG_NAME=digitalocean/project TESTARGS="-count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/project/... -count=1 -timeout 120m -parallel=2
=== RUN   TestAccDataSourceDigitalOceanProject_DefaultProject
=== PAUSE TestAccDataSourceDigitalOceanProject_DefaultProject
=== RUN   TestAccDataSourceDigitalOceanProject_NonDefaultProject
=== PAUSE TestAccDataSourceDigitalOceanProject_NonDefaultProject
=== RUN   TestAccDataSourceDigitalOceanProjects_Basic
--- PASS: TestAccDataSourceDigitalOceanProjects_Basic (12.35s)
=== RUN   TestAccDigitalOceanProject_importBasic
=== PAUSE TestAccDigitalOceanProject_importBasic
=== RUN   TestAccDigitalOceanProjectResources_Basic
=== PAUSE TestAccDigitalOceanProjectResources_Basic
=== RUN   TestAccDigitalOceanProject_CreateWithDefaults
=== PAUSE TestAccDigitalOceanProject_CreateWithDefaults
=== RUN   TestAccDigitalOceanProject_CreateWithIsDefault
=== PAUSE TestAccDigitalOceanProject_CreateWithIsDefault
=== RUN   TestAccDigitalOceanProject_CreateWithInitialValues
=== PAUSE TestAccDigitalOceanProject_CreateWithInitialValues
=== RUN   TestAccDigitalOceanProject_UpdateWithInitialValues
=== PAUSE TestAccDigitalOceanProject_UpdateWithInitialValues
=== RUN   TestAccDigitalOceanProject_CreateWithDropletResource
=== PAUSE TestAccDigitalOceanProject_CreateWithDropletResource
=== RUN   TestAccDigitalOceanProject_UpdateWithDropletResource
=== PAUSE TestAccDigitalOceanProject_UpdateWithDropletResource
=== RUN   TestAccDigitalOceanProject_UpdateFromDropletToSpacesResource
=== PAUSE TestAccDigitalOceanProject_UpdateFromDropletToSpacesResource
=== RUN   TestAccDigitalOceanProject_WithManyResources
=== PAUSE TestAccDigitalOceanProject_WithManyResources
=== CONT  TestAccDataSourceDigitalOceanProject_DefaultProject
=== CONT  TestAccDigitalOceanProject_CreateWithInitialValues
--- PASS: TestAccDigitalOceanProject_CreateWithInitialValues (2.86s)
=== CONT  TestAccDigitalOceanProject_UpdateWithDropletResource
--- PASS: TestAccDataSourceDigitalOceanProject_DefaultProject (5.53s)
=== CONT  TestAccDigitalOceanProject_WithManyResources
--- PASS: TestAccDigitalOceanProject_WithManyResources (7.49s)
=== CONT  TestAccDigitalOceanProject_UpdateFromDropletToSpacesResource
--- PASS: TestAccDigitalOceanProject_UpdateWithDropletResource (72.90s)
=== CONT  TestAccDigitalOceanProjectResources_Basic
--- PASS: TestAccDigitalOceanProject_UpdateFromDropletToSpacesResource (85.99s)
=== CONT  TestAccDigitalOceanProject_CreateWithIsDefault
    resource_project_test.go:81: Restoring original default project: Terraform Acceptance Testing (5f6d8250-63c9-4310-90ea-f301a8174dcd)
--- PASS: TestAccDigitalOceanProject_CreateWithIsDefault (4.54s)
=== CONT  TestAccDigitalOceanProject_CreateWithDefaults
--- PASS: TestAccDigitalOceanProject_CreateWithDefaults (2.45s)
=== CONT  TestAccDigitalOceanProject_CreateWithDropletResource
--- PASS: TestAccDigitalOceanProjectResources_Basic (83.61s)
=== CONT  TestAccDigitalOceanProject_UpdateWithInitialValues
--- PASS: TestAccDigitalOceanProject_UpdateWithInitialValues (4.37s)
=== CONT  TestAccDigitalOceanProject_importBasic
--- PASS: TestAccDigitalOceanProject_importBasic (2.96s)
=== CONT  TestAccDataSourceDigitalOceanProject_NonDefaultProject
--- PASS: TestAccDataSourceDigitalOceanProject_NonDefaultProject (5.75s)
--- PASS: TestAccDigitalOceanProject_CreateWithDropletResource (79.13s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/project    197.501s
```