### PR TITLE
databases: ignore seconds in maintenance_window.hour

### DIFF
--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -104,9 +104,12 @@ func ResourceDigitalOceanDatabaseCluster() *schema.Resource {
 							// Prevent a diff when seconds in response, e.g: "13:00" -> "13:00:00"
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								newSplit := strings.Split(new, ":")
+								oldSplit := strings.Split(old, ":")
 								if len(newSplit) == 3 {
-									newTrimed := strings.Join(newSplit[:2], ":")
-									return newTrimed == old
+									new = strings.Join(newSplit[:2], ":")
+								}
+								if len(oldSplit) == 3 {
+									old = strings.Join(oldSplit[:2], ":")
 								}
 								return old == new
 							},

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -781,7 +781,7 @@ resource "digitalocean_database_cluster" "foobar" {
 
   maintenance_window {
     day  = "friday"
-    hour = "13:00:00"
+    hour = "13:00"
   }
 }`
 


### PR DESCRIPTION
This resolves an issue with unexpected diffs from `maintenance_window.hour`. The logic in the existing `DiffSuppressFunc` is a bit backwards. It's not entirely clear to me if this was always just wrong or if the API changed behaviour at some point.

I think the best path forward from the provider perspective it to make it so seconds are ignored completely when calculating the diff. Users should not need to scheduled a maintenance down to the second. They are too fine grained.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1093