### PR TITLE
databases: Update Postgres versions in acceptance tests.

### DIFF
--- a/digitalocean/database/datasource_database_cluster_test.go
+++ b/digitalocean/database/datasource_database_cluster_test.go
@@ -89,7 +89,7 @@ const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -101,7 +101,7 @@ const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigWithDatasource = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -464,8 +464,8 @@ func TestAccDigitalOceanDatabaseCluster_MongoDBPassword(t *testing.T) {
 func TestAccDigitalOceanDatabaseCluster_Upgrade(t *testing.T) {
 	var database godo.Database
 	databaseName := acceptance.RandomTestName()
-	previousPGVersion := "13"
-	latestPGVersion := "14"
+	previousPGVersion := "14"
+	latestPGVersion := "15"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -671,7 +671,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-2gb"
   region     = "nyc1"
   node_count = 1
@@ -682,7 +682,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigWithBackupRestore = `
 resource "digitalocean_database_cluster" "foobar_backup" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-2gb"
   region     = "nyc1"
   node_count = 1
@@ -697,7 +697,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigWithUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-2vcpu-4gb"
   region     = "nyc1"
   node_count = 1
@@ -708,7 +708,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigWithMigration = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-2gb"
   region     = "lon1"
   node_count = 1
@@ -719,7 +719,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigWithMaintWindow = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -814,7 +814,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigWithEvictionPolicyError = `
 resource "digitalocean_database_cluster" "foobar" {
   name            = "%s"
   engine          = "pg"
-  version         = "11"
+  version         = "15"
   size            = "db-s-1vcpu-1gb"
   region          = "nyc1"
   node_count      = 1
@@ -826,7 +826,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigTagUpdate = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-2gb"
   region     = "nyc1"
   node_count = 1
@@ -842,7 +842,7 @@ resource "digitalocean_vpc" "foobar" {
 resource "digitalocean_database_cluster" "foobar" {
   name                 = "%s"
   engine               = "pg"
-  version              = "11"
+  version              = "15"
   size                 = "db-s-1vcpu-2gb"
   region               = "nyc1"
   node_count           = 1
@@ -878,7 +878,7 @@ resource "digitalocean_project" "foobar" {
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-2gb"
   region     = "nyc1"
   node_count = 1

--- a/digitalocean/database/resource_database_connection_pool_test.go
+++ b/digitalocean/database/resource_database_connection_pool_test.go
@@ -197,7 +197,7 @@ const testAccCheckDigitalOceanDatabaseConnectionPoolConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -216,7 +216,7 @@ const testAccCheckDigitalOceanDatabaseConnectionPoolConfigUpdated = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -234,7 +234,7 @@ const testAccCheckDigitalOceanDatabaseConnectionPoolConfigBad = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -253,7 +253,7 @@ const testAccCheckDigitalOceanDatabaseConnectionPoolConfigInboundUser = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/digitalocean/database/resource_database_db_test.go
+++ b/digitalocean/database/resource_database_db_test.go
@@ -145,7 +145,7 @@ const testAccCheckDigitalOceanDatabaseDBConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/digitalocean/database/resource_database_firewall_test.go
+++ b/digitalocean/database/resource_database_firewall_test.go
@@ -92,7 +92,7 @@ const testAccCheckDigitalOceanDatabaseFirewallConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -112,7 +112,7 @@ const testAccCheckDigitalOceanDatabaseFirewallConfigAddRule = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -137,7 +137,7 @@ const testAccCheckDigitalOceanDatabaseFirewallConfigMultipleResourceTypes = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -234,7 +234,7 @@ const testAccCheckDigitalOceanDatabaseUserConfigBasic = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "pg"
-  version    = "11"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1


### PR DESCRIPTION
We have acceptance tests failing:

```
    datasource_database_cluster_test.go:20: Step 1/2 error: Error running apply: exit status 1
        Error: Error creating database cluster: POST https://api.digitalocean.com/v2/databases: 422 (request "f1627cab-76fe-4d38-b86c-1f6460daed6a") invalid cluster engine version
          with digitalocean_database_cluster.foobar,
          on terraform_plugin_test.tf line 2, in resource "digitalocean_database_cluster" "foobar":
           2: resource "digitalocean_database_cluster" "foobar" {
--- FAIL: TestAccDataSourceDigitalOceanDatabaseCluster_Basic (0.91s)
```

Looks like version 11 has been EOLed for Postgres:

```
$ doctl databases options versions 
Engine     Versions
mysql      [8]
pg         [12,13,14,15]
redis      [7]
mongodb    [4.4,5.0,6.0]
```