### PR TITLE
databases: Fix custom create timeouts.

### DIFF
--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -521,7 +521,7 @@ func resourceDigitalOceanDatabaseClusterDelete(ctx context.Context, d *schema.Re
 func waitForDatabaseCluster(client *godo.Client, d *schema.ResourceData, status string) (*godo.Database, error) {
 	var (
 		tickerInterval = 15 * time.Second
-		timeoutSeconds = d.Timeout(schema.TimeoutDelete).Seconds()
+		timeoutSeconds = d.Timeout(schema.TimeoutCreate).Seconds()
 		timeout        = int(timeoutSeconds / tickerInterval.Seconds())
 		n              = 0
 		ticker         = time.NewTicker(tickerInterval)
@@ -543,7 +543,7 @@ func waitForDatabaseCluster(client *godo.Client, d *schema.ResourceData, status 
 			return database, nil
 		}
 
-		if n > timeout {
+		if n >= timeout {
 			ticker.Stop()
 			break
 		}


### PR DESCRIPTION
Looks like we accidentally used `TimeoutDelete` where it should be `TimeoutCreate` :man_facepalming: 

Also noticed `=` when it should be `>=` to prevent the corner case of the timeout being set lower than the interval. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/986