### PR TITLE
Parse nil region for global lb

### DIFF
--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -558,7 +558,6 @@ func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resourc
 	d.Set("ip", loadbalancer.IP)
 	d.Set("status", loadbalancer.Status)
 	d.Set("algorithm", loadbalancer.Algorithm)
-	d.Set("region", loadbalancer.Region.Slug)
 	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
 	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
 	d.Set("enable_backend_keepalive", loadbalancer.EnableBackendKeepalive)
@@ -571,6 +570,10 @@ func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resourc
 		d.Set("size_unit", loadbalancer.SizeUnit)
 	} else {
 		d.Set("size", loadbalancer.SizeSlug)
+	}
+
+	if loadbalancer.Region != nil {
+		d.Set("region", loadbalancer.Region.Slug)
 	}
 
 	d.Set("disable_lets_encrypt_dns_records", loadbalancer.DisableLetsEncryptDNSRecords)


### PR DESCRIPTION
Global lb creates are crashing on read after creates as it tries to parse nil `region` object: global lb doesn't have an associated region. 