### PR TITLE
droplet: Fix acceptance testing

### DIFF
--- a/digitalocean/droplet/datasource_droplet_test.go
+++ b/digitalocean/droplet/datasource_droplet_test.go
@@ -165,20 +165,20 @@ resource "digitalocean_vpc" "foobar" {
 
 resource "digitalocean_droplet" "foo" {
   name     = "%s"
-  size     = "s-1vcpu-1gb"
-  image    = "ubuntu-22-04-x64"
+  size     = "%s"
+  image    = "%s"
   region   = "nyc3"
   ipv6     = true
   vpc_uuid = digitalocean_vpc.foobar.id
-}`, acceptance.RandomTestName(), name)
+}`, acceptance.RandomTestName(), name, defaultSize, defaultImage)
 }
 
 func testAccCheckDataSourceDigitalOceanDropletConfig_basicById(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
-  size   = "s-1vcpu-1gb"
-  image  = "ubuntu-22-04-x64"
+  size   = "%s"
+  image  = "%s"
   region = "nyc3"
   ipv6   = true
 }
@@ -186,7 +186,7 @@ resource "digitalocean_droplet" "foo" {
 data "digitalocean_droplet" "foobar" {
   id = digitalocean_droplet.foo.id
 }
-`, name)
+`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDataSourceDigitalOceanDropletConfig_basicWithTag(tagName string, name string) string {
@@ -197,13 +197,13 @@ resource "digitalocean_tag" "foo" {
 
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
-  size   = "s-1vcpu-1gb"
-  image  = "ubuntu-22-04-x64"
+  size   = "%s"
+  image  = "%s"
   region = "nyc3"
   ipv6   = true
   tags   = [digitalocean_tag.foo.id]
 }
-`, tagName, name)
+`, tagName, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDataSourceDigitalOceanDropletConfig_basicByTag(tagName string, name string) string {
@@ -214,8 +214,8 @@ resource "digitalocean_tag" "foo" {
 
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
-  size   = "s-1vcpu-1gb"
-  image  = "ubuntu-22-04-x64"
+  size   = "%s"
+  image  = "%s"
   region = "nyc3"
   ipv6   = true
   tags   = [digitalocean_tag.foo.id]
@@ -224,5 +224,5 @@ resource "digitalocean_droplet" "foo" {
 data "digitalocean_droplet" "foobar" {
   tag = digitalocean_tag.foo.id
 }
-`, tagName, name)
+`, tagName, name, defaultSize, defaultImage)
 }

--- a/digitalocean/droplet/datasource_droplets_test.go
+++ b/digitalocean/droplet/datasource_droplets_test.go
@@ -15,18 +15,18 @@ func TestAccDataSourceDigitalOceanDroplets_Basic(t *testing.T) {
 	resourcesConfig := fmt.Sprintf(`
 resource "digitalocean_droplet" "foo" {
   name   = "%s"
-  size   = "s-1vcpu-1gb"
-  image  = "ubuntu-22-04-x64"
+  size   = "%s"
+  image  = "%s"
   region = "nyc3"
 }
 
 resource "digitalocean_droplet" "bar" {
   name   = "%s"
-  size   = "s-1vcpu-1gb"
-  image  = "ubuntu-22-04-x64"
+  size   = "%s"
+  image  = "%s"
   region = "nyc3"
 }
-`, name1, name2)
+`, name1, defaultSize, defaultImage, name2, defaultSize, defaultImage)
 
 	datasourceConfig := fmt.Sprintf(`
 data "digitalocean_droplets" "result" {

--- a/digitalocean/droplet/import_droplet_test.go
+++ b/digitalocean/droplet/import_droplet_test.go
@@ -123,9 +123,9 @@ func takeDropletSnapshot(t *testing.T, name string, droplet *godo.Droplet, snaps
 func testAccCheckDigitalOceanDropletConfig_fromSnapshot(t *testing.T, name string, snapshotID int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "from-snapshot" {
-  name      = "%s"
-  size      = "%s"
-  image     = "%d"
-  region    = "nyc3"
+  name   = "%s"
+  size   = "%s"
+  image  = "%d"
+  region = "nyc3"
 }`, name, defaultSize, snapshotID)
 }

--- a/digitalocean/droplet/import_droplet_test.go
+++ b/digitalocean/droplet/import_droplet_test.go
@@ -110,9 +110,9 @@ data "digitalocean_image" "snapshot" {
 
 resource "digitalocean_droplet" "from-snapshot" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
+  size      = "%s"
   image     = data.digitalocean_image.snapshot.id
   region    = "nyc3"
   user_data = "foobar"
-}`, name, name)
+}`, name, name, defaultSize)
 }

--- a/digitalocean/droplet/import_droplet_test.go
+++ b/digitalocean/droplet/import_droplet_test.go
@@ -47,11 +47,15 @@ func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 }
 
 func TestAccDigitalOceanDroplet_ImportWithNoImageSlug(t *testing.T) {
-	name := acceptance.RandomTestName()
-	var droplet godo.Droplet
-	var snapshotId []int
+	var (
+		droplet         godo.Droplet
+		restoredDroplet godo.Droplet
+		snapshotID      = godo.PtrTo(0)
+		name            = acceptance.RandomTestName()
+		restoredName    = acceptance.RandomTestName("restored")
+	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
@@ -60,11 +64,24 @@ func TestAccDigitalOceanDroplet_ImportWithNoImageSlug(t *testing.T) {
 				Config: acceptance.TestAccCheckDigitalOceanDropletConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
-					takeDropletSnapshot(name, &droplet, &snapshotId),
+					takeDropletSnapshot(t, name, &droplet, snapshotID),
 				),
 			},
+		},
+	})
+
+	importConfig := testAccCheckDigitalOceanDropletConfig_fromSnapshot(t, restoredName, *snapshotID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_fromSnapshot(name),
+				Config: importConfig,
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.from-snapshot", &restoredDroplet),
+				),
 			},
 			{
 				ResourceName:      "digitalocean_droplet.from-snapshot",
@@ -76,14 +93,14 @@ func TestAccDigitalOceanDroplet_ImportWithNoImageSlug(t *testing.T) {
 			{
 				Config: " ",
 				Check: resource.ComposeTestCheckFunc(
-					acceptance.DeleteDropletSnapshots(&snapshotId),
+					acceptance.DeleteDropletSnapshots(&[]int{*snapshotID}),
 				),
 			},
 		},
 	})
 }
 
-func takeDropletSnapshot(name string, droplet *godo.Droplet, snapshotId *[]int) resource.TestCheckFunc {
+func takeDropletSnapshot(t *testing.T, name string, droplet *godo.Droplet, snapshotID *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
 
@@ -97,22 +114,18 @@ func takeDropletSnapshot(name string, droplet *godo.Droplet, snapshotId *[]int) 
 		if err != nil {
 			return err
 		}
-		*snapshotId = retrieveDroplet.SnapshotIDs
+
+		*snapshotID = retrieveDroplet.SnapshotIDs[0]
 		return nil
 	}
 }
 
-func testAccCheckDigitalOceanDropletConfig_fromSnapshot(name string) string {
+func testAccCheckDigitalOceanDropletConfig_fromSnapshot(t *testing.T, name string, snapshotID int) string {
 	return fmt.Sprintf(`
-data "digitalocean_image" "snapshot" {
-  name = "%s"
-}
-
 resource "digitalocean_droplet" "from-snapshot" {
   name      = "%s"
   size      = "%s"
-  image     = data.digitalocean_image.snapshot.id
+  image     = "%d"
   region    = "nyc3"
-  user_data = "foobar"
-}`, name, name, defaultSize)
+}`, name, defaultSize, snapshotID)
 }

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+const (
+	defaultSize  = "s-1vcpu-1gb"
+	defaultImage = "ubuntu-22-04-x64"
+)
+
 func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 	var droplet godo.Droplet
 	name := acceptance.RandomTestName()
@@ -32,13 +37,13 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
+						"digitalocean_droplet.foobar", "size", defaultSize),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "price_hourly", "0.00893"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "price_monthly", "6"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "image", "ubuntu-22-04-x64"),
+						"digitalocean_droplet.foobar", "image", defaultImage),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -60,7 +65,6 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 	var droplet godo.Droplet
 	name := acceptance.RandomTestName()
-	slug := "ubuntu-22-04-x64"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -68,7 +72,7 @@ func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 		CheckDestroy:      acceptance.TestAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_withID(name, slug),
+				Config: testAccCheckDigitalOceanDropletConfig_withID(name, defaultImage),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.TestAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 				),
@@ -98,9 +102,9 @@ func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "name", name),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "size", "s-1vcpu-1gb"),
+						"digitalocean_droplet.foobar", "size", defaultSize),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "image", "ubuntu-22-04-x64"),
+						"digitalocean_droplet.foobar", "image", defaultImage),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -830,11 +834,11 @@ data "digitalocean_image" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
+  size      = "%s"
   image     = data.digitalocean_image.foobar.id
   region    = "nyc3"
   user_data = "foobar"
-}`, slug, name)
+}`, slug, name, defaultSize)
 }
 
 func testAccCheckDigitalOceanDropletConfig_withSSH(name string, testAccValidPublicKey string) string {
@@ -846,12 +850,12 @@ resource "digitalocean_ssh_key" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
+  size      = "%s"
+  image     = "%s"
   region    = "nyc3"
   user_data = "foobar"
   ssh_keys  = [digitalocean_ssh_key.foobar.id]
-}`, name, testAccValidPublicKey, name)
+}`, name, testAccValidPublicKey, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_tag_update(name string) string {
@@ -862,25 +866,25 @@ resource "digitalocean_tag" "barbaz" {
 
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
+  size      = "%s"
+  image     = "%s"
   region    = "nyc3"
   user_data = "foobar"
   tags      = [digitalocean_tag.barbaz.id]
 }
-`, name)
+`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_userdata_update(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
+  size      = "%s"
+  image     = "%s"
   region    = "nyc3"
   user_data = "foobar foobar"
 }
-`, name)
+`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_RenameAndResize(newName string) string {
@@ -888,10 +892,10 @@ func testAccCheckDigitalOceanDropletConfig_RenameAndResize(newName string) strin
 resource "digitalocean_droplet" "foobar" {
   name   = "%s"
   size   = "s-1vcpu-2gb"
-  image  = "ubuntu-22-04-x64"
+  image  = "%s"
   region = "nyc3"
 }
-`, newName)
+`, newName, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_resize_without_disk(name string) string {
@@ -899,12 +903,12 @@ func testAccCheckDigitalOceanDropletConfig_resize_without_disk(name string) stri
 resource "digitalocean_droplet" "foobar" {
   name        = "%s"
   size        = "s-1vcpu-2gb"
-  image       = "ubuntu-22-04-x64"
+  image       = "%s"
   region      = "nyc3"
   user_data   = "foobar"
   resize_disk = false
 }
-`, name)
+`, name, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_resize(name string) string {
@@ -912,25 +916,25 @@ func testAccCheckDigitalOceanDropletConfig_resize(name string) string {
 resource "digitalocean_droplet" "foobar" {
   name        = "%s"
   size        = "s-1vcpu-2gb"
-  image       = "ubuntu-22-04-x64"
+  image       = "%s"
   region      = "nyc3"
   user_data   = "foobar"
   resize_disk = true
 }
-`, name)
+`, name, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name               = "%s"
-  size               = "s-1vcpu-1gb"
-  image              = "ubuntu-22-04-x64"
+  size               = "%s"
+  image              = "%s"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
 }
-`, name)
+`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_VPCAndIpv6(name string) string {
@@ -942,25 +946,25 @@ resource "digitalocean_vpc" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name     = "%s"
-  size     = "s-1vcpu-1gb"
-  image    = "ubuntu-22-04-x64"
+  size     = "%s"
+  image    = "%s"
   region   = "nyc3"
   ipv6     = true
   vpc_uuid = digitalocean_vpc.foobar.id
 }
-`, acceptance.RandomTestName(), name)
+`, acceptance.RandomTestName(), name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_Monitoring(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name       = "%s"
-  size       = "s-1vcpu-1gb"
-  image      = "ubuntu-22-04-x64"
+  size       = "%s"
+  image      = "%s"
   region     = "nyc3"
   monitoring = true
 }
- `, name)
+ `, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_conditionalVolumes(name string) string {
@@ -983,35 +987,35 @@ resource "digitalocean_droplet" "foobar" {
   count      = 2
   name       = "%s-${count.index}"
   region     = "sfo3"
-  image      = "ubuntu-22-04-x64"
-  size       = "s-1vcpu-1gb"
+  image      = "%s"
+  size       = "%s"
   volume_ids = [count.index == 0 ? digitalocean_volume.myvol-01.id : digitalocean_volume.myvol-02.id]
 }
-`, name, name, name)
+`, name, name, name, defaultImage, defaultSize)
 }
 
 func testAccCheckDigitalOceanDropletConfig_EnableBackups(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
+  size      = "%s"
+  image     = "%s"
   region    = "nyc3"
   user_data = "foobar"
   backups   = true
-}`, name)
+}`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_DisableBackups(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name      = "%s"
-  size      = "s-1vcpu-1gb"
-  image     = "ubuntu-22-04-x64"
+  size      = "%s"
+  image     = "%s"
   region    = "nyc3"
   user_data = "foobar"
   backups   = false
-}`, name)
+}`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_DropletAgent(keyName, testAccValidPublicKey, dropletName, image, agent string) string {
@@ -1023,34 +1027,34 @@ resource "digitalocean_ssh_key" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name     = "%s"
-  size     = "s-1vcpu-1gb"
+  size     = "%s"
   image    = "%s"
   region   = "nyc3"
   ssh_keys = [digitalocean_ssh_key.foobar.id]
   %s
-}`, keyName, testAccValidPublicKey, dropletName, image, agent)
+}`, keyName, testAccValidPublicKey, dropletName, defaultSize, image, agent)
 }
 
 func testAccCheckDigitalOceanDropletConfig_EnableGracefulShutdown(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name              = "%s"
-  size              = "s-1vcpu-1gb"
-  image             = "ubuntu-22-04-x64"
+  size              = "%s"
+  image             = "%s"
   region            = "nyc3"
   user_data         = "foobar"
   graceful_shutdown = true
-}`, name)
+}`, name, defaultSize, defaultImage)
 }
 
 func testAccCheckDigitalOceanDropletConfig_DisableGracefulShutdown(name string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name              = "%s"
-  size              = "s-1vcpu-1gb"
-  image             = "ubuntu-22-04-x64"
+  size              = "%s"
+  image             = "%s"
   region            = "nyc3"
   user_data         = "foobar"
   graceful_shutdown = false
-}`, name)
+}`, name, defaultSize, defaultImage)
 }

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -553,6 +553,8 @@ func TestAccDigitalOceanDroplet_withDropletAgentSetTrue(t *testing.T) {
 // from the API when creating a Droplet using an OS that does not support the agent
 // if the `droplet_agent` field is explicitly set to false.
 func TestAccDigitalOceanDroplet_withDropletAgentSetFalse(t *testing.T) {
+	t.Skip("All Droplet OSes currently support the Droplet agent")
+
 	var droplet godo.Droplet
 	keyName := acceptance.RandomTestName()
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
@@ -587,6 +589,8 @@ func TestAccDigitalOceanDroplet_withDropletAgentSetFalse(t *testing.T) {
 // from the API when creating a Droplet using an OS that does not support the agent
 // if the `droplet_agent` field is not explicitly set.
 func TestAccDigitalOceanDroplet_withDropletAgentNotSet(t *testing.T) {
+	t.Skip("All Droplet OSes currently support the Droplet agent")
+
 	var droplet godo.Droplet
 	keyName := acceptance.RandomTestName()
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
@@ -622,6 +626,8 @@ func TestAccDigitalOceanDroplet_withDropletAgentNotSet(t *testing.T) {
 // from the API when creating a Droplet using an OS that does not support the agent
 // if the `droplet_agent` field is explicitly set to true.
 func TestAccDigitalOceanDroplet_withDropletAgentExpectError(t *testing.T) {
+	t.Skip("All Droplet OSes currently support the Droplet agent")
+
 	keyName := acceptance.RandomTestName()
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
 	if err != nil {


### PR DESCRIPTION
This PR contains a number of fixes and improvements to the Droplet acceptance tests. 

- Adds a const for default Droplet size and image in tests so that they can be updated in one place.
- Skip tests a number of tests that were meant to handling cases where Droplet OSes didn't support the Droplet agent (generally container based). Since the removal of Rancher and CoreOS, all supported Droplet OSes can now install the agent. I skipped them rather than deleting them as we may have new container based OSes in the future.