### PR TITLE
spaces: blr1 is a supported region.

### DIFF
--- a/digitalocean/spaces/spaces_buckets.go
+++ b/digitalocean/spaces/spaces_buckets.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// SpacesRegions is a list of DigitalOcean regions that support Spaces.
-	SpacesRegions = []string{"ams3", "fra1", "nyc3", "sfo2", "sfo3", "sgp1", "syd1"}
+	SpacesRegions = []string{"ams3", "blr1", "fra1", "nyc3", "sfo2", "sfo3", "sgp1", "syd1"}
 )
 
 type bucketMetadataStruct struct {


### PR DESCRIPTION
`blr1` is a supported region for Spaces: https://docs.digitalocean.com/products/spaces/details/availability/

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1083