### PR TITLE
certificates: handle missing certificate.

### DIFF
--- a/digitalocean/certificate/datasource_certificate.go
+++ b/digitalocean/certificate/datasource_certificate.go
@@ -3,7 +3,6 @@ package certificate
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
@@ -93,14 +92,9 @@ func dataSourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resour
 }
 
 func FindCertificateByName(client *godo.Client, name string) (*godo.Certificate, error) {
-
-	cert, resp, err := client.Certificates.ListByName(context.Background(), name, nil)
+	cert, _, err := client.Certificates.ListByName(context.Background(), name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving certificates: %s", err)
-	}
-
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, nil
 	}
 
 	if len(cert) == 0 {

--- a/digitalocean/certificate/resource_certificate.go
+++ b/digitalocean/certificate/resource_certificate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/digitalocean/godo"
@@ -251,15 +252,15 @@ func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resource
 	// certificate name as the primary identifier instead.
 	log.Printf("[INFO] Reading the details of the Certificate %s", d.Id())
 	cert, err := FindCertificateByName(client, d.Id())
-	if err != nil {
-		return diag.Errorf("Error retrieving Certificate: %s", err)
-	}
-
 	// check if the certificate no longer exists.
-	if cert == nil {
+	if cert == nil && strings.Contains(err.Error(), "not found") {
 		log.Printf("[WARN] DigitalOcean Certificate (%s) not found", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("Error retrieving Certificate: %s", err)
 	}
 
 	d.Set("name", cert.Name)


### PR DESCRIPTION
While reviewing https://github.com/digitalocean/terraform-provider-digitalocean/pull/1115, I realized an already existing issue with the certificate resource. `FindCertificateByName` will never return `StatusNotFound` as it is a list endpoint. It returns an empty list if there is no match. So our special casing of a 404 response is never encountered. 

This means if a certificate is deleted outside of Terraform, we currently do not attempt to reconcile state and prompt to recreate. `FindCertificateByName`  returns an error and we surface that to the user instead. This reorders the logic to check that `cert == nil` before checking `err != nil` so that a missing cert is handled like other missing resources. 

```
$ make testacc PKG_NAME=digitaloc
ean/certificate
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/certificate/...  -timeout 120m -parallel=2
=== RUN   TestAccDataSourceDigitalOceanCertificate_Basic
=== PAUSE TestAccDataSourceDigitalOceanCertificate_Basic
=== RUN   TestAccDigitalOceanCertificate_importBasic
=== PAUSE TestAccDigitalOceanCertificate_importBasic
=== RUN   TestResourceExampleInstanceStateUpgradeV0
2024/02/29 15:23:53 [DEBUG] Migrating certificate schema from v0 to v1.
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
=== RUN   TestAccDigitalOceanCertificate_Basic
=== PAUSE TestAccDigitalOceanCertificate_Basic
=== RUN   TestAccDigitalOceanCertificate_ExpectedErrors
=== PAUSE TestAccDigitalOceanCertificate_ExpectedErrors
=== CONT  TestAccDataSourceDigitalOceanCertificate_Basic
=== CONT  TestAccDigitalOceanCertificate_Basic
--- PASS: TestAccDigitalOceanCertificate_Basic (13.49s)
=== CONT  TestAccDigitalOceanCertificate_importBasic
--- PASS: TestAccDataSourceDigitalOceanCertificate_Basic (16.01s)
=== CONT  TestAccDigitalOceanCertificate_ExpectedErrors
--- PASS: TestAccDigitalOceanCertificate_ExpectedErrors (1.68s)
--- PASS: TestAccDigitalOceanCertificate_importBasic (13.87s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/certificate        28.111s
```