### PR TITLE
Support scalable storage settings separately for read-replica vs. primary

### DIFF
--- a/digitalocean/database/datasource_database_replica.go
+++ b/digitalocean/database/datasource_database_replica.go
@@ -93,6 +93,11 @@ func DataSourceDigitalOceanDatabaseReplica() *schema.Resource {
 				},
 				Set: util.HashStringIgnoreCase,
 			},
+
+			"storage_size_mib": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/digitalocean/database/datasource_database_replica_test.go
+++ b/digitalocean/database/datasource_database_replica_test.go
@@ -77,6 +77,8 @@ func TestAccDataSourceDigitalOceanDatabaseReplica_Basic(t *testing.T) {
 						"data.digitalocean_database_replica.my_db_replica", "tags.#", "1"),
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_replica.my_db_replica", "private_network_uuid"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_replica.my_db_replica", "storage_size_mib", "30720"),
 				),
 			},
 		},

--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -364,7 +364,11 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 			SizeSlug: d.Get("size").(string),
 			NumNodes: d.Get("node_count").(int),
 		}
-		if v, ok := d.GetOk("storage_size_mib"); ok {
+
+		// only include the storage_size_mib in the resize request if it has changed
+		// this avoids invalid values when plans sizes are increasing that require higher base levels of storage
+		// excluding this parameter will utilize default base storage levels for the given plan size
+		if v, ok := d.GetOk("storage_size_mib"); ok && d.HasChange("storage_size_mib") {
 			v, err := strconv.ParseUint(v.(string), 10, 64)
 			if err == nil {
 				opts.StorageSizeMib = v

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -930,7 +930,7 @@ const testAccCheckDigitalOceanDatabaseClusterConfigMongoDB = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "mongodb"
-  version    = "4"
+  version    = "6"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc3"
   node_count = 1

--- a/digitalocean/database/resource_database_replica_test.go
+++ b/digitalocean/database/resource_database_replica_test.go
@@ -256,22 +256,22 @@ resource "digitalocean_database_replica" "read-01" {
 
 const testAccCheckDigitalOceanDatabaseReplicaConfigResized = `
 resource "digitalocean_database_replica" "read-01" {
-  cluster_id = digitalocean_database_cluster.foobar.id
-  name       = "%s"
-  region     = "nyc3"
-  size       = "db-s-2vcpu-4gb"
+  cluster_id       = digitalocean_database_cluster.foobar.id
+  name             = "%s"
+  region           = "nyc3"
+  size             = "db-s-2vcpu-4gb"
   storage_size_mib = 61440
-  tags       = ["staging"]
+  tags             = ["staging"]
 }`
 
 const testAccCheckDigitalOceanDatabaseReplicaConfigResizedWithStorage = `
 resource "digitalocean_database_replica" "read-01" {
-  cluster_id = digitalocean_database_cluster.foobar.id
-  name       = "%s"
-  region     = "nyc3"
-  size       = "db-s-2vcpu-4gb"
+  cluster_id       = digitalocean_database_cluster.foobar.id
+  name             = "%s"
+  region           = "nyc3"
+  size             = "db-s-2vcpu-4gb"
   storage_size_mib = 71680
-  tags       = ["staging"]
+  tags             = ["staging"]
 }`
 
 const testAccCheckDigitalOceanDatabaseReplicaConfigWithVPC = `

--- a/digitalocean/database/resource_database_replica_test.go
+++ b/digitalocean/database/resource_database_replica_test.go
@@ -115,7 +115,6 @@ func TestAccDigitalOceanDatabaseReplica_Resize(t *testing.T) {
 	databaseConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigBasic, databaseName)
 	replicaConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseReplicaConfigBasic, databaseReplicaName)
 	resizedConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseReplicaConfigResized, databaseReplicaName)
-	resizedWithStorageConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseReplicaConfigResizedWithStorage, databaseReplicaName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -154,21 +153,6 @@ func TestAccDigitalOceanDatabaseReplica_Resize(t *testing.T) {
 						"digitalocean_database_replica.read-01", "storage_size_mib", "61440"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_replica.read-01", "name", databaseReplicaName),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_replica.read-01", "uuid"),
-				),
-			},
-			{
-				Config: databaseConfig + resizedWithStorageConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDigitalOceanDatabaseReplicaExists("digitalocean_database_replica.read-01", &databaseReplica),
-					testAccCheckDigitalOceanDatabaseReplicaAttributes(&databaseReplica, databaseReplicaName),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_replica.read-01", "size", "db-s-2vcpu-4gb"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_replica.read-01", "name", databaseReplicaName),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_replica.read-01", "storage_size_mib", "71680"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "uuid"),
 				),
@@ -261,16 +245,6 @@ resource "digitalocean_database_replica" "read-01" {
   region           = "nyc3"
   size             = "db-s-2vcpu-4gb"
   storage_size_mib = 61440
-  tags             = ["staging"]
-}`
-
-const testAccCheckDigitalOceanDatabaseReplicaConfigResizedWithStorage = `
-resource "digitalocean_database_replica" "read-01" {
-  cluster_id       = digitalocean_database_cluster.foobar.id
-  name             = "%s"
-  region           = "nyc3"
-  size             = "db-s-2vcpu-4gb"
-  storage_size_mib = 71680
   tags             = ["staging"]
 }`
 

--- a/digitalocean/database/resource_database_replica_test.go
+++ b/digitalocean/database/resource_database_replica_test.go
@@ -115,6 +115,7 @@ func TestAccDigitalOceanDatabaseReplica_Resize(t *testing.T) {
 	databaseConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigBasic, databaseName)
 	replicaConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseReplicaConfigBasic, databaseReplicaName)
 	resizedConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseReplicaConfigResized, databaseReplicaName)
+	resizedWithStorageConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseReplicaConfigResizedWithStorage, databaseReplicaName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -135,6 +136,8 @@ func TestAccDigitalOceanDatabaseReplica_Resize(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_replica.read-01", "size", "db-s-1vcpu-2gb"),
 					resource.TestCheckResourceAttr(
+						"digitalocean_database_replica.read-01", "storage_size_mib", "30720"),
+					resource.TestCheckResourceAttr(
 						"digitalocean_database_replica.read-01", "name", databaseReplicaName),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "uuid"),
@@ -148,7 +151,24 @@ func TestAccDigitalOceanDatabaseReplica_Resize(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_replica.read-01", "size", "db-s-2vcpu-4gb"),
 					resource.TestCheckResourceAttr(
+						"digitalocean_database_replica.read-01", "storage_size_mib", "61440"),
+					resource.TestCheckResourceAttr(
 						"digitalocean_database_replica.read-01", "name", databaseReplicaName),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_replica.read-01", "uuid"),
+				),
+			},
+			{
+				Config: databaseConfig + resizedWithStorageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseReplicaExists("digitalocean_database_replica.read-01", &databaseReplica),
+					testAccCheckDigitalOceanDatabaseReplicaAttributes(&databaseReplica, databaseReplicaName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_replica.read-01", "size", "db-s-2vcpu-4gb"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_replica.read-01", "name", databaseReplicaName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_replica.read-01", "storage_size_mib", "71680"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "uuid"),
 				),
@@ -240,6 +260,17 @@ resource "digitalocean_database_replica" "read-01" {
   name       = "%s"
   region     = "nyc3"
   size       = "db-s-2vcpu-4gb"
+  storage_size_mib = 61440
+  tags       = ["staging"]
+}`
+
+const testAccCheckDigitalOceanDatabaseReplicaConfigResizedWithStorage = `
+resource "digitalocean_database_replica" "read-01" {
+  cluster_id = digitalocean_database_cluster.foobar.id
+  name       = "%s"
+  region     = "nyc3"
+  size       = "db-s-2vcpu-4gb"
+  storage_size_mib = 71680
   tags       = ["staging"]
 }`
 

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -363,7 +363,7 @@ const testAccCheckDigitalOceanDatabaseUserConfigMongo = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "mongodb"
-  version    = "4"
+  version    = "6"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -383,7 +383,7 @@ const testAccCheckDigitalOceanDatabaseUserConfigMongoMultiUser = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "mongodb"
-  version    = "4"
+  version    = "6"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -61,7 +61,7 @@ resource "digitalocean_database_cluster" "kafka-example" {
 resource "digitalocean_database_cluster" "mongodb-example" {
   name       = "example-mongo-cluster"
   engine     = "mongodb"
-  version    = "4"
+  version    = "6"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc3"
   node_count = 1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb
+	github.com/digitalocean/godo v1.108.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.107.0
+	github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.107.0 h1:P72IbmGFQvKOvyjVLyT59bmHxilA4E5hWi40rF4zNQc=
-github.com/digitalocean/godo v1.107.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
+github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb h1:EkCLnubpU6vi87rH3HUy9K8hih9gPstEjHCydvwVa9s=
+github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb h1:EkCLnubpU6vi87rH3HUy9K8hih9gPstEjHCydvwVa9s=
-github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
+github.com/digitalocean/godo v1.108.0 h1:fWyMENvtxpCpva1UbKzOFnyAS04N1FNuBWWfPeTGquQ=
+github.com/digitalocean/godo v1.108.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.108.0] - 2024-01-17
+
+- #660 - @dweinshenker - Enable CRUD operations for replicas with storage_size_mib
+
 ## [v1.107.0] - 2023-12-07
 
 - #658 - @markusthoemmes - APPS-8033 Add the RUN_RESTARTED log type

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -376,6 +376,7 @@ type DatabaseReplica struct {
 	CreatedAt          time.Time           `json:"created_at"`
 	PrivateNetworkUUID string              `json:"private_network_uuid,omitempty"`
 	Tags               []string            `json:"tags,omitempty"`
+	StorageSizeMib     uint64              `json:"storage_size_mib,omitempty"`
 }
 
 // DatabasePool represents a database connection pool
@@ -436,6 +437,7 @@ type DatabaseCreateReplicaRequest struct {
 	Size               string   `json:"size"`
 	PrivateNetworkUUID string   `json:"private_network_uuid"`
 	Tags               []string `json:"tags,omitempty"`
+	StorageSizeMib     uint64   `json:"storage_size_mib,omitempty"`
 }
 
 // DatabaseUpdateFirewallRulesRequest is used to set the firewall rules for a database

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.107.0"
+	libraryVersion = "1.108.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb
+# github.com/digitalocean/godo v1.108.0
 ## explicit; go 1.20
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.107.0
+# github.com/digitalocean/godo v1.107.1-0.20240102155522-69dafba5f9cb
 ## explicit; go 1.20
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
**What**

- Enables read-replicas to set their own value for `storage_size_mib` to specify disk space
- Resolves some outdated Mongo tests using older versions
- Fixes resize issue for clusters when omitting `storage_size_mib`