### PR TITLE
kubernetes: add registry_integration to ImportStateVerifyIgnore

### DIFF
--- a/digitalocean/kubernetes/import_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/import_kubernetes_cluster_test.go
@@ -37,6 +37,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 					"kube_config",            // because kube_config was completely different for imported state
 					"node_pool.0.node_count", // because import test failed before DO had started the node in pool
 					"updated_at",             // because removing default tag updates the resource outside of Terraform
+					"registry_integration",   // registry_integration state can not be known via the API
 				},
 			},
 		},

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -590,13 +590,13 @@ func resourceDigitalOceanKubernetesClusterImportState(d *schema.ResourceData, me
 	return resourceDatas, nil
 }
 
-func enableRegistryIntegration(client *godo.Client, cluster_uuid string) error {
-	_, err := client.Kubernetes.AddRegistry(context.Background(), &godo.KubernetesClusterRegistryRequest{ClusterUUIDs: []string{cluster_uuid}})
+func enableRegistryIntegration(client *godo.Client, clusterUUID string) error {
+	_, err := client.Kubernetes.AddRegistry(context.Background(), &godo.KubernetesClusterRegistryRequest{ClusterUUIDs: []string{clusterUUID}})
 	return err
 }
 
-func disableRegistryIntegration(client *godo.Client, cluster_uuid string) error {
-	_, err := client.Kubernetes.RemoveRegistry(context.Background(), &godo.KubernetesClusterRegistryRequest{ClusterUUIDs: []string{cluster_uuid}})
+func disableRegistryIntegration(client *godo.Client, clusterUUID string) error {
+	_, err := client.Kubernetes.RemoveRegistry(context.Background(), &godo.KubernetesClusterRegistryRequest{ClusterUUIDs: []string{clusterUUID}})
 	return err
 }
 


### PR DESCRIPTION
The API does not have an endpoint to know if `registry_integration` has been set or not for a Kubernetes cluster. So its state can not be imported. This adds it to `ImportStateVerifyIgnore` for `TestAccDigitalOceanKubernetesCluster_ImportBasic`

It also cleans up a golint issue. `s/cluster_uuid/clusterUUID/g`

Fixup for https://github.com/digitalocean/terraform-provider-digitalocean/pull/963
