### PR TITLE
Databases: Set Kafka Connection Attributes (port, uri, private_uri)

### DIFF
--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -615,7 +615,7 @@ func setDatabaseConnectionInfo(database *godo.Database, d *schema.ResourceData) 
 		d.Set("host", database.Connection.Host)
 		if database.EngineSlug == kafkaDBEngineSlug {
 			// default for kafka will be Public SASL port, consistent with UI
-			d.Set("port", 25073)
+			d.Set("port", kafkaPublicSSLPort)
 		} else {
 			d.Set("port", database.Connection.Port)
 		}

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -67,6 +67,38 @@ func TestAccDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseCluster_KafkaConnectionDetails(t *testing.T) {
+	var database godo.Database
+	databaseName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterKafka, databaseName, "3.5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "name", databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "engine", "kafka"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "port", "25073"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "uri"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "private_uri"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "host"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanDatabaseCluster_WithUpdate(t *testing.T) {
 	var database godo.Database
 	databaseName := acceptance.RandomTestName()

--- a/docs/data-sources/database_cluster.md
+++ b/docs/data-sources/database_cluster.md
@@ -40,7 +40,9 @@ The following attributes are exported:
 * `host` - Database cluster's hostname.
 * `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database cluster is listening on.
+> Note: For kafka clusters, this is set to be the default public SASL port of 25073.
 * `uri` - The full URI for connecting to the database cluster.
+> Note: Documentation for connecting to clusters can be found here: [Kafka](https://docs.digitalocean.com/products/databases/kafka/how-to/connect/#connect-via-sasl), [PostgreSQL](https://docs.digitalocean.com/products/databases/postgresql/how-to/connect/), [MySQL](https://docs.digitalocean.com/products/databases/mysql/how-to/connect/), [Redis](https://docs.digitalocean.com/products/databases/redis/how-to/connect/), and [MongoDB](https://docs.digitalocean.com/products/databases/mongodb/how-to/connect/).
 * `private_uri` - Same as `uri`, but only accessible from resources within the account and in the same region.
 * `database` - Name of the cluster's default database.
 * `user` - Username for the cluster's default user.

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -141,7 +141,9 @@ In addition to the above arguments, the following attributes are exported:
 * `host` - Database cluster's hostname.
 * `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database cluster is listening on.
+> Note: For kafka clusters, this is set to be the default public SASL port of 25073.
 * `uri` - The full URI for connecting to the database cluster.
+> Note: Documentation for connecting to clusters can be found here: [Kafka](https://docs.digitalocean.com/products/databases/kafka/how-to/connect/#connect-via-sasl), [PostgreSQL](https://docs.digitalocean.com/products/databases/postgresql/how-to/connect/), [MySQL](https://docs.digitalocean.com/products/databases/mysql/how-to/connect/), [Redis](https://docs.digitalocean.com/products/databases/redis/how-to/connect/), and [MongoDB](https://docs.digitalocean.com/products/databases/mongodb/how-to/connect/).
 * `private_uri` - Same as `uri`, but only accessible from resources within the account and in the same region.
 * `database` - Name of the cluster's default database.
 * `user` - Username for the cluster's default user.


### PR DESCRIPTION
Addresses #1121

Database team is working on a ticket to address this in the API layer, but in the meantime this sets the port, uri, and private uri at the terraform layer so users can easily collect connection details for their kafka clusters.

Default port will be the public SASL port, 25073. This is consistent with the UI. 