### PR TITLE
docs: Use correct links in Update docs.

### DIFF
--- a/docs/resources/uptime_alert.md
+++ b/docs/resources/uptime_alert.md
@@ -4,8 +4,8 @@ page_title: "DigitalOcean: digitalocean_uptime_alert"
 
 # digitalocean_uptime_alert
 
-Provides a [DigitalOcean Uptime Alerts](https://docs.digitalocean.com/reference/api/kafka-beta-api-reference/#operation/uptime_alert_create)
-resource. Uptime Alerts provide the ability to add alerts to your [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/kafka-beta-api-reference/#tag/Uptime) when your endpoints are slow, unavailable, or SSL certificates are expiring. 
+Provides a [DigitalOcean Uptime Alerts](https://docs.digitalocean.com/reference/api/api-reference/#operation/uptime_alert_create)
+resource. Uptime Alerts provide the ability to add alerts to your [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/api-reference/#tag/Uptime) when your endpoints are slow, unavailable, or SSL certificates are expiring.
 
 
 ### Basic Example

--- a/docs/resources/uptime_check.md
+++ b/docs/resources/uptime_check.md
@@ -4,7 +4,7 @@ page_title: "DigitalOcean: digitalocean_uptime_check"
 
 # digitalocean_uptime_check
 
-Provides a [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/kafka-beta-api-reference/#tag/Uptime)
+Provides a [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/api-reference/#tag/Uptime)
 resource. Uptime Checks provide the ability to monitor your endpoints from around the world, and alert you when they're slow, unavailable, or SSL certificates are expiring.
 
 


### PR DESCRIPTION
These are not linking to the canonical location of the API documentation. 