### PR TITLE
datbase replica: Add uuid to data source schema.

### DIFF
--- a/digitalocean/database/datasource_database_replica.go
+++ b/digitalocean/database/datasource_database_replica.go
@@ -26,6 +26,11 @@ func DataSourceDigitalOceanDatabaseReplica() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"region": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/digitalocean/database/datasource_database_replica_test.go
+++ b/digitalocean/database/datasource_database_replica_test.go
@@ -53,6 +53,8 @@ func TestAccDataSourceDigitalOceanDatabaseReplica_Basic(t *testing.T) {
 						"data.digitalocean_database_replica.my_db_replica", "cluster_id"),
 					resource.TestCheckResourceAttrPair("digitalocean_database_replica.read-01", "name",
 						"data.digitalocean_database_replica.my_db_replica", "name"),
+					resource.TestCheckResourceAttrPair("digitalocean_database_replica.read-01", "uuid",
+						"data.digitalocean_database_replica.my_db_replica", "uuid"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_database_replica.my_db_replica", "region", "nyc3"),
 					resource.TestCheckResourceAttr(

--- a/docs/data-sources/database_replica.md
+++ b/docs/data-sources/database_replica.md
@@ -34,6 +34,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the database replica.
+* `uuid` - The UUID of the database replica.
 * `host` - Database replica's hostname.
 * `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database replica is listening on.


### PR DESCRIPTION
I noticed a new test failure cause by a panic. The database cluster replica data source calls the resource's `resourceDigitalOceanDatabaseReplicaRead` method. We recently added support for the new replica UUIDs to the resource, so it calls `d.Set("uuid", replica.ID)`. The schema for the replica data source was never updated to include `uuid`. So it panics:

```
panic: Invalid address to set: []string{"uuid"}

goroutine 943 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc0008cd000, {0x1072624, 0x4}, {0xee54a0, 0xc0003e5120})
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go:230 +0x291
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database.resourceDigitalOceanDatabaseReplicaRead({0xc0008cd000?, 0xc0005ff950?}, 0x44?, {0xf442a0?, 0xc0009aac00?})
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database/resource_database_replica.go:206 +0x26d
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database.dataSourceDigitalOceanDatabaseReplicaRead({0x13272a0, 0xc000623350}, 0x7f81c43cc718?, {0xf442a0, 0xc0009aac00})
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database/datasource_database_replica.go:99 +0x15f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000724700, {0x1327230, 0xc000572280}, 0xc000622ed0?, {0xf442a0, 0xc0009aac00})
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:358 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc000724700, {0x1327230, 0xc000572280}, 0xc0008ccf00, {0xf442a0, 0xc0009aac00})
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:569 +0xf7
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc000b4c960, {0x1327230, 0xc000572280}, 0xc000b842a0)
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:1133 +0x339
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc000ac2600, {0x13272d8?, 0xc0006221e0?}, 0xc0005720f0)
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go:478 +0x338
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x1035860?, 0xc000ac2600}, {0x13272d8, 0xc0006221e0}, 0xc000644240, 0x0)
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003d6000, {0x132bca0, 0xc00069b200}, 0xc0008c8100, 0xc000389470, 0x1a18610, 0x0)
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:1194 +0xcbe
google.golang.org/grpc.(*Server).handleStream(0xc0003d6000, {0x132bca0, 0xc00069b200}, 0xc0008c8100, 0x0)
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:1517 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:859 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/asb/development/gocode/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:857 +0x28a
FAIL    github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database   614.951s
```

https://github.com/digitalocean/terraform-provider-digitalocean/actions/runs/4629756218/jobs/8190428550#step:4:272