### PR TITLE
Remove unclean_leader_election_enable for kafka topic configuration

### DIFF
--- a/digitalocean/database/resource_database_kafka_topic.go
+++ b/digitalocean/database/resource_database_kafka_topic.go
@@ -284,11 +284,6 @@ func ResourceDigitalOceanDatabaseKafkaTopic() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: validateUint64(),
 						},
-						"unclean_leader_election_enable": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
 					},
 				},
 			},
@@ -419,7 +414,6 @@ func flattenTopicConfig(config *godo.TopicConfig) []map[string]interface{} {
 	item["segment_index_bytes"] = strconv.FormatUint(*config.SegmentIndexBytes, 10)
 	item["segment_jitter_ms"] = strconv.FormatUint(*config.SegmentJitterMS, 10)
 	item["segment_ms"] = strconv.FormatUint(*config.SegmentMS, 10)
-	item["unclean_leader_election_enable"] = *config.UncleanLeaderElectionEnable
 	result = append(result, item)
 
 	return result
@@ -570,9 +564,6 @@ func getTopicConfig(raw []interface{}) *godo.TopicConfig {
 			if err == nil {
 				res.SegmentMS = godo.PtrTo(v)
 			}
-		}
-		if v, ok := cfg["unclean_leader_election_enable"]; ok {
-			res.UncleanLeaderElectionEnable = godo.PtrTo(v.(bool))
 		}
 	}
 

--- a/digitalocean/database/resource_database_kafka_topic_test.go
+++ b/digitalocean/database/resource_database_kafka_topic_test.go
@@ -73,8 +73,6 @@ func TestAccDigitalOceanDatabaseKafkaTopic(t *testing.T) {
 						"digitalocean_database_kafka_topic.foobar", "config.0.segment_jitter_ms"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_kafka_topic.foobar", "config.0.segment_ms"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_kafka_topic.foobar", "config.0.unclean_leader_election_enable"),
 				),
 			},
 			{
@@ -136,8 +134,6 @@ func TestAccDigitalOceanDatabaseKafkaTopic(t *testing.T) {
 						"digitalocean_database_kafka_topic.foobar", "config.0.segment_jitter_ms"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_kafka_topic.foobar", "config.0.segment_ms"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_kafka_topic.foobar", "config.0.unclean_leader_election_enable"),
 				),
 			},
 		},

--- a/docs/resources/database_kafka_topic.md
+++ b/docs/resources/database_kafka_topic.md
@@ -39,7 +39,6 @@ resource "digitalocean_database_kafka_topic" "topic-01" {
     segment_index_bytes                 = 10485760
     segment_jitter_ms                   = 0
     segment_ms                          = 604800000
-    unclean_leader_election_enable      = true
   }
 }
 
@@ -91,7 +90,6 @@ The following arguments are supported:
 * `segment_index_bytes` - (Optional) The maximum size, in bytes, of the offset index.
 * `segment_jitter_ms` - (Optional) The maximum time, in ms, subtracted from the scheduled segment disk flush time to avoid the thundering herd problem for segment flushing.
 * `segment_ms` - (Optional) The maximum time, in ms, before the topic log will flush to disk.
-* `unclean_leader_election_enable` - (Optional) Determines whether to allow nodes that are not part of the in-sync replica set (IRS) to be elected as leader. Note: setting this to "true" could result in data loss.
 
 
 


### PR DESCRIPTION
**What**

- remove `unclean_leader_election_enable` property for topic configuration

**Why**

This property is no longer supported for kafka topics due to the dangerous nature of enabling it