### PR TITLE
Apps: Support Project Assignment

### DIFF
--- a/digitalocean/app/datasource_app.go
+++ b/digitalocean/app/datasource_app.go
@@ -31,10 +31,7 @@ func DataSourceDigitalOceanApp() *schema.Resource {
 			},
 			"project_id": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
 				Computed:     true,
-				ValidateFunc: validation.NoZeroValues,
 			},
 			"live_url": {
 				Type:     schema.TypeString,

--- a/digitalocean/app/datasource_app.go
+++ b/digitalocean/app/datasource_app.go
@@ -29,8 +29,8 @@ func DataSourceDigitalOceanApp() *schema.Resource {
 				Description: "The default URL to access the App",
 			},
 			"project_id": {
-				Type:         schema.TypeString,
-				Computed:     true,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"live_url": {
 				Type:     schema.TypeString,

--- a/digitalocean/app/datasource_app.go
+++ b/digitalocean/app/datasource_app.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceDigitalOceanApp() *schema.Resource {
@@ -27,6 +28,13 @@ func DataSourceDigitalOceanApp() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The default URL to access the App",
+			},
+			"project_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 			"live_url": {
 				Type:     schema.TypeString,

--- a/digitalocean/app/datasource_app.go
+++ b/digitalocean/app/datasource_app.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceDigitalOceanApp() *schema.Resource {

--- a/digitalocean/app/datasource_app_test.go
+++ b/digitalocean/app/datasource_app_test.go
@@ -35,6 +35,8 @@ func TestAccDataSourceDigitalOceanApp_Basic(t *testing.T) {
 						"data.digitalocean_app.foobar", "spec.0.name", appName),
 					resource.TestCheckResourceAttrPair("digitalocean_app.foobar", "default_ingress",
 						"data.digitalocean_app.foobar", "default_ingress"),
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_app.foobar", "project_id"),
 					resource.TestCheckResourceAttrPair("digitalocean_app.foobar", "live_url",
 						"data.digitalocean_app.foobar", "live_url"),
 					resource.TestCheckResourceAttrPair("digitalocean_app.foobar", "active_deployment_id",

--- a/digitalocean/app/resource_app.go
+++ b/digitalocean/app/resource_app.go
@@ -158,7 +158,7 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 func resourceDigitalOceanAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig).GodoClient()
 
-	if d.HasChanges("spec") {
+	if d.HasChange("spec") {
 		appUpdateRequest := &godo.AppUpdateRequest{}
 		appUpdateRequest.Spec = expandAppSpec(d.Get("spec").([]interface{}))
 

--- a/digitalocean/app/resource_app.go
+++ b/digitalocean/app/resource_app.go
@@ -104,7 +104,6 @@ func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	d.SetId(app.ID)
-
 	log.Printf("[DEBUG] Waiting for app (%s) deployment to become active", app.ID)
 	timeout := d.Timeout(schema.TimeoutCreate)
 	err = waitForAppDeployment(client, app.ID, timeout)

--- a/digitalocean/app/resource_app.go
+++ b/digitalocean/app/resource_app.go
@@ -104,7 +104,7 @@ func resourceDigitalOceanAppCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	d.SetId(app.ID)
-	d.Set("project_id", app.ProjectID)
+
 	log.Printf("[DEBUG] Waiting for app (%s) deployment to become active", app.ID)
 	timeout := d.Timeout(schema.TimeoutCreate)
 	err = waitForAppDeployment(client, app.ID, timeout)
@@ -159,7 +159,7 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 func resourceDigitalOceanAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig).GodoClient()
 
-	if d.HasChanges("spec", "project_id") {
+	if d.HasChanges("spec") {
 		appUpdateRequest := &godo.AppUpdateRequest{}
 		appUpdateRequest.Spec = expandAppSpec(d.Get("spec").([]interface{}))
 

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -1405,22 +1405,22 @@ resource "digitalocean_project" "foobar" {
 }
 
 resource "digitalocean_app" "foobar" {
-	project_id = digitalocean_project.foobar.id
-	spec {
-	  name   = "%s"
-	  region = "ams"
-  
-	  static_site {
-		name              = "sample-jekyll"
-		build_command     = "bundle exec jekyll build -d ./public"
-		output_dir        = "/public"
-		environment_slug  = "jekyll"
-		catchall_document = "404.html"
-  
-		git {
-		  repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
-		  branch         = "main"
-		}
-	  }
-	}
-  }`
+  project_id = digitalocean_project.foobar.id
+  spec {
+    name   = "%s"
+    region = "ams"
+
+    static_site {
+      name              = "sample-jekyll"
+      build_command     = "bundle exec jekyll build -d ./public"
+      output_dir        = "/public"
+      environment_slug  = "jekyll"
+      catchall_document = "404.html"
+
+      git {
+        repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
+        branch         = "main"
+      }
+    }
+  }
+}`

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -61,6 +61,8 @@ func TestAccDigitalOceanApp_Basic(t *testing.T) {
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.name", appName),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_app.foobar", "project_id"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "default_ingress"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
@@ -876,6 +878,30 @@ func TestAccDigitalOceanApp_Features(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanApp_nonDefaultProject(t *testing.T) {
+	var app godo.App
+	appName := acceptance.RandomTestName()
+	projectName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_NonDefaultProject, projectName, appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.name", appName),
+					resource.TestCheckResourceAttrPair(
+						"digitalocean_project.foobar", "id", "digitalocean_app.foobar", "project_id"),
+				),
+			},
+		},
+	})
+}
+
 var testAccCheckDigitalOceanAppConfig_basic = `
 resource "digitalocean_app" "foobar" {
   spec {
@@ -1372,3 +1398,29 @@ resource "digitalocean_app" "foobar" {
     }
   }
 }`
+
+var testAccCheckDigitalOceanAppConfig_NonDefaultProject = `
+resource "digitalocean_project" "foobar" {
+  name = "%s"
+}
+
+resource "digitalocean_app" "foobar" {
+	project_id = digitalocean_project.foobar.id
+	spec {
+	  name   = "%s"
+	  region = "ams"
+  
+	  static_site {
+		name              = "sample-jekyll"
+		build_command     = "bundle exec jekyll build -d ./public"
+		output_dir        = "/public"
+		environment_slug  = "jekyll"
+		catchall_document = "404.html"
+  
+		git {
+		  repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
+		  branch         = "main"
+		}
+	  }
+	}
+  }`

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -35,6 +35,7 @@ The following attributes are exported:
 * `updated_at` - The date and time of when the app was last updated.
 * `created_at` - The date and time of when the app was created.
 * `spec` - A DigitalOcean App spec describing the app.
+* `project_id` - The ID of the project that the app is assigned to.
 
 A spec can contain multiple components.
 

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -200,6 +200,7 @@ The following arguments are supported:
            * `expose_headers` - The set of HTTP response headers that browsers are allowed to access. This configures the `Access-Control-Expose-Headers` header.
            * `allow_methods` - The set of allowed HTTP methods. This configures the `Access-Control-Allow-Methods` header.
            * `allow_credentials` - Whether browsers should expose the response to the client-side JavaScript code when the request's credentials mode is `include`. This configures the `Access-Control-Allow-Credentials` header.
+* `project_id` - The ID of the project that the app is assigned to.
 
 A spec can contain multiple components.
 


### PR DESCRIPTION
Adds support for specifying a project ID for a app. Addresses #1112 

Tried it out locally and was able to confirm an App was created in specified project:
```
terraform {
  required_providers {
    digitalocean = {
      source = "digitalocean/digitalocean"
      version = ">= 2.8.0"
    }
  }
}

provider "digitalocean" {
  # You need to set this in your .bashrc
  # export DIGITALOCEAN_TOKEN="Your API TOKEN"
  #
}

resource "digitalocean_project" "foobar" {
  name = "test_apps"
}

resource "digitalocean_app" "golang-sample" {
  project_id = digitalocean_project.foobar.id
  spec {
    name   = "golang-sample"
    region = "ams"

    service {
      name               = "go-service"
      environment_slug   = "go"
      instance_count     = 1
      instance_size_slug = "professional-xs"

      git {
        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
        branch         = "main"
      }
    }
  }
}
```
