### PR TITLE
Bump Go version to 1.20.x

### DIFF
--- a/.github/workflows/acceptance-test-pr.yml
+++ b/.github/workflows/acceptance-test-pr.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Checkout PR
         uses: actions/checkout@v2

--- a/.github/workflows/acceptance-test-schedule.yml
+++ b/.github/workflows/acceptance-test-schedule.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     # Runs `go vet` and unit tests.
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x, 1.20.x]
 
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -71,4 +71,4 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110
 
 replace github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => github.com/keybase/go-crypto v0.0.0-20190416182011-b785b22cc757
 
-go 1.19
+go 1.20


### PR DESCRIPTION
Happened to notice we are still on 1.19 here. This bumps us up to 1.20