### PR TITLE
LBAAS-2800: no region field needed for global lb type

### DIFF
--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -81,7 +81,7 @@ func ResourceDigitalOceanLoadbalancer() *schema.Resource {
 				}
 			}
 
-			if err := loadbalancerDiffFunction(ctx, diff, v); err != nil {
+			if err := loadbalancerDiffCheck(ctx, diff, v); err != nil {
 				return err
 			}
 
@@ -117,7 +117,7 @@ func resourceDigitalOceanLoadBalancerV1() map[string]*schema.Schema {
 	return loadBalancerV1Schema
 }
 
-func loadbalancerDiffFunction(ctx context.Context, d *schema.ResourceDiff, v interface{}) error {
+func loadbalancerDiffCheck(ctx context.Context, d *schema.ResourceDiff, v interface{}) error {
 	typ, typSet := d.GetOk("type")
 	region, regionSet := d.GetOk("region")
 

--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -404,10 +404,11 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 				},
 			},
 			"type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "the type of the load balancer (GLOBAL or REGIONAL)",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "GLOBAL"}, true),
+				Description:  "the type of the load balancer (GLOBAL or REGIONAL)",
 			},
 		},
 	}

--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -118,7 +118,7 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				StateFunc: func(val interface{}) string {
 					// DO API V2 region slug is always lowercase


### PR DESCRIPTION
## Summary

Created a custom diff function to validate that `region` field is not required if the type file is set to `GLOBAL` and if set to `REGIONAL` validate `region` value is present and not empty. 

### Validation
Verified by running `terraform plan` for each case

#### type=GLOBAL and region="nyc3"
![Screenshot 2023-10-10 at 8 59 00](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/cca71681-a770-4e69-9d70-66261e176d04)


#### type=GLOBAL and region=""
![Screenshot 2023-10-10 at 8 54 35](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/259ef456-962e-4329-a568-a07a05a807d9)

#### type=GLOBAL and no region
![Screenshot 2023-10-10 at 8 59 22](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/f29180fb-029f-4119-aa12-6dc17a1b3df2)

#### type=REGIONAL and region="nyc3"
![Screenshot 2023-10-10 at 8 59 57](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/df407329-2d2d-4cc8-8b74-d2f808c4a4ad)

#### type=REGIONAL and region=""
![Screenshot 2023-10-10 at 9 04 46](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/d20ce141-0788-4a72-87ae-9fcfe0b05b30)

#### type=REGIONAL and no region
![Screenshot 2023-10-10 at 9 05 08](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/577b4727-9e1d-4e74-8bf4-c613fe6d8f19)

#### region="nyc3" and no type
![Screenshot 2023-10-10 at 9 05 50](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/fd655302-b916-4d13-889e-94e8f202df22)

#### no type and no region
![Screenshot 2023-10-10 at 9 06 10](https://github.com/digitalocean/terraform-provider-digitalocean/assets/143539236/542dc8fa-04d2-4031-a243-6420f84e8ed2)
