### PR TITLE
cdn: handle 'needs-cloudflare-cert' case in read func.

### DIFF
--- a/digitalocean/cdn/resource_cdn.go
+++ b/digitalocean/cdn/resource_cdn.go
@@ -212,7 +212,7 @@ func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("created_at", cdn.CreatedAt.UTC().String())
 	d.Set("custom_domain", cdn.CustomDomain)
 
-	if cdn.CertificateID != "" {
+	if cdn.CertificateID != "" && cdn.CertificateID != needsCloudflareCert {
 		// When the certificate type is lets_encrypt, the certificate
 		// ID will change when it's renewed, so we have to rely on the
 		// certificate name as the primary identifier instead.
@@ -222,6 +222,11 @@ func resourceDigitalOceanCDNRead(ctx context.Context, d *schema.ResourceData, me
 		}
 		d.Set("certificate_id", cert.Name)
 		d.Set("certificate_name", cert.Name)
+	}
+
+	if cdn.CertificateID == needsCloudflareCert {
+		d.Set("certificate_id", cdn.CertificateID)
+		d.Set("certificate_name", cdn.CertificateID)
 	}
 
 	return nil

--- a/digitalocean/cdn/resource_cdn_test.go
+++ b/digitalocean/cdn/resource_cdn_test.go
@@ -3,6 +3,7 @@ package cdn_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
@@ -40,9 +41,13 @@ func TestAccDigitalOceanCDN_Create(t *testing.T) {
 }
 
 func TestAccDigitalOceanCDN_CreateWithNeedCloudflareCert(t *testing.T) {
+	domain := os.Getenv("DO_TEST_SUBDOMAIN")
+	if domain == "" {
+		t.Skip("Test requires an active DO manage sub domain. Set DO_TEST_SUBDOMAIN")
+	}
 
 	bucketName := generateBucketName()
-	cdnCreateConfig := fmt.Sprintf(testAccCheckDigitalOceanCDNConfig_CreateWithNeedCloudflareCert, bucketName)
+	cdnCreateConfig := fmt.Sprintf(testAccCheckDigitalOceanCDNConfig_CreateWithNeedCloudflareCert, bucketName, domain)
 
 	expectedOrigin := bucketName + originSuffix
 	expectedTTL := "3600"
@@ -244,6 +249,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 resource "digitalocean_cdn" "foobar" {
   origin           = digitalocean_spaces_bucket.bucket.bucket_domain_name
   certificate_name = "needs-cloudflare-cert"
+  custom_domain    = "%s"
 }`
 
 const testAccCheckDigitalOceanCDNConfig_Create_with_TTL = `


### PR DESCRIPTION
This addresses the continued issue called out in https://github.com/digitalocean/terraform-provider-digitalocean/issues/1086. We need to handle the 'needs-cloudflare-cert' case in read func as well as create. 

The acceptance test did not catch this. In order to fully test the flow, we would need an active domain. We can do this in our own testing, but the acceptance test suite must be usable by external contributors and not depend on external resources. So the updated test is skipped if `DO_TEST_SUBDOMAIN` is not set to an active DO manage sub domain.