### PR TITLE
Database: Clarify Docs for Referencing DB Replicas

### DIFF
--- a/docs/resources/database_firewall.md
+++ b/docs/resources/database_firewall.md
@@ -66,6 +66,36 @@ resource "digitalocean_database_cluster" "postgres-example" {
 }
 ```
 
+### Create a new database firewall for a database replica
+
+```hcl
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_replica" "replica-example" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+  name       = "replica-example"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+}
+
+# Create firewall rule for database replica
+resource "digitalocean_database_firewall" "example-fw" {
+  cluster_id = digitalocean_database_replica.replica-example.uuid
+
+  rule {
+    type  = "ip_addr"
+    value = "192.168.1.1"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -27,7 +27,7 @@ resource "digitalocean_database_cluster" "postgres-example" {
 }
 ```
 
-### Create a new PostgreSQL database user with replica database
+### Create a new user for PostgreSQL database replica 
 ```hcl
 resource "digitalocean_database_cluster" "postgres-example" {
   name       = "example-postgres-cluster"

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -27,7 +27,7 @@ resource "digitalocean_database_cluster" "postgres-example" {
 }
 ```
 
-### Create a new user for PostgreSQL database replica 
+### Create a new user for a PostgreSQL database replica 
 ```hcl
 resource "digitalocean_database_cluster" "postgres-example" {
   name       = "example-postgres-cluster"

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -27,6 +27,30 @@ resource "digitalocean_database_cluster" "postgres-example" {
 }
 ```
 
+### Create a new PostgreSQL database user with replica database
+```hcl
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_replica" "replica-example" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+  name       = "replica-example"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+}
+
+resource "digitalocean_database_user" "user-example" {
+  cluster_id = digitalocean_database_replica.replica-example.uuid
+  name       = "foobar"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
Clarify that when referencing `digitalocean_database_replica`, the `uuid` must be used instead of `id`