### PR TITLE
apps: Add GHCR as a supported registry type.

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -221,6 +221,7 @@ func appSpecImageSourceSchema() map[string]*schema.Schema {
 				"UNSPECIFIED",
 				"DOCKER_HUB",
 				"DOCR",
+				"GHCR",
 			}, false),
 			Description: "The registry type.",
 		},


### PR DESCRIPTION
`GHCR` is now a supported registry type, but it never made its way here.

Fixes https://github.com/digitalocean/terraform-provider-digitalocean/issues/1107