### PR TITLE
Load Balancer: Deprecate "algorithm" attribute

### DIFF
--- a/digitalocean/loadbalancer/datasource_loadbalancer.go
+++ b/digitalocean/loadbalancer/datasource_loadbalancer.go
@@ -60,6 +60,7 @@ func DataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "algorithm used to determine which backend Droplet will be selected by a client",
+				Deprecated:  "This field has been deprecated. You can no longer specify an algorithm for load balancers.",
 			},
 			"status": {
 				Type:        schema.TypeString,

--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -200,6 +200,7 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 					"round_robin",
 					"least_connections",
 				}, false),
+				Deprecated: "This field has been deprecated. You can no longer specify an algorithm for load balancers.",
 			},
 
 			"forwarding_rule": {

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -93,8 +93,7 @@ The following arguments are supported:
 * `region` - (Required) The region to start in
 * `size` - (Optional) The size of the Load Balancer. It must be either `lb-small`, `lb-medium`, or `lb-large`. Defaults to `lb-small`. Only one of `size` or `size_unit` may be provided.
 * `size_unit` - (Optional) The size of the Load Balancer. It must be in the range (1, 100). Defaults to `1`. Only one of `size` or `size_unit` may be provided.
-* `algorithm` - (Optional) The load balancing algorithm used to determine
-which backend Droplet will be selected by a client. It must be either `round_robin`
+* `algorithm` - (Optional) **Deprecated** This field has been deprecated. You can no longer specify an algorithm for load balancers.
 or `least_connections`. The default value is `round_robin`.
 * `forwarding_rule` - (Required) A list of `forwarding_rule` to be assigned to the
 Load Balancer. The `forwarding_rule` block is documented below.


### PR DESCRIPTION
This field has been deprecated. You can no longer specify an algorithm for load balancers.

https://docs.digitalocean.com/reference/api/api-reference/#operation/loadBalancers_create