### PR TITLE
Add sweeper and use consistent naming for all Spaces buckets in tests.

### DIFF
--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -195,7 +194,7 @@ func testAccCheckDigitalOceanCDNExists(resource string) resource.TestCheckFunc {
 }
 
 func generateBucketName() string {
-	return fmt.Sprintf("tf-cdn-test-bucket-%d", acctest.RandInt())
+	return acceptance.RandomTestName("cdn")
 }
 
 const testAccCheckDigitalOceanCDNConfig_Create = `

--- a/digitalocean/spaces/datasource_spaces_bucket_object_test.go
+++ b/digitalocean/spaces/datasource_spaces_bucket_object_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceDigitalOceanSpacesBucketObject_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_basic(rInt)
+	name := acceptance.RandomTestName()
+	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_basic(name)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
@@ -49,8 +48,8 @@ func TestAccDataSourceDigitalOceanSpacesBucketObject_basic(t *testing.T) {
 }
 
 func TestAccDataSourceDigitalOceanSpacesBucketObject_readableBody(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_readableBody(rInt)
+	name := acceptance.RandomTestName()
+	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_readableBody(name)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
@@ -83,8 +82,8 @@ func TestAccDataSourceDigitalOceanSpacesBucketObject_readableBody(t *testing.T) 
 }
 
 func TestAccDataSourceDigitalOceanSpacesBucketObject_allParams(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_allParams(rInt)
+	name := acceptance.RandomTestName()
+	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_allParams(name)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
@@ -134,8 +133,8 @@ func TestAccDataSourceDigitalOceanSpacesBucketObject_LeadingSlash(t *testing.T) 
 	dataSourceName1 := "data.digitalocean_spaces_bucket_object.obj1"
 	dataSourceName2 := "data.digitalocean_spaces_bucket_object.obj2"
 	dataSourceName3 := "data.digitalocean_spaces_bucket_object.obj3"
-	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_leadingSlash(rInt)
+	name := acceptance.RandomTestName()
+	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_leadingSlash(name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -186,8 +185,8 @@ func TestAccDataSourceDigitalOceanSpacesBucketObject_MultipleSlashes(t *testing.
 	dataSourceName1 := "data.digitalocean_spaces_bucket_object.obj1"
 	dataSourceName2 := "data.digitalocean_spaces_bucket_object.obj2"
 	dataSourceName3 := "data.digitalocean_spaces_bucket_object.obj3"
-	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_multipleSlashes(rInt)
+	name := acceptance.RandomTestName()
+	resourceOnlyConf, conf := testAccDataSourceDigitalOceanSpacesObjectConfig_multipleSlashes(name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -273,61 +272,61 @@ func testAccCheckDigitalOceanSpacesObjectDataSourceExists(n string, obj *s3.GetO
 	}
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectConfig_basic(randInt int) (string, string) {
+func testAccDataSourceDigitalOceanSpacesObjectConfig_basic(name string) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name   = "tf-object-test-bucket-%d"
+  name   = "%s"
   region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object" {
   bucket  = digitalocean_spaces_bucket.object_bucket.name
   region  = digitalocean_spaces_bucket.object_bucket.region
-  key     = "tf-testing-obj-%d"
+  key     = "%s-object"
   content = "Hello World"
 }
-`, randInt, randInt)
+`, name, name)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
-  key    = "tf-testing-obj-%d"
+  key    = "%s-object"
 }
-`, resources, randInt, randInt)
+`, resources, name, name)
 
 	return resources, both
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectConfig_readableBody(randInt int) (string, string) {
+func testAccDataSourceDigitalOceanSpacesObjectConfig_readableBody(name string) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name   = "tf-object-test-bucket-%d"
+  name   = "%s"
   region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object" {
   bucket       = digitalocean_spaces_bucket.object_bucket.name
   region       = digitalocean_spaces_bucket.object_bucket.region
-  key          = "tf-testing-obj-%d-readable"
+  key          = "%s-readable"
   content      = "yes"
   content_type = "text/plain"
 }
-`, randInt, randInt)
+`, name, name)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
-  key    = "tf-testing-obj-%d-readable"
+  key    = "%s-readable"
 }
-`, resources, randInt, randInt)
+`, resources, name, name)
 
 	return resources, both
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectConfig_allParams(randInt int) (string, string) {
+func testAccDataSourceDigitalOceanSpacesObjectConfig_allParams(name string) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name   = "tf-object-test-bucket-%d"
+  name   = "%s"
   region = "nyc3"
   versioning {
     enabled = true
@@ -337,7 +336,7 @@ resource "digitalocean_spaces_bucket" "object_bucket" {
 resource "digitalocean_spaces_bucket_object" "object" {
   bucket              = digitalocean_spaces_bucket.object_bucket.name
   region              = digitalocean_spaces_bucket.object_bucket.region
-  key                 = "tf-testing-obj-%d-all-params"
+  key                 = "%s-all-params"
   content             = <<CONTENT
 {"msg": "Hi there!"}
 CONTENT
@@ -347,59 +346,59 @@ CONTENT
   content_encoding    = "identity"
   content_language    = "en-GB"
 }
-`, randInt, randInt)
+`, name, name)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
-  key    = "tf-testing-obj-%d-all-params"
+  key    = "%s-all-params"
 }
-`, resources, randInt, randInt)
+`, resources, name, name)
 
 	return resources, both
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectConfig_leadingSlash(randInt int) (string, string) {
+func testAccDataSourceDigitalOceanSpacesObjectConfig_leadingSlash(name string) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name   = "tf-object-test-bucket-%d"
+  name   = "%s"
   region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object" {
   bucket       = digitalocean_spaces_bucket.object_bucket.name
   region       = digitalocean_spaces_bucket.object_bucket.region
-  key          = "//tf-testing-obj-%d-readable"
+  key          = "//%s-readable"
   content      = "yes"
   content_type = "text/plain"
 }
-`, randInt, randInt)
+`, name, name)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj1" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
-  key    = "tf-testing-obj-%d-readable"
+  key    = "%s-readable"
 }
 data "digitalocean_spaces_bucket_object" "obj2" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
-  key    = "/tf-testing-obj-%d-readable"
+  key    = "/%s-readable"
 }
 data "digitalocean_spaces_bucket_object" "obj3" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
-  key    = "//tf-testing-obj-%d-readable"
+  key    = "//%s-readable"
 }
-`, resources, randInt, randInt, randInt, randInt, randInt, randInt)
+`, resources, name, name, name, name, name, name)
 
 	return resources, both
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectConfig_multipleSlashes(randInt int) (string, string) {
+func testAccDataSourceDigitalOceanSpacesObjectConfig_multipleSlashes(name string) (string, string) {
 	resources := fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
-  name   = "tf-object-test-bucket-%d"
+  name   = "%s"
   region = "nyc3"
 }
 resource "digitalocean_spaces_bucket_object" "object1" {
@@ -417,25 +416,25 @@ resource "digitalocean_spaces_bucket_object" "object2" {
   content      = "no"
   content_type = "text/plain"
 }
-`, randInt)
+`, name)
 
 	both := fmt.Sprintf(`%s
 data "digitalocean_spaces_bucket_object" "obj1" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
   key    = "first/second/third/"
 }
 data "digitalocean_spaces_bucket_object" "obj2" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
   key    = "first//second///third//"
 }
 data "digitalocean_spaces_bucket_object" "obj3" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "%s"
   region = "nyc3"
   key    = "first/second/third"
 }
-`, resources, randInt, randInt, randInt)
+`, resources, name, name, name)
 
 	return resources, both
 }

--- a/digitalocean/spaces/datasource_spaces_bucket_objects_test.go
+++ b/digitalocean/spaces/datasource_spaces_bucket_objects_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceDigitalOceanSpacesBucketObjects_basic(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -19,11 +18,11 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_basic(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(rInt), // NOTE: contains no data source
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name), // NOTE: contains no data source
 				// Does not need Check
 			},
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigBasic(rInt),
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesObjectsDataSourceExists("data.digitalocean_spaces_bucket_objects.yesh"),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket_objects.yesh", "keys.#", "2"),
@@ -36,7 +35,7 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_basic(t *testing.T) {
 }
 
 func TestAccDataSourceDigitalOceanSpacesBucketObjects_all(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -44,11 +43,11 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_all(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(rInt), // NOTE: contains no data source
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name), // NOTE: contains no data source
 				// Does not need Check
 			},
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigAll(rInt),
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigAll(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesObjectsDataSourceExists("data.digitalocean_spaces_bucket_objects.yesh"),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket_objects.yesh", "keys.#", "7"),
@@ -66,7 +65,7 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_all(t *testing.T) {
 }
 
 func TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -74,11 +73,11 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(rInt), // NOTE: contains no data source
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name), // NOTE: contains no data source
 				// Does not need Check
 			},
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigPrefixes(rInt),
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigPrefixes(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesObjectsDataSourceExists("data.digitalocean_spaces_bucket_objects.yesh"),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket_objects.yesh", "keys.#", "1"),
@@ -95,7 +94,7 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes(t *testing.T) {
 }
 
 func TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -103,11 +102,11 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigExtraResource(rInt), // NOTE: contains no data source
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigExtraResource(name), // NOTE: contains no data source
 				// Does not need Check
 			},
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigEncoded(rInt),
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigEncoded(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesObjectsDataSourceExists("data.digitalocean_spaces_bucket_objects.yesh"),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket_objects.yesh", "keys.#", "2"),
@@ -120,7 +119,7 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded(t *testing.T) {
 }
 
 func TestAccDataSourceDigitalOceanSpacesBucketObjects_maxKeys(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheck(t) },
@@ -128,11 +127,11 @@ func TestAccDataSourceDigitalOceanSpacesBucketObjects_maxKeys(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(rInt), // NOTE: contains no data source
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name), // NOTE: contains no data source
 				// Does not need Check
 			},
 			{
-				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigMaxKeys(rInt),
+				Config: testAccDataSourceDigitalOceanSpacesObjectsConfigMaxKeys(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesObjectsDataSourceExists("data.digitalocean_spaces_bucket_objects.yesh"),
 					resource.TestCheckResourceAttr("data.digitalocean_spaces_bucket_objects.yesh", "keys.#", "2"),
@@ -159,10 +158,10 @@ func testAccCheckDigitalOceanSpacesObjectsDataSourceExists(addr string) resource
 	}
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigResources(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "objects_bucket" {
-  name          = "tf-acc-objects-test-bucket-%d"
+  name          = "%s"
   region        = "nyc3"
   force_destroy = true
 }
@@ -215,10 +214,10 @@ resource "digitalocean_spaces_bucket_object" "object7" {
   key     = "arch/rubicon"
   content = "Devils Garden"
 }
-`, randInt)
+`, name)
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigBasic(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigBasic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -228,10 +227,10 @@ data "digitalocean_spaces_bucket_objects" "yesh" {
   prefix    = "arch/navajo/"
   delimiter = "/"
 }
-`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(randInt))
+`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name))
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigAll(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigAll(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -239,10 +238,10 @@ data "digitalocean_spaces_bucket_objects" "yesh" {
   bucket = digitalocean_spaces_bucket.objects_bucket.name
   region = digitalocean_spaces_bucket.objects_bucket.region
 }
-`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(randInt))
+`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name))
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigPrefixes(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigPrefixes(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -252,10 +251,10 @@ data "digitalocean_spaces_bucket_objects" "yesh" {
   prefix    = "arch/"
   delimiter = "/"
 }
-`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(randInt))
+`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name))
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigExtraResource(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigExtraResource(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -265,10 +264,10 @@ resource "digitalocean_spaces_bucket_object" "object8" {
   key     = "arch/ru b ic on"
   content = "Goose Island"
 }
-`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(randInt))
+`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name))
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigEncoded(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigEncoded(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -278,10 +277,10 @@ data "digitalocean_spaces_bucket_objects" "yesh" {
   encoding_type = "url"
   prefix        = "arch/ru"
 }
-`, testAccDataSourceDigitalOceanSpacesObjectsConfigExtraResource(randInt))
+`, testAccDataSourceDigitalOceanSpacesObjectsConfigExtraResource(name))
 }
 
-func testAccDataSourceDigitalOceanSpacesObjectsConfigMaxKeys(randInt int) string {
+func testAccDataSourceDigitalOceanSpacesObjectsConfigMaxKeys(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -290,5 +289,5 @@ data "digitalocean_spaces_bucket_objects" "yesh" {
   region   = digitalocean_spaces_bucket.objects_bucket.region
   max_keys = 2
 }
-`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(randInt))
+`, testAccDataSourceDigitalOceanSpacesObjectsConfigResources(name))
 }

--- a/digitalocean/spaces/datasource_spaces_bucket_test.go
+++ b/digitalocean/spaces/datasource_spaces_bucket_test.go
@@ -7,13 +7,11 @@ import (
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanSpacesBucket_Basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	bucketName := testAccBucketName(rInt)
+	bucketName := acceptance.RandomTestName()
 	bucketRegion := "nyc3"
 
 	resourceConfig := fmt.Sprintf(`

--- a/digitalocean/spaces/datasource_spaces_buckets_test.go
+++ b/digitalocean/spaces/datasource_spaces_buckets_test.go
@@ -6,15 +6,14 @@ import (
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDigitalOceanSpacesBuckets_Basic(t *testing.T) {
-	bucketName1 := testAccBucketName(acctest.RandInt())
+	bucketName1 := acceptance.RandomTestName()
 	bucketRegion1 := "nyc3"
 
-	bucketName2 := testAccBucketName(acctest.RandInt())
+	bucketName2 := acceptance.RandomTestName()
 	bucketRegion2 := "ams3"
 
 	bucketsConfig := fmt.Sprintf(`

--- a/digitalocean/spaces/import_spaces_bucket_policy_test.go
+++ b/digitalocean/spaces/import_spaces_bucket_policy_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanBucketPolicy_importBasic(t *testing.T) {
 	resourceName := "digitalocean_spaces_bucket_policy.policy"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	bucketPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Resource":"*"}]}`
 
@@ -22,7 +21,7 @@ func TestAccDigitalOceanBucketPolicy_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketPolicy(rInt, bucketPolicy),
+				Config: testAccDigitalOceanSpacesBucketPolicy(name, bucketPolicy),
 			},
 
 			{

--- a/digitalocean/spaces/import_spaces_bucket_test.go
+++ b/digitalocean/spaces/import_spaces_bucket_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDigitalOceanBucket_importBasic(t *testing.T) {
 	resourceName := "digitalocean_spaces_bucket.bucket"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,14 +19,14 @@ func TestAccDigitalOceanBucket_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanBucketConfigImport(rInt),
+				Config: testAccDigitalOceanBucketConfigImport(name),
 			},
 
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateIdPrefix:     fmt.Sprintf("%s,", "sfo2"),
+				ImportStateIdPrefix:     fmt.Sprintf("%s,", "sfo3"),
 				ImportStateVerifyIgnore: []string{"acl", "force_destroy"},
 			},
 			// Test importing non-existent resource provides expected error.
@@ -35,7 +34,7 @@ func TestAccDigitalOceanBucket_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: false,
-				ImportStateId:     "sfo2,nonexistent-bucket",
+				ImportStateId:     "sfo3,nonexistent-bucket",
 				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
 			{

--- a/digitalocean/spaces/resource_spaces_bucket.go
+++ b/digitalocean/spaces/resource_spaces_bucket.go
@@ -496,48 +496,8 @@ func resourceDigitalOceanBucketDelete(ctx context.Context, d *schema.ResourceDat
 			if d.Get("force_destroy").(bool) {
 				// bucket may have things delete them
 				log.Printf("[DEBUG] Spaces Bucket attempting to forceDestroy %+v", err)
-
 				bucket := d.Get("name").(string)
-				resp, err := svc.ListObjectVersions(
-					&s3.ListObjectVersionsInput{
-						Bucket: aws.String(bucket),
-					},
-				)
-
-				if err != nil {
-					return diag.Errorf("Error Spaces Bucket list Object Versions err: %s", err)
-				}
-
-				objectsToDelete := make([]*s3.ObjectIdentifier, 0)
-
-				if len(resp.DeleteMarkers) != 0 {
-
-					for _, v := range resp.DeleteMarkers {
-						objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
-							Key:       v.Key,
-							VersionId: v.VersionId,
-						})
-					}
-				}
-
-				if len(resp.Versions) != 0 {
-					for _, v := range resp.Versions {
-						objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
-							Key:       v.Key,
-							VersionId: v.VersionId,
-						})
-					}
-				}
-
-				params := &s3.DeleteObjectsInput{
-					Bucket: aws.String(bucket),
-					Delete: &s3.Delete{
-						Objects: objectsToDelete,
-					},
-				}
-
-				_, err = svc.DeleteObjects(params)
-
+				err := spacesBucketForceDelete(svc, bucket)
 				if err != nil {
 					return diag.Errorf("Error Spaces Bucket force_destroy error deleting: %s", err)
 				}

--- a/digitalocean/spaces/resource_spaces_bucket_object_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_object_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -48,7 +47,7 @@ func TestAccDigitalOceanSpacesBucketObject_noNameNoKey(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_empty(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -57,7 +56,7 @@ func TestAccDigitalOceanSpacesBucketObject_empty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {},
-				Config:    testAccDigitalOceanSpacesBucketObjectConfigEmpty(rInt),
+				Config:    testAccDigitalOceanSpacesBucketObjectConfigEmpty(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&obj, ""),
@@ -70,7 +69,7 @@ func TestAccDigitalOceanSpacesBucketObject_empty(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_source(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	source := testAccDigitalOceanSpacesBucketObjectCreateTempFile(t, "{anything will do }")
 	defer os.Remove(source)
@@ -81,7 +80,7 @@ func TestAccDigitalOceanSpacesBucketObject_source(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfigSource(rInt, source),
+				Config: testAccDigitalOceanSpacesBucketObjectConfigSource(name, source),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&obj, "{anything will do }"),
@@ -94,7 +93,7 @@ func TestAccDigitalOceanSpacesBucketObject_source(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_content(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -103,7 +102,7 @@ func TestAccDigitalOceanSpacesBucketObject_content(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {},
-				Config:    testAccDigitalOceanSpacesBucketObjectConfigContent(rInt, "some_bucket_content"),
+				Config:    testAccDigitalOceanSpacesBucketObjectConfigContent(name, "some_bucket_content"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&obj, "some_bucket_content"),
@@ -116,7 +115,7 @@ func TestAccDigitalOceanSpacesBucketObject_content(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_contentBase64(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -125,7 +124,7 @@ func TestAccDigitalOceanSpacesBucketObject_contentBase64(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {},
-				Config:    testAccDigitalOceanSpacesBucketObjectConfigContentBase64(rInt, base64.StdEncoding.EncodeToString([]byte("some_bucket_content"))),
+				Config:    testAccDigitalOceanSpacesBucketObjectConfigContentBase64(name, base64.StdEncoding.EncodeToString([]byte("some_bucket_content"))),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&obj, "some_bucket_content"),
@@ -138,7 +137,7 @@ func TestAccDigitalOceanSpacesBucketObject_contentBase64(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_withContentCharacteristics(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	source := testAccDigitalOceanSpacesBucketObjectCreateTempFile(t, "{anything will do }")
 	defer os.Remove(source)
@@ -149,7 +148,7 @@ func TestAccDigitalOceanSpacesBucketObject_withContentCharacteristics(t *testing
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_withContentCharacteristics(rInt, source),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_withContentCharacteristics(name, source),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&obj, "{anything will do }"),
@@ -167,6 +166,7 @@ func TestAccDigitalOceanSpacesBucketObject_NonVersioned(t *testing.T) {
 
 	var originalObj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -174,7 +174,7 @@ func TestAccDigitalOceanSpacesBucketObject_NonVersioned(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_NonVersioned(acctest.RandInt(), sourceInitial),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_NonVersioned(name, sourceInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &originalObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&originalObj, "initial object state"),
@@ -188,7 +188,7 @@ func TestAccDigitalOceanSpacesBucketObject_NonVersioned(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_updates(t *testing.T) {
 	var originalObj, modifiedObj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	sourceInitial := testAccDigitalOceanSpacesBucketObjectCreateTempFile(t, "initial object state")
 	defer os.Remove(sourceInitial)
@@ -201,7 +201,7 @@ func TestAccDigitalOceanSpacesBucketObject_updates(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(rInt, false, sourceInitial),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(name, false, sourceInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &originalObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&originalObj, "initial object state"),
@@ -209,7 +209,7 @@ func TestAccDigitalOceanSpacesBucketObject_updates(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(rInt, false, sourceModified),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(name, false, sourceModified),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &modifiedObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&modifiedObj, "modified object"),
@@ -223,7 +223,7 @@ func TestAccDigitalOceanSpacesBucketObject_updates(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_updateSameFile(t *testing.T) {
 	var originalObj, modifiedObj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	startingData := "lane 8"
 	changingData := "chicane"
@@ -245,7 +245,7 @@ func TestAccDigitalOceanSpacesBucketObject_updateSameFile(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(rInt, false, filename),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(name, false, filename),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &originalObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&originalObj, startingData),
@@ -255,7 +255,7 @@ func TestAccDigitalOceanSpacesBucketObject_updateSameFile(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(rInt, false, filename),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(name, false, filename),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &modifiedObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&modifiedObj, changingData),
@@ -269,7 +269,7 @@ func TestAccDigitalOceanSpacesBucketObject_updateSameFile(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning(t *testing.T) {
 	var originalObj, modifiedObj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	sourceInitial := testAccDigitalOceanSpacesBucketObjectCreateTempFile(t, "initial versioned object state")
 	defer os.Remove(sourceInitial)
@@ -282,7 +282,7 @@ func TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(rInt, true, sourceInitial),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(name, true, sourceInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &originalObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&originalObj, "initial versioned object state"),
@@ -290,7 +290,7 @@ func TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(rInt, true, sourceModified),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_updateable(name, true, sourceModified),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &modifiedObj),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&modifiedObj, "modified versioned object"),
@@ -305,7 +305,7 @@ func TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning(t *testing.T) {
 func TestAccDigitalOceanSpacesBucketObject_acl(t *testing.T) {
 	var obj1, obj2, obj3 s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -313,7 +313,7 @@ func TestAccDigitalOceanSpacesBucketObject_acl(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_acl(rInt, "some_bucket_content", "private"),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_acl(name, "some_bucket_content", "private"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj1),
 					testAccCheckDigitalOceanSpacesBucketObjectBody(&obj1, "some_bucket_content"),
@@ -322,7 +322,7 @@ func TestAccDigitalOceanSpacesBucketObject_acl(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_acl(rInt, "some_bucket_content", "public-read"),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_acl(name, "some_bucket_content", "public-read"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj2),
 					testAccCheckDigitalOceanSpacesBucketObjectVersionIdEquals(&obj2, &obj1),
@@ -332,7 +332,7 @@ func TestAccDigitalOceanSpacesBucketObject_acl(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_acl(rInt, "changed_some_bucket_content", "private"),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_acl(name, "changed_some_bucket_content", "private"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj3),
 					testAccCheckDigitalOceanSpacesBucketObjectVersionIdDiffers(&obj3, &obj2),
@@ -346,7 +346,7 @@ func TestAccDigitalOceanSpacesBucketObject_acl(t *testing.T) {
 }
 
 func TestAccDigitalOceanSpacesBucketObject_metadata(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	var obj s3.GetObjectOutput
 	resourceName := "digitalocean_spaces_bucket_object.object"
 
@@ -356,7 +356,7 @@ func TestAccDigitalOceanSpacesBucketObject_metadata(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(rInt, "key1", "value1", "key2", "value2"),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(name, "key1", "value1", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "metadata.%", "2"),
@@ -365,7 +365,7 @@ func TestAccDigitalOceanSpacesBucketObject_metadata(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(rInt, "key1", "value1updated", "key3", "value3"),
+				Config: testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(name, "key1", "value1updated", "key3", "value3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "metadata.%", "2"),
@@ -374,7 +374,7 @@ func TestAccDigitalOceanSpacesBucketObject_metadata(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketObjectConfigEmpty(rInt),
+				Config: testAccDigitalOceanSpacesBucketObjectConfigEmpty(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketObjectExists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "metadata.%", "0"),
@@ -589,11 +589,11 @@ resource "digitalocean_spaces_bucket_object" "object" {
 `, testAccDigitalOceanSpacesBucketObject_TestRegion, bucket, key)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfigEmpty(randInt int) string {
+func testAccDigitalOceanSpacesBucketObjectConfigEmpty(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -602,14 +602,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   bucket = digitalocean_spaces_bucket.object_bucket.name
   key    = "test-key"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfigSource(randInt int, source string) string {
+func testAccDigitalOceanSpacesBucketObjectConfigSource(name string, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -620,14 +620,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   source       = "%s"
   content_type = "binary/octet-stream"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, source)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, source)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfig_withContentCharacteristics(randInt int, source string) string {
+func testAccDigitalOceanSpacesBucketObjectConfig_withContentCharacteristics(name string, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -640,14 +640,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   content_type     = "binary/octet-stream"
   website_redirect = "http://google.com"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, source)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, source)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfigContent(randInt int, content string) string {
+func testAccDigitalOceanSpacesBucketObjectConfigContent(name string, content string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -657,14 +657,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   key     = "test-key"
   content = "%s"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, content)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, content)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfigContentBase64(randInt int, contentBase64 string) string {
+func testAccDigitalOceanSpacesBucketObjectConfigContentBase64(name string, contentBase64 string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -674,14 +674,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   key            = "test-key"
   content_base64 = "%s"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, contentBase64)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, contentBase64)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfig_updateable(randInt int, bucketVersioning bool, source string) string {
+func testAccDigitalOceanSpacesBucketObjectConfig_updateable(name string, bucketVersioning bool, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket_3" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 
   versioning {
@@ -696,14 +696,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   source = "%s"
   etag   = "${filemd5("%s")}"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, bucketVersioning, source, source)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, bucketVersioning, source, source)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfig_acl(randInt int, content, acl string) string {
+func testAccDigitalOceanSpacesBucketObjectConfig_acl(name string, content, acl string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 
   versioning {
@@ -718,14 +718,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
   content = "%s"
   acl     = "%s"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, content, acl)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, content, acl)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(randInt int, metadataKey1, metadataValue1, metadataKey2, metadataValue2 string) string {
+func testAccDigitalOceanSpacesBucketObjectConfig_withMetadata(name string, metadataKey1, metadataValue1, metadataKey2, metadataValue2 string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -739,14 +739,14 @@ resource "digitalocean_spaces_bucket_object" "object" {
     %[5]s = %[6]q
   }
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, metadataKey1, metadataValue1, metadataKey2, metadataValue2)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, metadataKey1, metadataValue1, metadataKey2, metadataValue2)
 }
 
-func testAccDigitalOceanSpacesBucketObjectConfig_NonVersioned(randInt int, source string) string {
+func testAccDigitalOceanSpacesBucketObjectConfig_NonVersioned(name string, source string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "object_bucket_3" {
   region        = "%s"
-  name          = "tf-object-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -757,5 +757,5 @@ resource "digitalocean_spaces_bucket_object" "object" {
   source = "%s"
   etag   = "${filemd5("%s")}"
 }
-`, testAccDigitalOceanSpacesBucketObject_TestRegion, randInt, source, source)
+`, testAccDigitalOceanSpacesBucketObject_TestRegion, name, source, source)
 }

--- a/digitalocean/spaces/resource_spaces_bucket_policy_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_policy_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -21,7 +20,7 @@ const (
 )
 
 func TestAccDigitalOceanBucketPolicy_basic(t *testing.T) {
-	randInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	bucketPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Resource":"*"}]}`
 
@@ -31,7 +30,7 @@ func TestAccDigitalOceanBucketPolicy_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketPolicy(randInt, bucketPolicy),
+				Config: testAccDigitalOceanSpacesBucketPolicy(name, bucketPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketPolicy("digitalocean_spaces_bucket_policy.policy", bucketPolicy),
 					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_policy.policy", "region", testAccDigitalOceanSpacesBucketPolicy_TestRegion),
@@ -42,7 +41,7 @@ func TestAccDigitalOceanBucketPolicy_basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucketPolicy_update(t *testing.T) {
-	randInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	initialBucketPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Resource":"*"}]}`
 	updatedBucketPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Resource":"*"},{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"*"}]}`
@@ -53,14 +52,14 @@ func TestAccDigitalOceanBucketPolicy_update(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketPolicy(randInt, initialBucketPolicy),
+				Config: testAccDigitalOceanSpacesBucketPolicy(name, initialBucketPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketPolicy("digitalocean_spaces_bucket_policy.policy", initialBucketPolicy),
 					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_policy.policy", "region", testAccDigitalOceanSpacesBucketPolicy_TestRegion),
 				),
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketPolicy(randInt, updatedBucketPolicy),
+				Config: testAccDigitalOceanSpacesBucketPolicy(name, updatedBucketPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSpacesBucketPolicy("digitalocean_spaces_bucket_policy.policy", updatedBucketPolicy),
 					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_policy.policy", "region", testAccDigitalOceanSpacesBucketPolicy_TestRegion),
@@ -71,7 +70,7 @@ func TestAccDigitalOceanBucketPolicy_update(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucketPolicy_invalidJson(t *testing.T) {
-	randInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	bucketPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Resource":"*"}}`
 	expectError := regexp.MustCompile(`"policy" contains an invalid JSON`)
@@ -82,7 +81,7 @@ func TestAccDigitalOceanBucketPolicy_invalidJson(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDigitalOceanSpacesBucketPolicy(randInt, bucketPolicy),
+				Config:      testAccDigitalOceanSpacesBucketPolicy(name, bucketPolicy),
 				ExpectError: expectError,
 			},
 		},
@@ -90,7 +89,7 @@ func TestAccDigitalOceanBucketPolicy_invalidJson(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucketPolicy_emptyPolicy(t *testing.T) {
-	randInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	expectError := regexp.MustCompile(`policy must not be empty`)
 
@@ -100,7 +99,7 @@ func TestAccDigitalOceanBucketPolicy_emptyPolicy(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDigitalOceanSpacesBucketEmptyPolicy(randInt),
+				Config:      testAccDigitalOceanSpacesBucketEmptyPolicy(name),
 				ExpectError: expectError,
 			},
 		},
@@ -199,11 +198,11 @@ func testAccCheckDigitalOceanSpacesBucketPolicyDestroy(s *terraform.State) error
 	return nil
 }
 
-func testAccDigitalOceanSpacesBucketPolicy(randInt int, policy string) string {
+func testAccDigitalOceanSpacesBucketPolicy(name string, policy string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "policy_bucket" {
   region        = "%s"
-  name          = "tf-policy-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -216,14 +215,14 @@ EOF
 }
 
 
-`, testAccDigitalOceanSpacesBucketPolicy_TestRegion, randInt, policy)
+`, testAccDigitalOceanSpacesBucketPolicy_TestRegion, name, policy)
 }
 
-func testAccDigitalOceanSpacesBucketEmptyPolicy(randInt int) string {
+func testAccDigitalOceanSpacesBucketEmptyPolicy(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "policy_bucket" {
   region        = "%s"
-  name          = "tf-policy-test-bucket-%d"
+  name          = "%s"
   force_destroy = true
 }
 
@@ -234,7 +233,7 @@ resource "digitalocean_spaces_bucket_policy" "policy" {
 }
 
 
-`, testAccDigitalOceanSpacesBucketPolicy_TestRegion, randInt)
+`, testAccDigitalOceanSpacesBucketPolicy_TestRegion, name)
 }
 
 func testAccDigitalOceanSpacesBucketUnknownBucket() string {

--- a/digitalocean/spaces/resource_spaces_bucket_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_test.go
@@ -13,17 +13,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDigitalOceanBucket_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-
 	expectedRegion := "ams3"
-	expectedBucketName := testAccBucketName(rInt)
+	expectedBucketName := acceptance.RandomTestName()
 	expectBucketURN := fmt.Sprintf("do:space:%s", expectedBucketName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,7 +33,7 @@ func TestAccDigitalOceanBucket_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanBucketConfig(rInt),
+				Config: testAccDigitalOceanBucketConfig(expectedBucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists("digitalocean_spaces_bucket.bucket"),
 					resource.TestCheckResourceAttr(
@@ -51,7 +48,7 @@ func TestAccDigitalOceanBucket_basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucket_region(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -59,7 +56,7 @@ func TestAccDigitalOceanBucket_region(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanBucketConfigWithRegion(rInt),
+				Config: testAccDigitalOceanBucketConfigWithRegion(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists("digitalocean_spaces_bucket.bucket"),
 					resource.TestCheckResourceAttr("digitalocean_spaces_bucket.bucket", "region", "ams3"),
@@ -70,9 +67,9 @@ func TestAccDigitalOceanBucket_region(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucket_UpdateAcl(t *testing.T) {
-	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithACL, ri)
-	postConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithACLUpdate, ri)
+	name := acceptance.RandomTestName()
+	preConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithACL, name)
+	postConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithACLUpdate, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -100,9 +97,9 @@ func TestAccDigitalOceanBucket_UpdateAcl(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucket_UpdateCors(t *testing.T) {
-	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithCORS, ri)
-	postConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithCORSUpdate, ri)
+	name := acceptance.RandomTestName()
+	preConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithCORS, name)
+	postConfig := fmt.Sprintf(testAccDigitalOceanBucketConfigWithCORSUpdate, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -139,7 +136,7 @@ func TestAccDigitalOceanBucket_UpdateCors(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucket_WithCors(t *testing.T) {
-	ri := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -147,7 +144,7 @@ func TestAccDigitalOceanBucket_WithCors(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccDigitalOceanBucketConfigWithCORSUpdate, ri),
+				Config: fmt.Sprintf(testAccDigitalOceanBucketConfigWithCORSUpdate, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists("digitalocean_spaces_bucket.bucket"),
 					testAccCheckDigitalOceanBucketCors(
@@ -168,7 +165,7 @@ func TestAccDigitalOceanBucket_WithCors(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucket_WithMultipleCorsRules(t *testing.T) {
-	ri := acctest.RandInt()
+	name := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -176,7 +173,7 @@ func TestAccDigitalOceanBucket_WithMultipleCorsRules(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccDigitalOceanBucketConfigWithMultiCORS, ri),
+				Config: fmt.Sprintf(testAccDigitalOceanBucketConfigWithMultiCORS, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists("digitalocean_spaces_bucket.bucket"),
 					testAccCheckDigitalOceanBucketCors(
@@ -206,14 +203,14 @@ func TestAccDigitalOceanBucket_WithMultipleCorsRules(t *testing.T) {
 // not empty" error in Terraform, to check against regresssions.
 // See https://github.com/hashicorp/terraform/pull/2925
 func TestAccDigitalOceanBucket_shouldFailNotFound(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanBucketDestroyedConfig(rInt),
+				Config: testAccDigitalOceanBucketDestroyedConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists("digitalocean_spaces_bucket.bucket"),
 					testAccCheckDigitalOceanDestroyBucket("digitalocean_spaces_bucket.bucket"),
@@ -225,7 +222,7 @@ func TestAccDigitalOceanBucket_shouldFailNotFound(t *testing.T) {
 }
 
 func TestAccDigitalOceanBucket_Versioning(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	resourceName := "digitalocean_spaces_bucket.bucket"
 
 	makeConfig := func(includeClause, versioning bool) string {
@@ -239,11 +236,11 @@ func TestAccDigitalOceanBucket_Versioning(t *testing.T) {
 		}
 		return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
+  name   = "%s"
   region = "ams3"
 %s
 }
-`, rInt, versioningClause)
+`, name, versioningClause)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -301,7 +298,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 }
 
 func TestAccDigitalOceanSpacesBucket_LifecycleBasic(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	resourceName := "digitalocean_spaces_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -310,7 +307,7 @@ func TestAccDigitalOceanSpacesBucket_LifecycleBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketConfigWithLifecycle(rInt),
+				Config: testAccDigitalOceanSpacesBucketConfigWithLifecycle(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 					resource.TestCheckResourceAttr(
@@ -344,13 +341,13 @@ func TestAccDigitalOceanSpacesBucket_LifecycleBasic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("ams3,tf-test-bucket-%d", rInt),
+				ImportStateId:     fmt.Sprintf("ams3,%s", name),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_destroy", "acl"},
 			},
 			{
-				Config: testAccDigitalOceanSpacesBucketConfigWithVersioningLifecycle(rInt),
+				Config: testAccDigitalOceanSpacesBucketConfigWithVersioningLifecycle(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 					resource.TestCheckResourceAttr(
@@ -370,7 +367,7 @@ func TestAccDigitalOceanSpacesBucket_LifecycleBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanBucketConfig(rInt),
+				Config: testAccDigitalOceanBucketConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 				),
@@ -380,7 +377,7 @@ func TestAccDigitalOceanSpacesBucket_LifecycleBasic(t *testing.T) {
 }
 
 func TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly(t *testing.T) {
-	rInt := acctest.RandInt()
+	name := acceptance.RandomTestName()
 	resourceName := "digitalocean_spaces_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -389,7 +386,7 @@ func TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanSpacesBucketConfigWithLifecycleExpireMarker(rInt),
+				Config: testAccDigitalOceanSpacesBucketConfigWithLifecycleExpireMarker(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 					resource.TestCheckResourceAttr(
@@ -408,13 +405,13 @@ func TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("ams3,tf-test-bucket-%d", rInt),
+				ImportStateId:     fmt.Sprintf("ams3,%s", name),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_destroy", "acl"},
 			},
 			{
-				Config: testAccDigitalOceanBucketConfig(rInt),
+				Config: testAccDigitalOceanBucketConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 				),
@@ -433,9 +430,9 @@ func TestAccDigitalOceanSpacesBucket_RegionError(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket"
+  name   = "%s"
   region = "%s"
-}`, badRegion),
+}`, acceptance.RandomTestName(), badRegion),
 				ExpectError: regexp.MustCompile(`expected region to be one of`),
 			},
 		},
@@ -631,71 +628,66 @@ func testAccCheckDigitalOceanBucketVersioning(n string, versioningStatus string)
 	}
 }
 
-// These need a bit of randomness as the name can only be used once globally
-func testAccBucketName(randInt int) string {
-	return fmt.Sprintf("tf-test-bucket-%d", randInt)
-}
-
-func testAccDigitalOceanBucketConfig(randInt int) string {
+func testAccDigitalOceanBucketConfig(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
+  name   = "%s"
   acl    = "public-read"
   region = "ams3"
 }
-`, randInt)
+`, name)
 }
 
-func testAccDigitalOceanBucketDestroyedConfig(randInt int) string {
+func testAccDigitalOceanBucketDestroyedConfig(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name = "%s"
   acl  = "public-read"
 }
-`, randInt)
+`, name)
 }
 
-func testAccDigitalOceanBucketConfigWithRegion(randInt int) string {
+func testAccDigitalOceanBucketConfigWithRegion(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
+  name   = "%s"
   region = "ams3"
 }
-`, randInt)
+`, name)
 }
 
-func testAccDigitalOceanBucketConfigImport(randInt int) string {
+func testAccDigitalOceanBucketConfigImport(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
-  region = "sfo2"
+  name   = "%s"
+  region = "sfo3"
 }
-`, randInt)
+`, name)
 }
 
 var testAccDigitalOceanBucketConfigWithACL = `
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name = "%s"
   acl  = "public-read"
 }
 `
 
 var testAccDigitalOceanBucketConfigWithACLUpdate = `
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name = "%s"
   acl  = "private"
 }
 `
 
 var testAccDigitalOceanBucketConfigWithCORS = `
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name = "%s"
 }
 `
 
 var testAccDigitalOceanBucketConfigWithCORSUpdate = `
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name = "%s"
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT", "POST"]
@@ -707,7 +699,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 
 var testAccDigitalOceanBucketConfigWithMultiCORS = `
 resource "digitalocean_spaces_bucket" "bucket" {
-  name = "tf-test-bucket-%d"
+  name = "%s"
 
   cors_rule {
     allowed_headers = ["*"]
@@ -725,10 +717,10 @@ resource "digitalocean_spaces_bucket" "bucket" {
 }
 `
 
-func testAccDigitalOceanSpacesBucketConfigWithLifecycle(randInt int) string {
+func testAccDigitalOceanSpacesBucketConfigWithLifecycle(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
+  name   = "%s"
   acl    = "private"
   region = "ams3"
 
@@ -760,13 +752,13 @@ resource "digitalocean_spaces_bucket" "bucket" {
     abort_incomplete_multipart_upload_days = 30
   }
 }
-`, randInt)
+`, name)
 }
 
-func testAccDigitalOceanSpacesBucketConfigWithLifecycleExpireMarker(randInt int) string {
+func testAccDigitalOceanSpacesBucketConfigWithLifecycleExpireMarker(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
+  name   = "%s"
   acl    = "private"
   region = "ams3"
 
@@ -780,13 +772,13 @@ resource "digitalocean_spaces_bucket" "bucket" {
     }
   }
 }
-`, randInt)
+`, name)
 }
 
-func testAccDigitalOceanSpacesBucketConfigWithVersioningLifecycle(randInt int) string {
+func testAccDigitalOceanSpacesBucketConfigWithVersioningLifecycle(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-  name   = "tf-test-bucket-%d"
+  name   = "%s"
   acl    = "private"
   region = "ams3"
 
@@ -814,5 +806,5 @@ resource "digitalocean_spaces_bucket" "bucket" {
     }
   }
 }
-`, randInt)
+`, name)
 }

--- a/digitalocean/spaces/sweep.go
+++ b/digitalocean/spaces/sweep.go
@@ -1,0 +1,64 @@
+package spaces
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sweep"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("digitalocean_spaces_bucket", &resource.Sweeper{
+		Name: "digitalocean_spaces_bucket",
+		F:    sweepSpaces,
+	})
+
+}
+
+func sweepSpaces(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range SpacesRegions {
+		client, err := meta.(*config.CombinedConfig).SpacesClient(r)
+		if err != nil {
+			return fmt.Errorf("Error building Spaces client: %s", err)
+		}
+
+		svc := s3.New(client)
+
+		buckets, err := getSpacesBucketsInRegion(meta, r)
+		if err != nil {
+			return err
+		}
+
+		for _, b := range buckets {
+			if strings.HasPrefix(*b.Name, sweep.TestNamePrefix) {
+				log.Printf("[DEBUG] Destroying Spaces bucket %s in %s", *b.Name, r)
+
+				_, err = svc.DeleteBucket(&s3.DeleteBucketInput{
+					Bucket: b.Name,
+				})
+				if err != nil {
+					if IsAWSErr(err, "BucketNotEmpty", "") {
+						log.Printf("[DEBUG] Deleting objects in Spaces bucket %s in %s", *b.Name, r)
+						err := spacesBucketForceDelete(svc, *b.Name)
+						if err != nil {
+							return err
+						}
+					} else {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/digitalocean/sweep/sweep.go
+++ b/digitalocean/sweep/sweep.go
@@ -2,6 +2,7 @@ package sweep
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
@@ -24,10 +25,22 @@ func SharedConfigForRegion(region string) (interface{}, error) {
 		spacesEndpoint = "https://{{.Region}}.digitaloceanspaces.com"
 	}
 
+	spacesAccessKeyID := os.Getenv("SPACES_ACCESS_KEY_ID")
+	if spacesAccessKeyID == "" {
+		log.Println("[DEBUG] SPACES_ACCESS_KEY_ID not set")
+	}
+
+	spacesSecretAccessKey := os.Getenv("SPACES_SECRET_ACCESS_KEY")
+	if spacesSecretAccessKey == "" {
+		log.Println("[DEBUG] SPACES_SECRET_ACCESS_KEY not set")
+	}
+
 	conf := config.Config{
 		Token:             os.Getenv("DIGITALOCEAN_TOKEN"),
 		APIEndpoint:       apiEndpoint,
 		SpacesAPIEndpoint: spacesEndpoint,
+		AccessID:          spacesAccessKeyID,
+		SecretKey:         spacesSecretAccessKey,
 	}
 
 	// configures a default client for the region, using the above env vars

--- a/digitalocean/sweep/sweep_test.go
+++ b/digitalocean/sweep/sweep_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/reservedip"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/snapshot"
+	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sshkey"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/volume"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/vpc"


### PR DESCRIPTION
```
$ make testacc PKG_NAME=digitalocean/spaces TESTARGS="-count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/spaces/... -count=1 -timeout 120m -parallel=10
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObject_basic
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObject_basic
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObject_readableBody
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObject_readableBody
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObject_allParams
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObject_allParams
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObject_LeadingSlash
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObject_LeadingSlash
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObject_MultipleSlashes
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObject_MultipleSlashes
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObject_RegionError
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObject_RegionError
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObjects_basic
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObjects_basic
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObjects_all
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObjects_all
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded
=== RUN   TestAccDataSourceDigitalOceanSpacesBucketObjects_maxKeys
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucketObjects_maxKeys
=== RUN   TestAccDataSourceDigitalOceanSpacesBucket_Basic
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucket_Basic
=== RUN   TestAccDataSourceDigitalOceanSpacesBucket_NotFound
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucket_NotFound
=== RUN   TestAccDataSourceDigitalOceanSpacesBucket_RegionError
=== PAUSE TestAccDataSourceDigitalOceanSpacesBucket_RegionError
=== RUN   TestAccDataSourceDigitalOceanSpacesBuckets_Basic
=== PAUSE TestAccDataSourceDigitalOceanSpacesBuckets_Basic
=== RUN   TestAccDigitalOceanBucketPolicy_importBasic
=== PAUSE TestAccDigitalOceanBucketPolicy_importBasic
=== RUN   TestAccDigitalOceanBucket_importBasic
=== PAUSE TestAccDigitalOceanBucket_importBasic
=== RUN   TestAccDigitalOceanSpacesBucketObject_noNameNoKey
=== PAUSE TestAccDigitalOceanSpacesBucketObject_noNameNoKey
=== RUN   TestAccDigitalOceanSpacesBucketObject_empty
=== PAUSE TestAccDigitalOceanSpacesBucketObject_empty
=== RUN   TestAccDigitalOceanSpacesBucketObject_source
=== PAUSE TestAccDigitalOceanSpacesBucketObject_source
=== RUN   TestAccDigitalOceanSpacesBucketObject_content
=== PAUSE TestAccDigitalOceanSpacesBucketObject_content
=== RUN   TestAccDigitalOceanSpacesBucketObject_contentBase64
=== PAUSE TestAccDigitalOceanSpacesBucketObject_contentBase64
=== RUN   TestAccDigitalOceanSpacesBucketObject_withContentCharacteristics
=== PAUSE TestAccDigitalOceanSpacesBucketObject_withContentCharacteristics
=== RUN   TestAccDigitalOceanSpacesBucketObject_NonVersioned
=== PAUSE TestAccDigitalOceanSpacesBucketObject_NonVersioned
=== RUN   TestAccDigitalOceanSpacesBucketObject_updates
=== PAUSE TestAccDigitalOceanSpacesBucketObject_updates
=== RUN   TestAccDigitalOceanSpacesBucketObject_updateSameFile
=== PAUSE TestAccDigitalOceanSpacesBucketObject_updateSameFile
=== RUN   TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning
=== PAUSE TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning
=== RUN   TestAccDigitalOceanSpacesBucketObject_acl
=== PAUSE TestAccDigitalOceanSpacesBucketObject_acl
=== RUN   TestAccDigitalOceanSpacesBucketObject_metadata
=== PAUSE TestAccDigitalOceanSpacesBucketObject_metadata
=== RUN   TestAccDigitalOceanSpacesBucketObject_RegionError
=== PAUSE TestAccDigitalOceanSpacesBucketObject_RegionError
=== RUN   TestAccDigitalOceanBucketPolicy_basic
=== PAUSE TestAccDigitalOceanBucketPolicy_basic
=== RUN   TestAccDigitalOceanBucketPolicy_update
=== PAUSE TestAccDigitalOceanBucketPolicy_update
=== RUN   TestAccDigitalOceanBucketPolicy_invalidJson
=== PAUSE TestAccDigitalOceanBucketPolicy_invalidJson
=== RUN   TestAccDigitalOceanBucketPolicy_emptyPolicy
=== PAUSE TestAccDigitalOceanBucketPolicy_emptyPolicy
=== RUN   TestAccDigitalOceanBucketPolicy_unknownBucket
=== PAUSE TestAccDigitalOceanBucketPolicy_unknownBucket
=== RUN   TestAccDigitalOceanBucket_basic
=== PAUSE TestAccDigitalOceanBucket_basic
=== RUN   TestAccDigitalOceanBucket_region
=== PAUSE TestAccDigitalOceanBucket_region
=== RUN   TestAccDigitalOceanBucket_UpdateAcl
=== PAUSE TestAccDigitalOceanBucket_UpdateAcl
=== RUN   TestAccDigitalOceanBucket_UpdateCors
=== PAUSE TestAccDigitalOceanBucket_UpdateCors
=== RUN   TestAccDigitalOceanBucket_WithCors
=== PAUSE TestAccDigitalOceanBucket_WithCors
=== RUN   TestAccDigitalOceanBucket_WithMultipleCorsRules
=== PAUSE TestAccDigitalOceanBucket_WithMultipleCorsRules
=== RUN   TestAccDigitalOceanBucket_shouldFailNotFound
=== PAUSE TestAccDigitalOceanBucket_shouldFailNotFound
=== RUN   TestAccDigitalOceanBucket_Versioning
=== PAUSE TestAccDigitalOceanBucket_Versioning
=== RUN   TestAccDigitalOceanSpacesBucket_LifecycleBasic
=== PAUSE TestAccDigitalOceanSpacesBucket_LifecycleBasic
=== RUN   TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly
=== RUN   TestAccDigitalOceanSpacesBucket_RegionError
=== PAUSE TestAccDigitalOceanSpacesBucket_RegionError
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObject_basic
=== CONT  TestAccDigitalOceanBucketPolicy_emptyPolicy
=== CONT  TestAccDataSourceDigitalOceanSpacesBuckets_Basic
=== CONT  TestAccDataSourceDigitalOceanSpacesBucket_RegionError
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObjects_all
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObjects_basic
=== CONT  TestAccDigitalOceanBucketPolicy_invalidJson
=== CONT  TestAccDigitalOceanSpacesBucketObject_noNameNoKey
=== CONT  TestAccDigitalOceanBucket_importBasic
=== CONT  TestAccDigitalOceanBucketPolicy_importBasic
--- PASS: TestAccDataSourceDigitalOceanSpacesBucket_RegionError (0.96s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObject_RegionError
--- PASS: TestAccDigitalOceanBucketPolicy_invalidJson (0.99s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObject_MultipleSlashes
--- PASS: TestAccDigitalOceanSpacesBucketObject_noNameNoKey (1.21s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucket_NotFound
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObject_RegionError (0.38s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucket_Basic
--- PASS: TestAccDataSourceDigitalOceanSpacesBucket_NotFound (0.48s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObject_LeadingSlash
--- PASS: TestAccDigitalOceanBucket_importBasic (24.04s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObjects_maxKeys
--- PASS: TestAccDigitalOceanBucketPolicy_emptyPolicy (29.41s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObject_allParams
--- PASS: TestAccDigitalOceanBucketPolicy_importBasic (31.31s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObject_basic (31.78s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObject_readableBody
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObjects_basic (31.79s)
=== CONT  TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObject_MultipleSlashes (31.02s)
=== CONT  TestAccDigitalOceanBucketPolicy_update
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObjects_all (32.09s)
=== CONT  TestAccDigitalOceanBucketPolicy_basic
--- PASS: TestAccDataSourceDigitalOceanSpacesBucket_Basic (30.92s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_RegionError
--- PASS: TestAccDigitalOceanSpacesBucketObject_RegionError (0.18s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_metadata
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObject_LeadingSlash (39.82s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_acl
--- PASS: TestAccDataSourceDigitalOceanSpacesBuckets_Basic (42.14s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_contentBase64
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObjects_maxKeys (20.37s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_content
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObject_allParams (30.74s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning
--- PASS: TestAccDigitalOceanSpacesBucketObject_contentBase64 (18.75s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_source
--- PASS: TestAccDigitalOceanBucketPolicy_basic (29.17s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_updateSameFile
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObjects_encoded (30.58s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_updates
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObject_readableBody (30.29s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_empty
--- PASS: TestAccDataSourceDigitalOceanSpacesBucketObjects_prefixes (30.42s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_NonVersioned
--- PASS: TestAccDigitalOceanBucketPolicy_update (30.31s)
=== CONT  TestAccDigitalOceanSpacesBucketObject_withContentCharacteristics
--- PASS: TestAccDigitalOceanSpacesBucketObject_metadata (31.72s)
=== CONT  TestAccDigitalOceanBucket_WithMultipleCorsRules
--- PASS: TestAccDigitalOceanSpacesBucketObject_source (18.86s)
=== CONT  TestAccDigitalOceanSpacesBucket_RegionError
--- PASS: TestAccDigitalOceanSpacesBucket_RegionError (0.16s)
=== CONT  TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly
--- PASS: TestAccDigitalOceanSpacesBucketObject_updatesWithVersioning (20.28s)
=== CONT  TestAccDigitalOceanSpacesBucket_LifecycleBasic
--- PASS: TestAccDigitalOceanSpacesBucketObject_empty (18.65s)
=== CONT  TestAccDigitalOceanBucket_Versioning
--- PASS: TestAccDigitalOceanSpacesBucketObject_NonVersioned (18.59s)
=== CONT  TestAccDigitalOceanBucket_shouldFailNotFound
--- PASS: TestAccDigitalOceanSpacesBucketObject_withContentCharacteristics (18.67s)
=== CONT  TestAccDigitalOceanBucket_UpdateAcl
--- PASS: TestAccDigitalOceanSpacesBucketObject_content (38.66s)
=== CONT  TestAccDigitalOceanBucket_WithCors
--- PASS: TestAccDigitalOceanSpacesBucketObject_acl (41.58s)
=== CONT  TestAccDigitalOceanBucket_basic
--- PASS: TestAccDigitalOceanBucket_WithMultipleCorsRules (28.57s)
=== CONT  TestAccDigitalOceanBucket_UpdateCors
--- PASS: TestAccDigitalOceanBucket_WithCors (11.10s)
=== CONT  TestAccDigitalOceanBucket_region
--- PASS: TestAccDigitalOceanSpacesBucketObject_updateSameFile (40.29s)
=== CONT  TestAccDigitalOceanBucketPolicy_unknownBucket
--- PASS: TestAccDigitalOceanBucketPolicy_unknownBucket (0.49s)
--- PASS: TestAccDigitalOceanSpacesBucketObject_updates (40.33s)
--- PASS: TestAccDigitalOceanBucket_shouldFailNotFound (28.04s)
--- PASS: TestAccDigitalOceanBucket_UpdateAcl (29.24s)
--- PASS: TestAccDigitalOceanBucket_UpdateCors (20.10s)
--- PASS: TestAccDigitalOceanBucket_region (21.79s)
--- PASS: TestAccDigitalOceanSpacesBucket_LifecycleExpireMarkerOnly (45.53s)
--- PASS: TestAccDigitalOceanSpacesBucket_LifecycleBasic (47.29s)
--- PASS: TestAccDigitalOceanBucket_Versioning (53.48s)
--- PASS: TestAccDigitalOceanBucket_basic (62.96s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces     146.087s
```