### PR TITLE
apps: included registry_credentials option for images

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -255,6 +255,12 @@ func appSpecImageSourceSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"registry_credentials": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Access credentials for third-party registries",
+			Sensitive:   true,
+		},
 	}
 }
 
@@ -1377,10 +1383,11 @@ func expandAppImageSourceSpec(config []interface{}) *godo.ImageSourceSpec {
 	imageSourceConfig := config[0].(map[string]interface{})
 
 	imageSource := &godo.ImageSourceSpec{
-		RegistryType: godo.ImageSourceSpecRegistryType(imageSourceConfig["registry_type"].(string)),
-		Registry:     imageSourceConfig["registry"].(string),
-		Repository:   imageSourceConfig["repository"].(string),
-		Tag:          imageSourceConfig["tag"].(string),
+		RegistryType:        godo.ImageSourceSpecRegistryType(imageSourceConfig["registry_type"].(string)),
+		Registry:            imageSourceConfig["registry"].(string),
+		Repository:          imageSourceConfig["repository"].(string),
+		Tag:                 imageSourceConfig["tag"].(string),
+		RegistryCredentials: imageSourceConfig["registry_credentials"].(string),
 	}
 
 	docrPush := imageSourceConfig["deploy_on_push"].([]interface{})
@@ -1403,6 +1410,7 @@ func flattenAppImageSourceSpec(i *godo.ImageSourceSpec) []interface{} {
 		r["registry"] = (*i).Registry
 		r["repository"] = (*i).Repository
 		r["tag"] = (*i).Tag
+		r["registry_credentials"] = (*i).RegistryCredentials
 
 		if i.DeployOnPush != nil {
 			docrPush := make([]interface{}, 1)


### PR DESCRIPTION
This unblocks users of private non-DOCR registries with App Platform (https://github.com/digitalocean/terraform-provider-digitalocean/issues/1132). 

`registry_credentials` is currently documented here:  https://docs.digitalocean.com/products/app-platform/how-to/deploy-from-container-images/#deploy-container-using-the-apps-spec

This unfortunately has the same draw back as other App Platform secret values when used with Terraform:

> The registry_credentials field requires you to initially submit your access credentials in clear text, but App Platform then encrypts and stores these values similar to secret environment variables. After submitting the spec, App Platform replaces the values in the spec with encrypted values. Once the values are encrypted, you can safely store the spec in the app’s repo.

So it requires manually changing the value in the Terraform configuration to the returned encrypted one or using a `lifecycle` block to ignore the changes. E.g.

```hcl
  lifecycle {
    ignore_changes = [
        spec.0.service.0.image["registry_credentials"]
    ]
  }
```