### PR TITLE
Error out with a message if the user tries to disable IPv6 on a droplet

### DIFF
--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -592,6 +592,13 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
+	// User is trying to disable IpV6, error out that this is not possible 
+	// (It might be better to set ForceNew = true if this condition happens)
+	if d.HasChange("ipv6") && d.Get("ipv6").(bool) == false {
+		return diag.Errorf(
+			"IPv6 Cannot be disabled. Destroy the instance and re-deploy with IPv6 set to false (%s)", d.Id())
+	}
+	
 	// As there is no way to disable IPv6, we only check if it needs to be enabled
 	if d.HasChange("ipv6") && d.Get("ipv6").(bool) {
 		_, _, err = client.DropletActions.EnableIPv6(context.Background(), id)

--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -598,7 +598,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 				"Error waiting for private networking to be enabled on for droplet (%s): %s", d.Id(), err)
 		}
 	}
-	
+
 	// As there is no way to disable IPv6, we only check if it needs to be enabled
 	if d.HasChange("ipv6") && d.Get("ipv6").(bool) {
 		_, _, err = client.DropletActions.EnableIPv6(context.Background(), id)


### PR DESCRIPTION
It appears the API does not support disablement of IPv6, only enablement. If ipv6 is set to false after being set to true then nothing changes on the cloud provider and the diff keeps happening forever #1104

This update uses forces a replacement if the user is trying to disable ipv6
