### PR TITLE
kubernetes: Require importing additional node pools manually.

### DIFF
--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -898,13 +898,10 @@ provider "kubernetes" {
   token = digitalocean_kubernetes_cluster.foobar.kube_config[0].token
 }
 
-resource "kubernetes_service_account" "tiller" {
+resource "kubernetes_namespace" "example" {
   metadata {
-    name      = "tiller"
-    namespace = "kube-system"
+    name = "example-namespace"
   }
-
-  automount_service_account_token = true
 }
 `, testClusterVersion, rName)
 }

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -53,11 +53,10 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "nyc1"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "surge_upgrade", "true"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "ha", "true"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "ha", "false"),
 					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
-					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "endpoint"),

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -211,12 +211,19 @@ In addition to the arguments listed above, the following additional attributes a
 
 Before importing a Kubernetes cluster, the cluster's default node pool must be tagged with
 the `terraform:default-node-pool` tag. The provider will automatically add this tag if
-the cluster has a single node pool. Clusters with more than one node pool, however, will require
+the cluster only has a single node pool. Clusters with more than one node pool, however, will require
 that you manually add the `terraform:default-node-pool` tag to the node pool that you intend to be
 the default node pool.
 
-Then the Kubernetes cluster and all of its node pools can be imported using the cluster's `id`, e.g.
+Then the Kubernetes cluster and its default node pool can be imported using the cluster's `id`, e.g.
 
 ```
 terraform import digitalocean_kubernetes_cluster.mycluster 1b8b2100-0e9f-4e8f-ad78-9eb578c2a0af
+```
+
+Additional node pools must be imported separately as `digitalocean_kubernetes_cluster`
+resources, e.g.
+
+```
+terraform import digitalocean_kubernetes_node_pool.mynodepool 9d76f410-9284-4436-9633-4066852442c8
 ```

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -98,7 +98,7 @@ In addition to the arguments listed above, the following additional attributes a
 ## Import
 
 If you are importing an existing Kubernetes cluster with a single node pool, just
-import the cluster. Additional node pools can be imported it by using their `id`, e.g.
+import the cluster. Additional node pools can be imported by using their `id`, e.g.
 
 ```
 terraform import digitalocean_kubernetes_node_pool.mynodepool 9d76f410-9284-4436-9633-4066852442c8

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -97,10 +97,8 @@ In addition to the arguments listed above, the following additional attributes a
 
 ## Import
 
-If you are importing an existing Kubernetes cluster, just import the cluster. Importing a cluster also imports
-all of its associated node pools.
-
-If you still need to import a single node pool, then import it by using its `id`, e.g.
+If you are importing an existing Kubernetes cluster with a single node pool, just
+import the cluster. Additional node pools can be imported it by using their `id`, e.g.
 
 ```
 terraform import digitalocean_kubernetes_node_pool.mynodepool 9d76f410-9284-4436-9633-4066852442c8


### PR DESCRIPTION
This resolves https://github.com/digitalocean/terraform-provider-digitalocean/issues/892 by only importing the default node pool when importing a cluster. Additional pools should now be imported separately as `digitalocean_kubernetes_node_pool` resources.

The old approach of importing multiple resources in one go was fragile, and the upstream Terraform developer documentation has begun to actively discourage it:

> Multiple resource import is generally discouraged due to the implementation/testing complexity and since the resource addresses saved into the Terraform state will likely not align with the operator's configuration.

https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/import#multiple-resource-import

Other providers like AWS' have removed all usage of "complex imports," https://github.com/hashicorp/terraform-provider-aws/issues/13408.

I think this is likely a bug in upstream Terraform. Though this "feature" is not widely used, and they are clearly trying to move away from it. So I believe this is the best approach moving forward.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/892

```
$ make testacc TESTARGS='-run TestAccDigitalOceanKubernetesCluster_Import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/... -run TestAccDigitalOceanKubernetesCluster_Import -timeout 120m -parallel=2
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportBasic
=== PAUSE TestAccDigitalOceanKubernetesCluster_ImportBasic
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportErrorNonDefaultNodePool
=== PAUSE TestAccDigitalOceanKubernetesCluster_ImportErrorNonDefaultNodePool
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
=== PAUSE TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
=== CONT  TestAccDigitalOceanKubernetesCluster_ImportBasic
=== CONT  TestAccDigitalOceanKubernetesCluster_ImportErrorNonDefaultNodePool
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportBasic (297.67s)
=== CONT  TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportErrorNonDefaultNodePool (476.18s)
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool (496.43s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes 794.131s
```