### PR TITLE
Rework deployment logic

### DIFF
--- a/digitalocean/app/resource_app.go
+++ b/digitalocean/app/resource_app.go
@@ -221,7 +221,14 @@ func waitForAppDeployment(client *godo.Client, id string, timeout time.Duration)
 				return fmt.Errorf("Error trying to read app deployment state: %s", err)
 			}
 
-			allSuccessful := deployment.Progress.SuccessSteps == deployment.Progress.TotalSteps
+			allSuccessful := true
+			for _, step := range deployment.Progress.Steps {
+				if step.Status != godo.DeploymentProgressStepStatus_Success {
+					allSuccessful = false
+					break
+				}
+			}
+
 			if allSuccessful {
 				ticker.Stop()
 				return nil

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -181,6 +181,10 @@ func TestAccDigitalOceanApp_Job(t *testing.T) {
 						"digitalocean_app.foobar", "spec.0.job.1.log_destination.0.datadog.0.endpoint", "https://example.com"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.job.1.log_destination.0.datadog.0.api_key", "test-api-key"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.job.2.name", "example-failed-job"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.job.2.kind", "FAILED_DEPLOY"),
 				),
 			},
 		},
@@ -1189,10 +1193,6 @@ resource "digitalocean_app" "foobar" {
         repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
         branch         = "main"
       }
-
-      routes {
-        path = "/"
-      }
     }
 
     job {
@@ -1217,6 +1217,21 @@ resource "digitalocean_app" "foobar" {
         }
       }
     }
+
+    job {
+        name               = "example-failed-job"
+        instance_count     = 1
+        instance_size_slug = "basic-xxs"
+        kind               = "FAILED_DEPLOY"
+        run_command        = "echo 'This is a failed deploy job.'"
+
+        image {
+          registry_type = "DOCKER_HUB"
+          registry      = "frolvlad"
+          repository    = "alpine-bash"
+          tag           = "latest"
+        }
+      }
   }
 }`
 

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -1219,19 +1219,19 @@ resource "digitalocean_app" "foobar" {
     }
 
     job {
-        name               = "example-failed-job"
-        instance_count     = 1
-        instance_size_slug = "basic-xxs"
-        kind               = "FAILED_DEPLOY"
-        run_command        = "echo 'This is a failed deploy job.'"
+      name               = "example-failed-job"
+      instance_count     = 1
+      instance_size_slug = "basic-xxs"
+      kind               = "FAILED_DEPLOY"
+      run_command        = "echo 'This is a failed deploy job.'"
 
-        image {
-          registry_type = "DOCKER_HUB"
-          registry      = "frolvlad"
-          repository    = "alpine-bash"
-          tag           = "latest"
-        }
+      image {
+        registry_type = "DOCKER_HUB"
+        registry      = "frolvlad"
+        repository    = "alpine-bash"
+        tag           = "latest"
       }
+    }
   }
 }`
 


### PR DESCRIPTION
This commit modifies the logic used by the `digitalocean_app` resource to check each step for a success status rather than using the counts of steps. The step counting method fails to work with jobs of kind `FAILED_DEPLOY` as these will always be pending, meaning that any app deployed with a job of this type will always time out even when it is successful.

Closes #1047