### PR TITLE
Fix inconsistencies in digitalocean_uptime_alert documentation

### DIFF
--- a/docs/resources/uptime_alert.md
+++ b/docs/resources/uptime_alert.md
@@ -11,26 +11,26 @@ resource. Uptime Alerts provide the ability to add alerts to your [DigitalOcean 
 ### Basic Example
 
 ```hcl
-# Create a new check for the target endpoint in a specifc region
+# Create a new check for the target endpoint in a specific region
 resource "digitalocean_uptime_check" "foobar" {
-  name  = "example-europe-check"
-  target = "https://www.example.com"
+  name    = "example-europe-check"
+  target  = "https://www.example.com"
   regions = ["eu_west"]
 }
 
-
+# Create a latency alert for the uptime check
 resource "digitalocean_uptime_alert" "alert-example" {
-  name  = "latency-alert"
-  check_id = "${digitalocean_uptime_check.foobar.id}"
-  type = "latency"
-	threshold = 300
-	comparison = "greater_than"
-  period = "2m"
+  name       = "latency-alert"
+  check_id   = digitalocean_uptime_check.foobar.id
+  type       = "latency"
+  threshold  = 300
+  comparison = "greater_than"
+  period     = "2m"
   notifications {
     email = ["sammy@digitalocean.com"]
     slack {
-      channel   = "Production Alerts"
-      url       = "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
+      channel = "Production Alerts"
+      url     = "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
     }
   }
 }

--- a/docs/resources/uptime_alert.md
+++ b/docs/resources/uptime_alert.md
@@ -43,10 +43,10 @@ The following arguments are supported:
 * `check_id` - (Required) A unique identifier for a check
 * `name` - (Required) A human-friendly display name.
 * `notifications` (Required) - The notification settings for a trigger alert.
-* `type` - The type of health check to perform: 'ping' 'http' 'https'.
-* `threshold` - The comparison operator used against the alert's threshold: "greater_than", "less_than"
-* `comparison` - A boolean value indicating whether the check is enabled/disabled.
-* `period` - Period of time the threshold must be exceeded to trigger the alert: "2m" "3m" "5m" "10m" "15m" "30m" "1h"
+* `type` (Required) - The type of health check to perform. Must be one of `latency`, `down`, `down_global` or `ssl_expiry`.
+* `threshold` - The threshold at which the alert will enter a trigger state. The specific threshold is dependent on the alert type.
+* `comparison` - The comparison operator used against the alert's threshold. Must be one of `greater_than` or `less_than`.
+* `period` - Period of time the threshold must be exceeded to trigger the alert. Must be one of `2m`, `3m`, `5m`, `10m`, `15m`, `30m` or `1h`.
 
 ## Attributes Reference
 

--- a/docs/resources/uptime_alert.md
+++ b/docs/resources/uptime_alert.md
@@ -48,6 +48,13 @@ The following arguments are supported:
 * `comparison` - The comparison operator used against the alert's threshold. Must be one of `greater_than` or `less_than`.
 * `period` - Period of time the threshold must be exceeded to trigger the alert. Must be one of `2m`, `3m`, `5m`, `10m`, `15m`, `30m` or `1h`.
 
+`notifications` supports the following:
+
+* `email` - List of email addresses to sent notifications to.
+* `slack`
+  * `channel` (Required) - The Slack channel to send alerts to.
+  * `url` (Required) - The webhook URL for Slack.
+
 ## Attributes Reference
 
 The following attributes are exported.


### PR DESCRIPTION
Hi!

I noticed some inconsistencies in [the documentation of the `digitalocean_uptime_alert` resource](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/uptime_alert). The `type` argument mentions the options `ping`, `http` and `https`, which actually belong to the `digitalocean_uptime_check` resource instead. When diving into the source code I also noticed some other issues in the documentation.

This PR should fix those, and also adds the contents of the `notifications` object to the argument reference. Last but not least I have fixed some formatting issues and a small typo in the example code.