### PR TITLE
Use terrafmt on docs directory.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,9 +51,11 @@ install-terrafmt:
 
 terrafmt: install-terrafmt # Formats Terraform configuration blocks in tests.
 	@terrafmt fmt --fmtcompat digitalocean/
+	@terrafmt fmt --fmtcompat docs/
 
 terrafmt-check: install-terrafmt # Returns non-0 exit code if terrafmt would make a change.
 	@terrafmt diff --check --fmtcompat digitalocean/
+	@terrafmt diff --check --fmtcompat docs/
 
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -21,8 +21,8 @@ also uses the regular expression `match_by` mode in order to match domains by su
 ```hcl
 data "digitalocean_domains" "examples" {
   filter {
-    key    = "name"
-    values = ["example\\.com$"]
+    key      = "name"
+    values   = ["example\\.com$"]
     match_by = "re"
   }
 }

--- a/docs/data-sources/firewall.md
+++ b/docs/data-sources/firewall.md
@@ -12,11 +12,11 @@ Get the firewall:
 
 ```hcl
 data "digitalocean_firewall" "example" {
-    firewall_id = "1df48973-6eef-4214-854f-fa7726e7e583"
+  firewall_id = "1df48973-6eef-4214-854f-fa7726e7e583"
 }
 
 output "example_firewall_name" {
-    value = data.digitalocean_firewall.example.name
+  value = data.digitalocean_firewall.example.name
 }
 ```
 

--- a/docs/data-sources/kubernetes_cluster.md
+++ b/docs/data-sources/kubernetes_cluster.md
@@ -14,8 +14,8 @@ data "digitalocean_kubernetes_cluster" "example" {
 }
 
 provider "kubernetes" {
-  host             = data.digitalocean_kubernetes_cluster.example.endpoint
-  token            = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
+  host  = data.digitalocean_kubernetes_cluster.example.endpoint
+  token = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(
     data.digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
   )

--- a/docs/data-sources/records.md
+++ b/docs/data-sources/records.md
@@ -15,7 +15,7 @@ Get data for all MX records in a domain:
 data "digitalocean_records" "example" {
   domain = "example.com"
   filter {
-    key = "type"
+    key    = "type"
     values = ["MX"]
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Use the navigation to the left to read about the available resources.
 terraform {
   required_providers {
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
       version = "~> 2.0"
     }
   }

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -60,8 +60,8 @@ resource "digitalocean_app" "static-site-example" {
 ```hcl
 resource "digitalocean_app" "mono-repo-example" {
   spec {
-    name    = "mono-repo-example"
-    region  = "ams"
+    name   = "mono-repo-example"
+    region = "ams"
     domain {
       name = "foo.example.com"
     }

--- a/docs/resources/container_registry_docker_credentials.md
+++ b/docs/resources/container_registry_docker_credentials.md
@@ -58,8 +58,8 @@ data "digitalocean_kubernetes_cluster" "example" {
 }
 
 provider "kubernetes" {
-  host             = data.digitalocean_kubernetes_cluster.example.endpoint
-  token            = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
+  host  = data.digitalocean_kubernetes_cluster.example.endpoint
+  token = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(
     data.digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
   )

--- a/docs/resources/custom_image.md
+++ b/docs/resources/custom_image.md
@@ -20,17 +20,17 @@ Image documentation for [additional requirements](https://www.digitalocean.com/d
 
 ```hcl
 resource "digitalocean_custom_image" "flatcar" {
-  name   = "flatcar"
-  url = "https://stable.release.flatcar-linux.net/amd64-usr/2605.7.0/flatcar_production_digitalocean_image.bin.bz2"
+  name    = "flatcar"
+  url     = "https://stable.release.flatcar-linux.net/amd64-usr/2605.7.0/flatcar_production_digitalocean_image.bin.bz2"
   regions = ["nyc3"]
 }
 
 resource "digitalocean_droplet" "example" {
-  image     = digitalocean_custom_image.flatcar.id
-  name      = "example-01"
-  region    = "nyc3"
-  size      = "s-1vcpu-1gb"
-  ssh_keys  = [12345]
+  image    = digitalocean_custom_image.flatcar.id
+  name     = "example-01"
+  region   = "nyc3"
+  size     = "s-1vcpu-1gb"
+  ssh_keys = [12345]
 }
 ```
 

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -76,9 +76,9 @@ resource "digitalocean_database_cluster" "doby_backup" {
   region     = "nyc1"
   node_count = 1
   tags       = ["production"]
-  
+
   backup_restore {
-    database_name  = "dobydb"
+    database_name = "dobydb"
   }
 
   depends_on = [

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -71,8 +71,8 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   version      = data.digitalocean_kubernetes_versions.example.latest_version
 
   maintenance_policy {
-    start_time  = "04:00"
-    day         = "sunday"
+    start_time = "04:00"
+    day        = "sunday"
   }
 
   node_pool {
@@ -107,8 +107,8 @@ data "digitalocean_kubernetes_cluster" "example" {
 }
 
 provider "kubernetes" {
-  host             = data.digitalocean_kubernetes_cluster.example.endpoint
-  token            = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
+  host  = data.digitalocean_kubernetes_cluster.example.endpoint
+  token = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(
     data.digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
   )
@@ -124,7 +124,7 @@ initializing the provider.
 
 ```hcl
 provider "kubernetes" {
-  host                   = data.digitalocean_kubernetes_cluster.foo.endpoint
+  host = data.digitalocean_kubernetes_cluster.foo.endpoint
   cluster_ca_certificate = base64decode(
     data.digitalocean_kubernetes_cluster.foo.kube_config[0].cluster_ca_certificate
   )

--- a/docs/resources/monitor_alert.md
+++ b/docs/resources/monitor_alert.md
@@ -26,8 +26,8 @@ resource "digitalocean_monitor_alert" "cpu_alert" {
   alerts {
     email = ["sammy@digitalocean.com"]
     slack {
-      channel   = "Production Alerts"
-      url       = "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
+      channel = "Production Alerts"
+      url     = "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
     }
   }
   window      = "5m"

--- a/docs/resources/spaces_bucket_policy.md
+++ b/docs/resources/spaces_bucket_policy.md
@@ -49,23 +49,23 @@ resource "digitalocean_spaces_bucket_policy" "foobar" {
   region = digitalocean_spaces_bucket.foobar.region
   bucket = digitalocean_spaces_bucket.foobar.name
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "IPAllow",
-            "Effect": "Deny",
-            "Principal": "*",
-            "Action": "s3:*",
-            "Resource": [
-                "arn:aws:s3:::${digitalocean_spaces_bucket.foobar.name}",
-                "arn:aws:s3:::${digitalocean_spaces_bucket.foobar.name}/*"
-            ],
-            "Condition": {
-                "NotIpAddress": {
-                    "aws:SourceIp": "54.240.143.0/24"
-                }
-            }
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "IPAllow",
+        "Effect" : "Deny",
+        "Principal" : "*",
+        "Action" : "s3:*",
+        "Resource" : [
+          "arn:aws:s3:::${digitalocean_spaces_bucket.foobar.name}",
+          "arn:aws:s3:::${digitalocean_spaces_bucket.foobar.name}/*"
+        ],
+        "Condition" : {
+          "NotIpAddress" : {
+            "aws:SourceIp" : "54.240.143.0/24"
+          }
         }
+      }
     ]
   })
 }

--- a/docs/resources/uptime_check.md
+++ b/docs/resources/uptime_check.md
@@ -13,8 +13,8 @@ resource. Uptime Checks provide the ability to monitor your endpoints from aroun
 ```hcl
 # Create a new check for the target endpoint in a specifc region
 resource "digitalocean_uptime_check" "foobar" {
-  name  = "example-europe-check"
-  target = "https://www.example.com"
+  name    = "example-europe-check"
+  target  = "https://www.example.com"
   regions = ["eu_west"]
 }
 ```


### PR DESCRIPTION
Went to use `make terrafmt` on some new docs I'm writing and found we aren't pointing it at the docs directory in the makefile target. This updates the makefile to run it against the docs and fixes up existing formatting issues. 