### PR TITLE
uptime alerts: fix importing existing alerts

### DIFF
--- a/docs/resources/uptime_alert.md
+++ b/docs/resources/uptime_alert.md
@@ -63,8 +63,9 @@ The following attributes are exported.
 
 ## Import
 
-Uptime checks can be imported using the uptime alert's `id`, e.g.
+Uptime alerts can be imported using the both IDs of the alert's parent check and its
+own separated by a comma in the format: `check_id,alert_id`. For example:
 
 ```shell
-terraform import digitalocean_uptime_alert.target 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+terraform import digitalocean_uptime_alert.target 94a7d216-d821-11ee-a327-33d3239ffc4b,5a4981aa-9653-4bd1-bef5-d6bff52042e4
 ```


### PR DESCRIPTION
Importing an uptime alert requires knowing the ID of its parent uptime check. 

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1118

```
$ make testacc PKG_NAME=digitaloc
ean/uptime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v ./digitalocean/uptime/...  -timeout 120m -parallel=2
=== RUN   TestAccDigitalOceanUptimeAlert_importBasic
=== PAUSE TestAccDigitalOceanUptimeAlert_importBasic
=== RUN   TestAccDigitalOceanUptimeAlert_Basic
=== PAUSE TestAccDigitalOceanUptimeAlert_Basic
=== RUN   TestAccDigitalOceanUptimeCheck_Basic
=== PAUSE TestAccDigitalOceanUptimeCheck_Basic
=== CONT  TestAccDigitalOceanUptimeAlert_importBasic
=== CONT  TestAccDigitalOceanUptimeCheck_Basic
--- PASS: TestAccDigitalOceanUptimeCheck_Basic (15.04s)
=== CONT  TestAccDigitalOceanUptimeAlert_Basic
--- PASS: TestAccDigitalOceanUptimeAlert_importBasic (15.42s)
--- PASS: TestAccDigitalOceanUptimeAlert_Basic (9.00s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/uptime     24.055s
```