### PR TITLE
database replicas: set uuid on read.

### DIFF
--- a/digitalocean/database/import_database_replica_test.go
+++ b/digitalocean/database/import_database_replica_test.go
@@ -41,7 +41,7 @@ func TestAccDigitalOceanDatabaseReplica_importBasic(t *testing.T) {
 				// Requires passing both the cluster ID and replica name
 				ImportStateIdFunc: testAccDatabaseReplicaImportID(resourceName),
 				// The DO API does not return the size on read, but it is required on create
-				ImportStateVerifyIgnore: []string{"size", "uuid"},
+				ImportStateVerifyIgnore: []string{"size"},
 			},
 			// Test importing non-existent resource provides expected error.
 			{

--- a/digitalocean/database/resource_database_replica.go
+++ b/digitalocean/database/resource_database_replica.go
@@ -203,6 +203,7 @@ func resourceDigitalOceanDatabaseReplicaRead(ctx context.Context, d *schema.Reso
 	d.Set("tags", tag.FlattenTags(replica.Tags))
 
 	// Computed values
+	d.Set("uuid", replica.ID)
 	d.Set("host", replica.Connection.Host)
 	d.Set("private_host", replica.PrivateConnection.Host)
 	d.Set("port", replica.Connection.Port)


### PR DESCRIPTION
As pointed out in https://github.com/digitalocean/terraform-provider-digitalocean/issues/878, we've exposed the `uuid` of a database replica, but it is not set during imports. We only set it in the create method. It should be set in the read method as well.

Test change on its own shows the problem:

```
=== CONT  TestAccDigitalOceanDatabaseReplica_importBasic
    import_database_replica_test.go:23: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=1) {
         (string) (len=4) "uuid": (string) (len=36) "bcb92ee3-5f0b-4b90-8a43-a0350b718396"
        }
--- FAIL: TestAccDigitalOceanDatabaseReplica_importBasic (509.30s)
```

Fixed with the code change:

```
=== RUN   TestAccDigitalOceanDatabaseReplica_importBasic
=== PAUSE TestAccDigitalOceanDatabaseReplica_importBasic
=== CONT  TestAccDigitalOceanDatabaseReplica_importBasic
--- PASS: TestAccDigitalOceanDatabaseReplica_importBasic (601.54s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database   601.579s
```