### PR TITLE
CDN: Add Support for "needs-cloudflare-cert"

### DIFF
--- a/digitalocean/cdn/resource_cdn.go
+++ b/digitalocean/cdn/resource_cdn.go
@@ -284,12 +284,16 @@ func resourceDigitalOceanCDNUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		certName := d.Get("certificate_name").(string)
 		if certName != "" {
-			cert, err := certificate.FindCertificateByName(client, certName)
-			if err != nil {
-				return diag.FromErr(err)
-			}
+			if certName == needsCloudflareCert {
+				cdnUpdateRequest.CertificateID = needsCloudflareCert
+			} else {
+				cert, err := certificate.FindCertificateByName(client, certName)
+				if err != nil {
+					return diag.FromErr(err)
+				}
 
-			cdnUpdateRequest.CertificateID = cert.ID
+				cdnUpdateRequest.CertificateID = cert.ID
+			}
 		}
 
 		_, _, err := client.CDNs.UpdateCustomDomain(context.Background(), d.Id(), cdnUpdateRequest)

--- a/digitalocean/cdn/resource_cdn.go
+++ b/digitalocean/cdn/resource_cdn.go
@@ -17,6 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+var (
+	needsCloudflareCert = "needs-cloudflare-cert"
+)
+
 func ResourceDigitalOceanCDN() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDigitalOceanCDNCreate,
@@ -142,12 +146,15 @@ func resourceDigitalOceanCDNCreate(ctx context.Context, d *schema.ResourceData, 
 	if name, nameOk := d.GetOk("certificate_name"); nameOk {
 		certName := name.(string)
 		if certName != "" {
-			cert, err := certificate.FindCertificateByName(client, certName)
-			if err != nil {
-				return diag.FromErr(err)
+			if certName == needsCloudflareCert {
+				cdnRequest.CertificateID = needsCloudflareCert
+			} else {
+				cert, err := certificate.FindCertificateByName(client, certName)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				cdnRequest.CertificateID = cert.ID
 			}
-
-			cdnRequest.CertificateID = cert.ID
 		}
 	}
 

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -39,6 +39,33 @@ func TestAccDigitalOceanCDN_Create(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanCDN_CreateWithNeedsCloudflareCert(t *testing.T) {
+
+	bucketName := generateBucketName()
+	cdnCreateConfig := fmt.Sprintf(testAccCheckDigitalOceanCDNConfig_CreateWithNeedsCloudflareCert, bucketName)
+
+	expectedOrigin := bucketName + originSuffix
+	expectedTTL := "3600"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanCDNDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cdnCreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanCDNExists("digitalocean_cdn.foobar"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_cdn.foobar", "origin", expectedOrigin),
+					resource.TestCheckResourceAttr("digitalocean_cdn.foobar", "ttl", expectedTTL),
+					resource.TestCheckResourceAttr("digitalocean_cdn.foobar", "certificate_name", "need-cloudflare-cert"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanCDN_Create_with_TTL(t *testing.T) {
 
 	bucketName := generateBucketName()
@@ -205,6 +232,18 @@ resource "digitalocean_spaces_bucket" "bucket" {
 
 resource "digitalocean_cdn" "foobar" {
   origin = digitalocean_spaces_bucket.bucket.bucket_domain_name
+}`
+
+const testAccCheckDigitalOceanCDNConfig_CreateWithNeedsCloudflareCert = `
+resource "digitalocean_spaces_bucket" "bucket" {
+  name   = "%s"
+  region = "ams3"
+  acl    = "public-read"
+}
+
+resource "digitalocean_cdn" "foobar" {
+  origin = digitalocean_spaces_bucket.bucket.bucket_domain_name
+  certificate_name = "needs-cloudflare-cert"
 }`
 
 const testAccCheckDigitalOceanCDNConfig_Create_with_TTL = `

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -39,10 +39,10 @@ func TestAccDigitalOceanCDN_Create(t *testing.T) {
 	})
 }
 
-func TestAccDigitalOceanCDN_CreateWithNeedsCloudflareCert(t *testing.T) {
+func TestAccDigitalOceanCDN_CreateWithNeedCloudflareCert(t *testing.T) {
 
 	bucketName := generateBucketName()
-	cdnCreateConfig := fmt.Sprintf(testAccCheckDigitalOceanCDNConfig_CreateWithNeedsCloudflareCert, bucketName)
+	cdnCreateConfig := fmt.Sprintf(testAccCheckDigitalOceanCDNConfig_CreateWithNeedCloudflareCert, bucketName)
 
 	expectedOrigin := bucketName + originSuffix
 	expectedTTL := "3600"
@@ -234,7 +234,7 @@ resource "digitalocean_cdn" "foobar" {
   origin = digitalocean_spaces_bucket.bucket.bucket_domain_name
 }`
 
-const testAccCheckDigitalOceanCDNConfig_CreateWithNeedsCloudflareCert = `
+const testAccCheckDigitalOceanCDNConfig_CreateWithNeedCloudflareCert = `
 resource "digitalocean_spaces_bucket" "bucket" {
   name   = "%s"
   region = "ams3"
@@ -243,7 +243,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 
 resource "digitalocean_cdn" "foobar" {
   origin           = digitalocean_spaces_bucket.bucket.bucket_domain_name
-  certificate_name = "needs-cloudflare-cert"
+  certificate_name = "need-cloudflare-cert"
 }`
 
 const testAccCheckDigitalOceanCDNConfig_Create_with_TTL = `

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -59,7 +59,7 @@ func TestAccDigitalOceanCDN_CreateWithNeedCloudflareCert(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_cdn.foobar", "origin", expectedOrigin),
 					resource.TestCheckResourceAttr("digitalocean_cdn.foobar", "ttl", expectedTTL),
-					resource.TestCheckResourceAttr("digitalocean_cdn.foobar", "certificate_name", "need-cloudflare-cert"),
+					resource.TestCheckResourceAttr("digitalocean_cdn.foobar", "certificate_name", "needs-cloudflare-cert"),
 				),
 			},
 		},
@@ -243,7 +243,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 
 resource "digitalocean_cdn" "foobar" {
   origin           = digitalocean_spaces_bucket.bucket.bucket_domain_name
-  certificate_name = "need-cloudflare-cert"
+  certificate_name = "needs-cloudflare-cert"
 }`
 
 const testAccCheckDigitalOceanCDNConfig_Create_with_TTL = `

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -242,7 +242,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 }
 
 resource "digitalocean_cdn" "foobar" {
-  origin = digitalocean_spaces_bucket.bucket.bucket_domain_name
+  origin           = digitalocean_spaces_bucket.bucket.bucket_domain_name
   certificate_name = "needs-cloudflare-cert"
 }`
 

--- a/docs/resources/cdn.md
+++ b/docs/resources/cdn.md
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `origin` - (Required) The fully qualified domain name, (FQDN) for a Space.
 * `ttl` - (Optional) The time to live for the CDN Endpoint, in seconds. Default is 3600 seconds.
-* `certificate_name`- (Optional) The unique name of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+* `certificate_name`- (Optional) The unique name of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided. Pass in `needs-cloudflare-cert` to have Cloudflare generate a certificate.
 * `certificate_id`- (Optional) **Deprecated** The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
 * `custom_domain` - (Optional) The fully qualified domain name (FQDN) of the custom subdomain used with the CDN Endpoint.
 

--- a/docs/resources/cdn.md
+++ b/docs/resources/cdn.md
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `origin` - (Required) The fully qualified domain name, (FQDN) for a Space.
 * `ttl` - (Optional) The time to live for the CDN Endpoint, in seconds. Default is 3600 seconds.
-* `certificate_name`- (Optional) The unique name of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided. Pass in `needs-cloudflare-cert` to have Cloudflare generate a certificate.
+* `certificate_name`- (Optional) The unique name of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
 * `certificate_id`- (Optional) **Deprecated** The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
 * `custom_domain` - (Optional) The fully qualified domain name (FQDN) of the custom subdomain used with the CDN Endpoint.
 


### PR DESCRIPTION
Address #1086 

In order to have Cloudflare generate a certificate, `certificate_id` must be set to the value "needs-cloudflare-cert" in our API.

In the Terraform provider `certificate_name` is passed in instead of a `certificate_id` _(we've deprecated certificate_id attribute in favor of certificate_name for digitalocean_cdn because when the certificate type is lets_encrypt, the certificate ID will change on renewal (after 3 months)_), we use the name to look up the id and then set that id to `certificate_id`.....hence the `certificate_id` will not be `needs-cloudflare-cert` [here](https://github.com/digitalocean/terraform-provider-digitalocean/blob/main/digitalocean/cdn/resource_cdn.go#L142-L151):
```
	if name, nameOk := d.GetOk("certificate_name"); nameOk {
		certName := name.(string)
		if certName != "" {
			cert, err := certificate.FindCertificateByName(client, certName)
			if err != nil {
				return diag.FromErr(err)
			}

			cdnRequest.CertificateID = cert.ID
		}
```

Added logic to check if `needs-cloudflare-cert`is passed into `certificate_name` to set that as the `certificate_id`