### PR TITLE
k8s: Add destroy_all_associated_resources option.

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -163,6 +163,7 @@ The following arguments are supported:
 * `maintenance_policy` - (Optional) A block representing the cluster's maintenance window. Updates will be applied within this window. If not specified, a default maintenance window will be chosen. `auto_upgrade` must be set to `true` for this to have an effect.
   - `day` - (Required) The day of the maintenance window policy. May be one of "monday" through "sunday", or "any" to indicate an arbitrary week day.
   - `start_time` (Required) The start time in UTC of the maintenance window policy in 24-hour clock format / HH:MM notation (e.g., 15:00).
+* `destroy_all_associated_resources` - (Optional) **Use with caution.** When set to true, all associated DigitalOcean resources created via the Kubernetes API (load balancers, volumes, and volume snapshots) will be destroyed along with the cluster when it is destroyed.
 
 This resource supports [customized create timeouts](https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts). The default timeout is 30 minutes.
 


### PR DESCRIPTION
This adds an option to destroy all associated DigitalOcean resources created via the Kubernetes API (load balancers, volumes, and volume snapshots) along with the cluster when it is destroyed. 