### PR TITLE
Kafka topic + user ACL management doc fixes

### DIFF
--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -843,7 +843,7 @@ resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "kafka"
   version    = "%s"
-  size       = "db-s-1vcpu-2gb"
+  size       = "db-s-2vcpu-2gb"
   region     = "nyc1"
   node_count = 3
   tags       = ["production"]

--- a/digitalocean/database/resource_database_kafka_topic.go
+++ b/digitalocean/database/resource_database_kafka_topic.go
@@ -239,8 +239,8 @@ func ResourceDigitalOceanDatabaseKafkaTopic() *schema.Resource {
 						},
 						"min_insync_replicas": {
 							Type:         schema.TypeInt,
+							Default:      1,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"preallocate": {

--- a/digitalocean/database/resource_database_kafka_topic_test.go
+++ b/digitalocean/database/resource_database_kafka_topic_test.go
@@ -122,6 +122,8 @@ func TestAccDigitalOceanDatabaseKafkaTopic(t *testing.T) {
 						"digitalocean_database_kafka_topic.foobar", "config.0.min_compaction_lag_ms"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_kafka_topic.foobar", "config.0.min_insync_replicas"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_kafka_topic.foobar", "config.0.min_insync_replicas", "1"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_kafka_topic.foobar", "config.0.retention_bytes"),
 					resource.TestCheckResourceAttrSet(

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -417,7 +417,7 @@ resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "kafka"
   version    = "3.5"
-  size       = "db-s-1vcpu-2gb"
+  size       = "db-s-2vcpu-2gb"
   region     = "nyc1"
   node_count = 3
 }

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -50,7 +50,7 @@ resource "digitalocean_database_cluster" "kafka-example" {
   name       = "example-kafka-cluster"
   engine     = "kafka"
   version    = "3.5"
-  size       = "db-s-1vcpu-2gb"
+  size       = "db-s-2vcpu-2gb"
   region     = "nyc1"
   node_count = 3
 }

--- a/docs/resources/database_kafka_topic.md
+++ b/docs/resources/database_kafka_topic.md
@@ -46,7 +46,7 @@ resource "digitalocean_database_cluster" "kafka-example" {
   name       = "example-kafka-cluster"
   engine     = "kafka"
   version    = "3.5"
-  size       = "db-s-1vcpu-2gb"
+  size       = "db-s-2vcpu-2gb"
   region     = "nyc1"
   node_count = 3
   tags       = ["production"]

--- a/docs/resources/database_kafka_topic.md
+++ b/docs/resources/database_kafka_topic.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 * `message_timestamp_difference_max_ms` - (Optional) The maximum difference, in ms, between the timestamp specific in a message and when the broker receives the message.
 * `message_timestamp_type` - (Optional) Specifies which timestamp to use for the message. This may be one of "create_time" or "log_append_time".
 * `min_cleanable_dirty_ratio` - (Optional) A scale between 0.0 and 1.0 which controls the frequency of the compactor. Larger values mean more frequent compactions. This is often paired with `max_compaction_lag_ms` to control the compactor frequency.
-* `min_insync_replicas` - (Optional) The number of replicas that must acknowledge a write before it is considered successful. -1 is a special setting to indicate that all nodes must ack a message before a write is considered successful.
+* `min_insync_replicas` - (Optional) The number of replicas that must acknowledge a write before it is considered successful. -1 is a special setting to indicate that all nodes must ack a message before a write is considered successful. Default is 1, indicating at least 1 replica must acknowledge a write to be considered successful.
 * `preallocate` - (Optional) Determines whether to preallocate a file on disk when creating a new log segment within a topic.
 * `retention_bytes` - (Optional) The maximum size, in bytes, of a topic before messages are deleted. -1 is a special setting indicating that this setting has no limit.
 * `retention_ms` - (Optional) The maximum time, in ms, that a topic log file is retained before deleting it. -1 is a special setting indicating that this setting has no limit.

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -103,7 +103,7 @@ The `settings` block is documented below.
 
 An individual ACL includes the following:
 
-* `topic` - (Required) A regex for matching the topic(s) that this ACL should apply to.
+* `topic` - (Required) A regex for matching the topic(s) that this ACL should apply to. The regex can assume one of 3 patterns: "*", "<prefix>*", or "<literal>". "*" is a special value indicating a wildcard that matches on all topics. "<prefix>*" defines a regex that matches all topics with the prefix. "<literal>" performs an exact match on a topic name and only applies to that topic.
 * `permission` - (Required) The permission level applied to the ACL. This includes "admin", "consume", "produce", and "produceconsume". "admin" allows for producing and consuming as well as add/delete/update permission for topics. "consume" allows only for reading topic messages. "produce" allows only for writing topic messages. "produceconsume" allows for both reading and writing topic messages.
 
 ## Attributes Reference

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -57,7 +57,7 @@ resource "digitalocean_database_cluster" "kafka-example" {
   name       = "example-kafka-cluster"
   engine     = "kafka"
   version    = "3.5"
-  size       = "db-s-1vcpu-2gb"
+  size       = "db-s-2vcpu-2gb"
   region     = "nyc1"
   node_count = 3
 }


### PR DESCRIPTION
**What**

- Address default minimum for `min_insync_replicas` for topic advanced config
- Address deprecated kafka plan
- Update documentation

**Why**

When providing a topic's advanced config, we should enforce the default to be 1 for `min_insync_replicas`, even when it is not set. The default is in line with kafka defaults.

https://kafka.apache.org/documentation/#brokerconfigs_min.insync.replicas

**Before**

```
│ Error: Error creating database kafka topic: POST https://api.digitalocean.com/v2/databases/d75f23ac-41db-48f4-9364-33438fc5fe96/topics: 422 (request "4f8db04d-5c7a-4002-837c-5cc81b266999") invalid input for config 'min.insync.replicas': 0 is less than the minimum of 1
```

**After**

```
digitalocean_database_kafka_topic.foobar_topic_6: Creating...
digitalocean_database_kafka_topic.foobar_topic_6: Still creating... [10s elapsed]
digitalocean_database_kafka_topic.foobar_topic_6: Still creating... [20s elapsed]
digitalocean_database_kafka_topic.foobar_topic_6: Still creating... [30s elapsed]
digitalocean_database_kafka_topic.foobar_topic_6: Creation complete after 32s [id=d75f23ac-41db-48f4-9364-33438fc5fe96/topic/topic-6]
```

**Testing**

Ran `TestAccDigitalOceanDatabaseUser_KafkaACLs` and `TestAccDigitalOceanDatabaseKafkaTopic` acceptance tests to confirm results