### PR TITLE
Database Users: Update settings independent of other user settings

### DIFF
--- a/digitalocean/database/resource_database_user.go
+++ b/digitalocean/database/resource_database_user.go
@@ -88,13 +88,11 @@ func userACLSchema() *schema.Resource {
 			"topic": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"permission": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"admin",
 					"consume",
@@ -209,6 +207,16 @@ func resourceDigitalOceanDatabaseUserUpdate(ctx context.Context, d *schema.Resou
 		_, _, err := client.Databases.ResetUserAuth(context.Background(), d.Get("cluster_id").(string), d.Get("name").(string), authReq)
 		if err != nil {
 			return diag.Errorf("Error updating mysql_auth_plugin for DatabaseUser: %s", err)
+		}
+	}
+	if d.HasChange("settings") {
+		updateReq := &godo.DatabaseUpdateUserRequest{}
+		if v, ok := d.GetOk("settings"); ok {
+			updateReq.Settings = expandUserSettings(v.([]interface{}))
+		}
+		_, _, err := client.Databases.UpdateUser(context.Background(), d.Get("cluster_id").(string), d.Get("name").(string), updateReq)
+		if err != nil {
+			return diag.Errorf("Error updating settings for DatabaseUser: %s", err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.105.1
+	github.com/digitalocean/godo v1.107.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.105.0 h1:bUfWVsyQCYZ7OQLK+p2EBFYWD5BoOgpyq/PMSQHEeMg=
-github.com/digitalocean/godo v1.105.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
-github.com/digitalocean/godo v1.105.1 h1:3FjFDurw7po27Y0uHhdR+EvwNil06KCeu1Nx/0jZbmI=
-github.com/digitalocean/godo v1.105.1/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
+github.com/digitalocean/godo v1.107.0 h1:P72IbmGFQvKOvyjVLyT59bmHxilA4E5hWi40rF4zNQc=
+github.com/digitalocean/godo v1.107.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v1.107.0] - 2023-12-07
+
+- #658 - @markusthoemmes - APPS-8033 Add the RUN_RESTARTED log type
+- #656 - @dweinshenker - Enhancement: add database user update
+- #657 - @markusthoemmes - apps: Add registry_credentials field, GHCR registry type and the egress spec
+
+## [v1.106.0] - 2023-11-14
+
+- #654 - @dweinshenker - Remove unclean_leader_election_enable for topic configuration
+
 ## [v1.105.1] - 2023-11-07
 
 - #652 - @andrewsomething - Retry on HTTP/2 internal errors.

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -244,6 +244,20 @@ const (
 	AppDomainSpecType_Alias       AppDomainSpecType = "ALIAS"
 )
 
+// AppEgressSpec Specification for app egress configurations.
+type AppEgressSpec struct {
+	Type AppEgressSpecType `json:"type,omitempty"`
+}
+
+// AppEgressSpecType the model 'AppEgressSpecType'
+type AppEgressSpecType string
+
+// List of AppEgressSpecType
+const (
+	APPEGRESSSPECTYPE_Autoassign  AppEgressSpecType = "AUTOASSIGN"
+	APPEGRESSSPECTYPE_DedicatedIp AppEgressSpecType = "DEDICATED_IP"
+)
+
 // AppFunctionsSpec struct for AppFunctionsSpec
 type AppFunctionsSpec struct {
 	// The name. Must be unique across all components within the same app.
@@ -495,6 +509,7 @@ type AppSpec struct {
 	// A list of alerts which apply to the app.
 	Alerts   []*AppAlertSpec `json:"alerts,omitempty"`
 	Ingress  *AppIngressSpec `json:"ingress,omitempty"`
+	Egress   *AppEgressSpec  `json:"egress,omitempty"`
 	Features []string        `json:"features,omitempty"`
 }
 
@@ -1012,8 +1027,10 @@ type ImageSourceSpec struct {
 	// The repository tag. Defaults to `latest` if not provided and no digest is provided. Cannot be specified if digest is provided.
 	Tag string `json:"tag,omitempty"`
 	// The image digest. Cannot be specified if tag is provided.
-	Digest       string                       `json:"digest,omitempty"`
-	DeployOnPush *ImageSourceSpecDeployOnPush `json:"deploy_on_push,omitempty"`
+	Digest string `json:"digest,omitempty"`
+	// The credentials to be able to pull the image. The value will be encrypted on first submission. On following submissions, the encrypted value should be used. - \"$username:$access_token\" for registries of type `DOCKER_HUB`. - \"$username:$access_token\" for registries of type `GHCR`.
+	RegistryCredentials string                       `json:"registry_credentials,omitempty"`
+	DeployOnPush        *ImageSourceSpecDeployOnPush `json:"deploy_on_push,omitempty"`
 }
 
 // ImageSourceSpecDeployOnPush struct for ImageSourceSpecDeployOnPush
@@ -1022,7 +1039,7 @@ type ImageSourceSpecDeployOnPush struct {
 	Enabled bool `json:"enabled,omitempty"`
 }
 
-// ImageSourceSpecRegistryType  - DOCR: The DigitalOcean container registry type.  - DOCKER_HUB: The DockerHub container registry type.
+// ImageSourceSpecRegistryType  - DOCR: The DigitalOcean container registry type.  - DOCKER_HUB: The DockerHub container registry type.  - GHCR: The GitHub container registry type.
 type ImageSourceSpecRegistryType string
 
 // List of ImageSourceSpecRegistryType
@@ -1030,6 +1047,7 @@ const (
 	ImageSourceSpecRegistryType_Unspecified ImageSourceSpecRegistryType = "UNSPECIFIED"
 	ImageSourceSpecRegistryType_DOCR        ImageSourceSpecRegistryType = "DOCR"
 	ImageSourceSpecRegistryType_DockerHub   ImageSourceSpecRegistryType = "DOCKER_HUB"
+	ImageSourceSpecRegistryType_Ghcr        ImageSourceSpecRegistryType = "GHCR"
 )
 
 // AppInstanceSize struct for AppInstanceSize

--- a/vendor/github.com/digitalocean/godo/apps.go
+++ b/vendor/github.com/digitalocean/godo/apps.go
@@ -21,6 +21,8 @@ const (
 	AppLogTypeDeploy AppLogType = "DEPLOY"
 	// AppLogTypeRun represents run logs.
 	AppLogTypeRun AppLogType = "RUN"
+	// AppLogTypeRunRestarted represents logs of crashed/restarted instances during runtime.
+	AppLogTypeRunRestarted AppLogType = "RUN_RESTARTED"
 )
 
 // AppsService is an interface for interfacing with the App Platform endpoints

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -757,6 +757,14 @@ func (a *AppDomainValidation) GetTXTValue() string {
 	return a.TXTValue
 }
 
+// GetType returns the Type field.
+func (a *AppEgressSpec) GetType() AppEgressSpecType {
+	if a == nil {
+		return ""
+	}
+	return a.Type
+}
+
 // GetAlerts returns the Alerts field.
 func (a *AppFunctionsSpec) GetAlerts() []*AppAlertSpec {
 	if a == nil {
@@ -1731,6 +1739,14 @@ func (a *AppSpec) GetDomains() []*AppDomainSpec {
 		return nil
 	}
 	return a.Domains
+}
+
+// GetEgress returns the Egress field.
+func (a *AppSpec) GetEgress() *AppEgressSpec {
+	if a == nil {
+		return nil
+	}
+	return a.Egress
 }
 
 // GetEnvs returns the Envs field.
@@ -3187,6 +3203,14 @@ func (i *ImageSourceSpec) GetRegistry() string {
 		return ""
 	}
 	return i.Registry
+}
+
+// GetRegistryCredentials returns the RegistryCredentials field.
+func (i *ImageSourceSpec) GetRegistryCredentials() string {
+	if i == nil {
+		return ""
+	}
+	return i.RegistryCredentials
 }
 
 // GetRegistryType returns the RegistryType field.

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -118,6 +118,7 @@ type DatabasesService interface {
 	GetUser(context.Context, string, string) (*DatabaseUser, *Response, error)
 	ListUsers(context.Context, string, *ListOptions) ([]DatabaseUser, *Response, error)
 	CreateUser(context.Context, string, *DatabaseCreateUserRequest) (*DatabaseUser, *Response, error)
+	UpdateUser(context.Context, string, string, *DatabaseUpdateUserRequest) (*DatabaseUser, *Response, error)
 	DeleteUser(context.Context, string, string) (*Response, error)
 	ResetUserAuth(context.Context, string, string, *DatabaseResetUserAuthRequest) (*DatabaseUser, *Response, error)
 	ListDBs(context.Context, string, *ListOptions) ([]DatabaseDB, *Response, error)
@@ -347,7 +348,6 @@ type TopicConfig struct {
 	SegmentIndexBytes               *uint64  `json:"segment_index_bytes,omitempty"`
 	SegmentJitterMS                 *uint64  `json:"segment_jitter_ms,omitempty"`
 	SegmentMS                       *uint64  `json:"segment_ms,omitempty"`
-	UncleanLeaderElectionEnable     *bool    `json:"unclean_leader_election_enable,omitempty"`
 }
 
 // DatabaseCreateTopicRequest is used to create a new topic within a kafka cluster
@@ -411,6 +411,11 @@ type DatabaseCreateUserRequest struct {
 	Name          string                     `json:"name"`
 	MySQLSettings *DatabaseMySQLUserSettings `json:"mysql_settings,omitempty"`
 	Settings      *DatabaseUserSettings      `json:"settings,omitempty"`
+}
+
+// DatabaseUpdateUserRequest is used to update an existing database user
+type DatabaseUpdateUserRequest struct {
+	Settings *DatabaseUserSettings `json:"settings,omitempty"`
 }
 
 // DatabaseResetUserAuthRequest is used to reset a users DB auth
@@ -860,6 +865,21 @@ func (svc *DatabasesServiceOp) ListUsers(ctx context.Context, databaseID string,
 func (svc *DatabasesServiceOp) CreateUser(ctx context.Context, databaseID string, createUser *DatabaseCreateUserRequest) (*DatabaseUser, *Response, error) {
 	path := fmt.Sprintf(databaseUsersPath, databaseID)
 	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, createUser)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseUserRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.User, resp, nil
+}
+
+// UpdateUser will update an existing database user
+func (svc *DatabasesServiceOp) UpdateUser(ctx context.Context, databaseID, userID string, updateUser *DatabaseUpdateUserRequest) (*DatabaseUser, *Response, error) {
+	path := fmt.Sprintf(databaseUserPath, databaseID, userID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, updateUser)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.105.1"
+	libraryVersion = "1.107.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.105.1
+# github.com/digitalocean/godo v1.107.0
 ## explicit; go 1.20
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
**What**

- Prevent changes to kafka user ACLs from replacing database user resources

**Why**

The ability to update `settings`, and thus kafka user ACLs, allows for user management without replacing the user resources. Replacement of user resources is especially painful given that it will generate a new password.

**Evidence**

Ran acceptance tests
```
ok  	github.com/digitalocean/terraform-provider-digitalocean/digitalocean/certificate	(cached) [no tests to run]
=== RUN   TestAccDigitalOceanDatabaseUser_KafkaACLs
=== PAUSE TestAccDigitalOceanDatabaseUser_KafkaACLs
=== CONT  TestAccDigitalOceanDatabaseUser_KafkaACLs
--- PASS: TestAccDigitalOceanDatabaseUser_KafkaACLs (289.63s)
```

Making a change locally to a user's ACLs on a test cluster and running `terraform plan` shows the user resource not being replaced anymore
```
  # digitalocean_database_user.kafka-acl-user-1 will be updated in-place
  ~ resource "digitalocean_database_user" "kafka-acl-user-1" {
        id         = "352c8602-261c-4c00-a2e2-0130f015e243/user/kafka-acl-user-1"
        name       = "kafka-acl-user-1"
        # (3 unchanged attributes hidden)

      ~ settings {
          ~ acl {
                id         = "acl47b2345b42e"
              ~ permission = "produceconsume" -> "consume"
                # (1 unchanged attribute hidden)
            }

            # (1 unchanged block hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```