### PR TITLE
load balancers: ignore 404 on delete.

### DIFF
--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -655,8 +656,13 @@ func resourceDigitalOceanLoadbalancerDelete(ctx context.Context, d *schema.Resou
 	client := meta.(*config.CombinedConfig).GodoClient()
 
 	log.Printf("[INFO] Deleting Load Balancer: %s", d.Id())
-	_, err := client.LoadBalancers.Delete(context.Background(), d.Id())
+	resp, err := client.LoadBalancers.Delete(context.Background(), d.Id())
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return diag.Errorf("Error deleting Load Balancer: %s", err)
 	}
 


### PR DESCRIPTION
As brought up in this discussion thread, there are cases where Kubernetes will delete a load balancer itself. This can cause an error when Terraform attempts to do so. We can safely ignore a 404 error when attempting to delete as that just indicates that the load balancer has already been destroyed. 

https://github.com/digitalocean/terraform-provider-digitalocean/discussions/1065