### PR TITLE
database: Add access_cert and access_key for kafka users

### DIFF
--- a/digitalocean/database/datasource_database_user.go
+++ b/digitalocean/database/datasource_database_user.go
@@ -32,6 +32,16 @@ func DataSourceDigitalOceanDatabaseUser() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"access_cert": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 			"mysql_auth_plugin": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -73,6 +83,13 @@ func dataSourceDigitalOceanDatabaseUserRead(ctx context.Context, d *schema.Resou
 
 	if user.MySQLSettings != nil {
 		d.Set("mysql_auth_plugin", user.MySQLSettings.AuthPlugin)
+	}
+
+	if user.AccessCert != "" {
+		d.Set("access_cert", user.AccessCert)
+	}
+	if user.AccessKey != "" {
+		d.Set("access_key", user.AccessKey)
 	}
 
 	if err := d.Set("settings", flattenUserSettings(user.Settings)); err != nil {

--- a/digitalocean/database/datasource_database_user_test.go
+++ b/digitalocean/database/datasource_database_user_test.go
@@ -34,6 +34,10 @@ func TestAccDataSourceDigitalOceanDatabaseUser_Basic(t *testing.T) {
 						"digitalocean_database_user.foobar_user", "role"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_user.foobar_user", "password"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "access_cert"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "access_key"),
 				),
 			},
 			{
@@ -45,6 +49,10 @@ func TestAccDataSourceDigitalOceanDatabaseUser_Basic(t *testing.T) {
 						"data.digitalocean_database_user.foobar_user", "role"),
 					resource.TestCheckResourceAttrPair("digitalocean_database_user.foobar_user", "password",
 						"data.digitalocean_database_user.foobar_user", "password"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "access_cert"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "access_key"),
 				),
 			},
 		},

--- a/digitalocean/database/resource_database_user.go
+++ b/digitalocean/database/resource_database_user.go
@@ -74,6 +74,16 @@ func ResourceDigitalOceanDatabaseUser() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"access_cert": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -185,6 +195,14 @@ func setDatabaseUserAttributes(d *schema.ResourceData, user *godo.DatabaseUser) 
 
 	if user.MySQLSettings != nil {
 		d.Set("mysql_auth_plugin", user.MySQLSettings.AuthPlugin)
+	}
+
+	// This is only set for kafka users
+	if user.AccessCert != "" {
+		d.Set("access_cert", user.AccessCert)
+	}
+	if user.AccessKey != "" {
+		d.Set("access_key", user.AccessKey)
 	}
 }
 

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -35,6 +35,12 @@ func TestAccDigitalOceanDatabaseUser_Basic(t *testing.T) {
 						"digitalocean_database_user.foobar_user", "role"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_user.foobar_user", "password"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "mysql_auth_plugin"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "access_cert"),
+					resource.TestCheckNoResourceAttr(
+						"digitalocean_database_user.foobar_user", "access_key"),
 				),
 			},
 			{
@@ -198,6 +204,10 @@ func TestAccDigitalOceanDatabaseUser_KafkaACLs(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_user.foobar_user", "password"),
 					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "access_cert"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "access_key"),
+					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_user.foobar_user", "settings.0.acl.0.id"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_user.foobar_user", "settings.0.acl.0.topic", "topic-1"),
@@ -234,6 +244,10 @@ func TestAccDigitalOceanDatabaseUser_KafkaACLs(t *testing.T) {
 						"digitalocean_database_user.foobar_user", "role"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_user.foobar_user", "password"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "access_cert"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "access_key"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_user.foobar_user", "settings.0.acl.0.id"),
 					resource.TestCheckResourceAttr(

--- a/docs/data-sources/database_user.md
+++ b/docs/data-sources/database_user.md
@@ -37,4 +37,6 @@ The following attributes are exported:
 
 * `role` - The role of the database user. The value will be either `primary` or `normal`.
 * `password` - The password of the database user. This will not be set for MongoDB users.
+* `access_cert` - Access certificate for TLS client authentication. (Kafka only)
+* `access_key` - Access key for TLS client authentication. (Kafka only)
 * `mysql_auth_plugin` - The authentication method of the MySQL user. The value will be `mysql_native_password` or `caching_sha2_password`.

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -112,6 +112,8 @@ In addition to the above arguments, the following attributes are exported:
 
 * `role` - Role for the database user. The value will be either "primary" or "normal".
 * `password` - Password for the database user.
+* `access_cert` - Access certificate for TLS client authentication. (Kafka only)
+* `access_key` - Access key for TLS client authentication. (Kafka only)
 
 For individual ACLs for Kafka topics, the following attributes are exported:
 * `id` - An identifier for the ACL, this will be automatically assigned when you create an ACL entry


### PR DESCRIPTION
I didn't create an issue but saw this functionality was missing while it was available via the DO API as well as in `godo`.

I ran the following acceptance tests:

```
➜  terraform-provider-digitalocean git:(add-database-user-cert-attributes) ✗ make testacc TESTARGS='-run="^(TestAccDigitalOceanDatabaseUser_Basic|TestAccDigitalOceanDatabaseUser_KafkaACLs|TestAccDataSourceDigitalOceanDatabaseUser_Basic)$$"' PKG_NAME=digitalocean/database
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/database/... -run="^(TestAccDigitalOceanDatabaseUser_Basic|TestAccDigitalOceanDatabaseUser_KafkaACLs|TestAccDataSourceDigitalOceanDatabaseUser_Basic)$" -timeout 120m -parallel=3
=== RUN   TestAccDataSourceDigitalOceanDatabaseUser_Basic
=== PAUSE TestAccDataSourceDigitalOceanDatabaseUser_Basic
=== RUN   TestAccDigitalOceanDatabaseUser_Basic
=== PAUSE TestAccDigitalOceanDatabaseUser_Basic
=== RUN   TestAccDigitalOceanDatabaseUser_KafkaACLs
=== PAUSE TestAccDigitalOceanDatabaseUser_KafkaACLs
=== CONT  TestAccDataSourceDigitalOceanDatabaseUser_Basic
=== CONT  TestAccDigitalOceanDatabaseUser_KafkaACLs
=== CONT  TestAccDigitalOceanDatabaseUser_Basic
--- PASS: TestAccDigitalOceanDatabaseUser_Basic (249.61s)
--- PASS: TestAccDataSourceDigitalOceanDatabaseUser_Basic (306.01s)
--- PASS: TestAccDigitalOceanDatabaseUser_KafkaACLs (428.15s)
PASS
ok  	github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database	428.168s
```