### PR TITLE
Update retryOnAwsCode to Five Minutes

### DIFF
--- a/digitalocean/spaces/resource_spaces_bucket.go
+++ b/digitalocean/spaces/resource_spaces_bucket.go
@@ -751,7 +751,7 @@ func BucketEndpoint(region string) string {
 
 func retryOnAwsCode(code string, f func() (interface{}, error)) (interface{}, error) {
 	var resp interface{}
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		var err error
 		resp, err = f()
 		if err != nil {


### PR DESCRIPTION
Users have been experiencing errors being returned on successful spaces create requests that take longer than 1 minute. Github issue is #996 

The only referenced function in `resourceDigitalOceanBucketCreate` that's using a 1 minute timeout is the `retryOnAwsCode` so updating that to 5 minutes to hopefully mitigate the errors on successful bucket creations.