### PR TITLE
docs: apps can be added to projects.

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -12,14 +12,15 @@ in ways that align with the applications you host on DigitalOcean.
 
 The following resource types can be associated with a project:
 
+* App Platform Apps
 * Database Clusters
 * Domains
 * Droplets
-* Floating IP
-* Kubernetes Cluster
+* Floating IPs
+* Kubernetes Clusters
 * Load Balancers
-* Spaces Bucket
-* Volume
+* Spaces Buckets
+* Volumes
 
 **Note:** A Terraform managed project cannot be set as a default project.
 

--- a/docs/resources/project_resources.md
+++ b/docs/resources/project_resources.md
@@ -9,14 +9,15 @@ managed in Terraform to a DigitalOcean Project managed outside of Terraform.
 
 The following resource types can be associated with a project:
 
+* App Platform Apps
 * Database Clusters
 * Domains
 * Droplets
-* Floating IP
-* Kubernetes Cluster
+* Floating IPs
+* Kubernetes Clusters
 * Load Balancers
-* Spaces Bucket
-* Volume
+* Spaces Buckets
+* Volumes
 
 ## Example Usage
 


### PR DESCRIPTION
As mentioned in https://github.com/digitalocean/terraform-provider-digitalocean/issues/1117, the docs don't mention that apps can be added to projects when they can:

https://docs.digitalocean.com/reference/api/api-reference/#tag/Project-Resources

(Also went all in on plural)