### PR TITLE
cdn: Add test sweeper and retry with backoff.

### DIFF
--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -181,7 +181,6 @@ func testAccCheckDigitalOceanCDNExists(resource string) resource.TestCheckFunc {
 		}
 
 		foundCDN, _, err := client.CDNs.Get(context.Background(), rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}
@@ -224,12 +223,11 @@ resource "digitalocean_cdn" "foobar" {
 func testAccCheckDigitalOceanCDNConfig_CustomDomain(domain string, spaceName string, certName string) string {
 	return fmt.Sprintf(`
 resource "tls_private_key" "example" {
-  algorithm   = "ECDSA"
-  ecdsa_curve = "P384"
+  algorithm   = "RSA"
 }
 
 resource "tls_self_signed_cert" "example" {
-  key_algorithm   = "ECDSA"
+  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.example.private_key_pem
   dns_names       = ["foo.%s"]
   subject {

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -223,7 +223,7 @@ resource "digitalocean_cdn" "foobar" {
 func testAccCheckDigitalOceanCDNConfig_CustomDomain(domain string, spaceName string, certName string) string {
 	return fmt.Sprintf(`
 resource "tls_private_key" "example" {
-  algorithm   = "RSA"
+  algorithm = "RSA"
 }
 
 resource "tls_self_signed_cert" "example" {

--- a/digitalocean/cdn/sweep.go
+++ b/digitalocean/cdn/sweep.go
@@ -1,0 +1,47 @@
+package cdn
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sweep"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("digitalocean_cdn", &resource.Sweeper{
+		Name: "digitalocean_cdn",
+		F:    sweepCDN,
+	})
+
+}
+
+func sweepCDN(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opt := &godo.ListOptions{PerPage: 200}
+	cdns, _, err := client.CDNs.List(context.Background(), opt)
+	if err != nil {
+		return err
+	}
+
+	for _, c := range cdns {
+		if strings.HasPrefix(c.Origin, sweep.TestNamePrefix) {
+			log.Printf("Destroying CDN %s", c.Origin)
+
+			if _, err := client.CDNs.Delete(context.Background(), c.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/digitalocean/sweep/sweep_test.go
+++ b/digitalocean/sweep/sweep_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/app"
+	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/cdn"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/certificate"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/domain"


### PR DESCRIPTION
The CDN API seems to have additional rate limiting applied to it that is stricter than the rest of our API. I also experienced some lag in being able to GET a newly created CDN where it would return 404 for the first few attempts. So this adds a retry with backoff for GETing a CDN. 

It also adds a test sweeper and fixes a test failure cause due to the type of certificate that was used.

```
$ make testacc PKG_NAME=digitalocean/cdn TESTARGS="-count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/cdn/... -count=1 -timeout 120m -parallel=2
=== RUN   TestAccDigitalOceanCDN_Create
=== PAUSE TestAccDigitalOceanCDN_Create
=== RUN   TestAccDigitalOceanCDN_Create_with_TTL
=== PAUSE TestAccDigitalOceanCDN_Create_with_TTL
=== RUN   TestAccDigitalOceanCDN_Create_and_Update
=== PAUSE TestAccDigitalOceanCDN_Create_and_Update
=== RUN   TestAccDigitalOceanCDN_CustomDomain
=== PAUSE TestAccDigitalOceanCDN_CustomDomain
=== CONT  TestAccDigitalOceanCDN_Create
=== CONT  TestAccDigitalOceanCDN_Create_and_Update
--- PASS: TestAccDigitalOceanCDN_Create (70.86s)
=== CONT  TestAccDigitalOceanCDN_CustomDomain
--- PASS: TestAccDigitalOceanCDN_Create_and_Update (88.23s)
=== CONT  TestAccDigitalOceanCDN_Create_with_TTL
--- PASS: TestAccDigitalOceanCDN_Create_with_TTL (55.90s)
--- PASS: TestAccDigitalOceanCDN_CustomDomain (89.31s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/cdn        160.184s
```