### PR TITLE
Add PostgreSQL configuration resource and test

### DIFF
--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -860,6 +860,17 @@ resource "digitalocean_database_cluster" "foobar" {
   tags       = ["production"]
 }`
 
+const testAccCheckDigitalOceanDatabaseClusterPostgreSQL = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "%s"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
+}`
+
 const testAccCheckDigitalOceanDatabaseClusterConfigWithEvictionPolicy = `
 resource "digitalocean_database_cluster" "foobar" {
   name            = "%s"

--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -14,6 +14,13 @@ import (
 
 func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 	return &schema.Resource{
+		CreateContext: resourceDigitalOceanDatabasePostgreSQLConfigCreate,
+		ReadContext:   resourceDigitalOceanDatabasePostgreSQLConfigRead,
+		UpdateContext: resourceDigitalOceanDatabasePostgreSQLConfigUpdate,
+		DeleteContext: resourceDigitalOceanDatabasePostgreSQLConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDigitalOceanDatabasePostgreSQLConfigImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {
 				Type:         schema.TypeString,

--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -485,7 +485,7 @@ func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client 
 		opts.IdleInTransactionSessionTimeout = godo.PtrTo(v.(int))
 	}
 
-	if v, ok := d.GetOk("jit"); ok {
+	if v, ok := d.GetOkExists("jit"); ok {
 		opts.JIT = godo.PtrTo(v.(bool))
 	}
 

--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -80,6 +80,13 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"default_toast_compression": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"lz4",
+						"pglz",
+					},
+					false,
+				),
 			},
 			"idle_in_transaction_session_timeout": {
 				Type:     schema.TypeInt,
@@ -96,10 +103,26 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"log_error_verbosity": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"TERSE",
+						"DEFAULT",
+						"VERBOSE",
+					},
+					false,
+				),
 			},
 			"log_line_prefix": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"pid=%p,user=%u,db=%d,app=%a,client=%h",
+						"%m [%p] %q[user=%u,db=%d,app=%a]",
+						"%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h",
+					},
+					false,
+				),
 			},
 			"log_min_duration_statement": {
 				Type:     schema.TypeInt,
@@ -180,14 +203,36 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"track_commit_timestamp": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"off",
+						"on",
+					},
+					false,
+				),
 			},
 			"track_functions": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"all",
+						"pl",
+						"none",
+					},
+					false,
+				),
 			},
 			"track_io_timing": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"off",
+						"on",
+					},
+					false,
+				),
 			},
 			"max_wal_senders": {
 				Type:     schema.TypeInt,
@@ -204,6 +249,10 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"shared_buffers_percentage": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				ValidateFunc: validation.FloatBetween(
+					20.0,
+					60.0,
+				),
 			},
 			"pgbouncer": {
 				Type:     schema.TypeList,

--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -31,62 +31,77 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"autovacuum_freeze_max_age": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_max_workers": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_naptime": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_vacuum_threshold": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_analyze_threshold": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_vacuum_scale_factor": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_analyze_scale_factor": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_vacuum_cost_delay": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"autovacuum_vacuum_cost_limit": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"bgwriter_delay": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"bgwriter_flush_after": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"bgwriter_lru_maxpages": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"bgwriter_lru_multiplier": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 			},
 			"deadlock_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"default_toast_compression": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						"lz4",
@@ -98,18 +113,22 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"idle_in_transaction_session_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"jit": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"log_autovacuum_min_duration": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"log_error_verbosity": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						"TERSE",
@@ -122,6 +141,7 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"log_line_prefix": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						"pid=%p,user=%u,db=%d,app=%a,client=%h",
@@ -134,82 +154,102 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"log_min_duration_statement": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_files_per_process": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_prepared_transactions": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_pred_locks_per_transaction": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_locks_per_transaction": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_stack_depth": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_standby_archive_delay": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_standby_streaming_delay": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_replication_slots": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_logical_replication_workers": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_parallel_workers": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_parallel_workers_per_gather": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"max_worker_processes": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"pg_partman_bgw_role": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"pg_partman_bgw_interval": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"pg_stat_statements_track": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"temp_file_limit": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"timezone": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"track_activity_query_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"track_commit_timestamp": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						"off",
@@ -221,6 +261,7 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"track_functions": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						"all",
@@ -233,6 +274,7 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"track_io_timing": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						"off",
@@ -244,18 +286,22 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"max_wal_senders": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"wal_sender_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"wal_writer_delay": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"shared_buffers_percentage": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.FloatBetween(
 					20.0,
 					60.0,
@@ -264,31 +310,83 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 			"pgbouncer": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						// ... Define the fields for PostgreSQLBouncerConfig here
+						"server_reset_query_always": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"ignore_startup_parameters": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Optional: true,
+							Computed: true,
+						},
+						"min_pool_size": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"server_lifetime": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"server_idle_timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"autodb_pool_size": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"autodb_pool_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"autodb_max_db_connections": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"autodb_idle_timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},
 			"backup_hour": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"backup_minute": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"work_mem": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"timescaledb": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						// ... Define the fields for PostgreSQLTimeScaleDBConfig here
-					},
+						"timescaledb": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						}},
 				},
 			},
 		},
@@ -344,11 +442,11 @@ func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client 
 	}
 
 	if v, ok := d.GetOk("autovacuum_vacuum_scale_factor"); ok {
-		opts.AutovacuumVacuumScaleFactor = godo.PtrTo(v.(float32))
+		opts.AutovacuumVacuumScaleFactor = godo.PtrTo(float32(v.(float64)))
 	}
 
 	if v, ok := d.GetOk("autovacuum_analyze_scale_factor"); ok {
-		opts.AutovacuumAnalyzeScaleFactor = godo.PtrTo(v.(float32))
+		opts.AutovacuumAnalyzeScaleFactor = godo.PtrTo(float32(v.(float64)))
 	}
 
 	if v, ok := d.GetOk("autovacuum_vacuum_cost_delay"); ok {
@@ -372,7 +470,7 @@ func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client 
 	}
 
 	if v, ok := d.GetOk("bgwriter_lru_multiplier"); ok {
-		opts.BGWriterLRUMultiplier = godo.PtrTo(v.(float32))
+		opts.BGWriterLRUMultiplier = godo.PtrTo(float32(v.(float64)))
 	}
 
 	if v, ok := d.GetOk("deadlock_timeout"); ok {
@@ -504,11 +602,11 @@ func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client 
 	}
 
 	if v, ok := d.GetOk("shared_buffers_percentage"); ok {
-		opts.SharedBuffersPercentage = godo.PtrTo(v.(float32))
+		opts.SharedBuffersPercentage = godo.PtrTo(float32(v.(float64)))
 	}
 
 	if v, ok := d.GetOk("pgbouncer"); ok {
-		opts.PgBouncer = godo.PtrTo(v.(godo.PostgreSQLBouncerConfig))
+		opts.PgBouncer = expandPgBouncer(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("backup_hour"); ok {
@@ -524,7 +622,7 @@ func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client 
 	}
 
 	if v, ok := d.GetOk("timescaledb"); ok {
-		opts.TimeScaleDB = godo.PtrTo(v.(godo.PostgreSQLTimeScaleDBConfig))
+		opts.TimeScaleDB = expandTimeScaleDB(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] PostgreSQL configuration: %s", godo.Stringify(opts))
@@ -596,11 +694,21 @@ func resourceDigitalOceanDatabasePostgreSQLConfigRead(ctx context.Context, d *sc
 	d.Set("wal_sender_timeout", config.WalSenderTimeout)
 	d.Set("wal_writer_delay", config.WalWriterDelay)
 	d.Set("shared_buffers_percentage", config.SharedBuffersPercentage)
-	d.Set("pgbouncer", config.PgBouncer)
 	d.Set("backup_hour", config.BackupHour)
 	d.Set("backup_minute", config.BackupMinute)
 	d.Set("work_mem", config.WorkMem)
-	d.Set("timescaledb", config.TimeScaleDB)
+
+	if _, ok := d.GetOk("pgbouncer"); ok {
+		if err := d.Set("pgbouncer", flattenPGBouncerOpts(*config.PgBouncer)); err != nil {
+			return diag.Errorf("[DEBUG] Error setting pgbouncer - error: %#v", err)
+		}
+	}
+
+	if _, ok := d.GetOk("timescaledb"); ok {
+		if err := d.Set("timescaledb", flattenTimeScaleDBOpts(*config.TimeScaleDB)); err != nil {
+			return diag.Errorf("[DEBUG] Error setting timescaledb - error: %#v", err)
+		}
+	}
 
 	return nil
 }
@@ -630,4 +738,62 @@ func resourceDigitalOceanDatabasePostgreSQLConfigImport(d *schema.ResourceData, 
 
 func makeDatabasePostgreSQLConfigID(clusterID string) string {
 	return fmt.Sprintf("%s/postgresql-config", clusterID)
+}
+
+func expandPgBouncer(config []interface{}) *godo.PostgreSQLBouncerConfig {
+	configMap := config[0].(map[string]interface{})
+
+	pgBouncerConfig := &godo.PostgreSQLBouncerConfig{
+		ServerResetQueryAlways:  godo.PtrTo(configMap["server_reset_query_always"].(bool)),
+		IgnoreStartupParameters: godo.PtrTo(configMap["ignore_startup_parameters"].([]string)),
+		MinPoolSize:             godo.PtrTo(configMap["min_pool_size"].(int)),
+		ServerLifetime:          godo.PtrTo(configMap["server_lifetime"].(int)),
+		ServerIdleTimeout:       godo.PtrTo(configMap["server_idle_timeout"].(int)),
+		AutodbPoolSize:          godo.PtrTo(configMap["autodb_pool_size"].(int)),
+		AutodbPoolMode:          godo.PtrTo(configMap["autodb_pool_mode"].(string)),
+		AutodbMaxDbConnections:  godo.PtrTo(configMap["autodb_max_db_connections"].(int)),
+		AutodbIdleTimeout:       godo.PtrTo(configMap["autodb_idle_timeout"].(int)),
+	}
+
+	return pgBouncerConfig
+}
+
+func expandTimeScaleDB(config []interface{}) *godo.PostgreSQLTimeScaleDBConfig {
+	configMap := config[0].(map[string]interface{})
+
+	timeScaleDBConfig := &godo.PostgreSQLTimeScaleDBConfig{
+		MaxBackgroundWorkers: godo.PtrTo(configMap["max_background_workers"].(int)),
+	}
+
+	return timeScaleDBConfig
+}
+
+func flattenPGBouncerOpts(opts godo.PostgreSQLBouncerConfig) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	item := make(map[string]interface{})
+
+	item["server_reset_query_always"] = opts.ServerResetQueryAlways
+	item["ignore_startup_parameters"] = opts.IgnoreStartupParameters
+	item["min_pool_size"] = opts.MinPoolSize
+	item["server_lifetime"] = opts.ServerLifetime
+	item["server_idle_timeout"] = opts.ServerIdleTimeout
+	item["autodb_pool_size"] = opts.AutodbPoolSize
+	item["autodb_pool_mode"] = opts.AutodbPoolMode
+	item["autodb_max_db_connections"] = opts.AutodbMaxDbConnections
+	item["autodb_idle_timeout"] = opts.AutodbIdleTimeout
+
+	result = append(result, item)
+
+	return result
+}
+
+func flattenTimeScaleDBOpts(opts godo.PostgreSQLTimeScaleDBConfig) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	item := make(map[string]interface{})
+
+	item["max_background_workers"] = opts.MaxBackgroundWorkers
+
+	result = append(result, item)
+
+	return result
 }

--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -1,0 +1,577 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"autovacuum_freeze_max_age": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"autovacuum_max_workers": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"autovacuum_naptime": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"autovacuum_vacuum_threshold": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"autovacuum_analyze_threshold": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"autovacuum_vacuum_scale_factor": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"autovacuum_analyze_scale_factor": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"autovacuum_vacuum_cost_delay": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"autovacuum_vacuum_cost_limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bgwriter_delay": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bgwriter_flush_after": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bgwriter_lru_maxpages": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bgwriter_lru_multiplier": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"deadlock_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"default_toast_compression": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"idle_in_transaction_session_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"jit": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"log_autovacuum_min_duration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"log_error_verbosity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"log_line_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"log_min_duration_statement": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_files_per_process": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_prepared_transactions": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_pred_locks_per_transaction": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_locks_per_transaction": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_stack_depth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_standby_archive_delay": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_standby_streaming_delay": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_replication_slots": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_logical_replication_workers": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_parallel_workers": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_parallel_workers_per_gather": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_worker_processes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"pg_partman_bgw_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pg_partman_bgw_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"pg_stat_statements_track": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"temp_file_limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"track_activity_query_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"track_commit_timestamp": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"track_functions": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"track_io_timing": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_wal_senders": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"wal_sender_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"wal_writer_delay": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"shared_buffers_percentage": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"pgbouncer": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// ... Define the fields for PostgreSQLBouncerConfig here
+					},
+				},
+			},
+			"backup_hour": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"backup_minute": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"work_mem": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"timescaledb": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// ... Define the fields for PostgreSQLTimeScaleDBConfig here
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanDatabasePostgreSQLConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	if err := updatePostgreSQLConfig(ctx, d, client); err != nil {
+		return diag.Errorf("Error updating PostgreSQL configuration: %s", err)
+	}
+
+	d.SetId(makeDatabasePostgreSQLConfigID(clusterID))
+
+	return resourceDigitalOceanDatabasePostgreSQLConfigRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanDatabasePostgreSQLConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	if err := updatePostgreSQLConfig(ctx, d, client); err != nil {
+		return diag.Errorf("Error updating PostgreSQL configuration: %s", err)
+	}
+
+	return resourceDigitalOceanDatabasePostgreSQLConfigRead(ctx, d, meta)
+}
+
+func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client *godo.Client) error {
+	clusterID := d.Get("cluster_id").(string)
+
+	opts := &godo.PostgreSQLConfig{}
+
+	if v, ok := d.GetOk("autovacuum_freeze_max_age"); ok {
+		opts.AutovacuumFreezeMaxAge = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("autovacuum_max_workers"); ok {
+		opts.AutovacuumMaxWorkers = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("autovacuum_naptime"); ok {
+		opts.AutovacuumNaptime = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("autovacuum_vacuum_threshold"); ok {
+		opts.AutovacuumVacuumThreshold = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("autovacuum_analyze_threshold"); ok {
+		opts.AutovacuumAnalyzeThreshold = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("autovacuum_vacuum_scale_factor"); ok {
+		opts.AutovacuumVacuumScaleFactor = godo.PtrTo(v.(float32))
+	}
+
+	if v, ok := d.GetOk("autovacuum_analyze_scale_factor"); ok {
+		opts.AutovacuumAnalyzeScaleFactor = godo.PtrTo(v.(float32))
+	}
+
+	if v, ok := d.GetOk("autovacuum_vacuum_cost_delay"); ok {
+		opts.AutovacuumVacuumCostDelay = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("autovacuum_vacuum_cost_limit"); ok {
+		opts.AutovacuumVacuumCostLimit = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("bgwriter_delay"); ok {
+		opts.BGWriterDelay = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("bgwriter_flush_after"); ok {
+		opts.BGWriterFlushAfter = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("bgwriter_lru_maxpages"); ok {
+		opts.BGWriterLRUMaxpages = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("bgwriter_lru_multiplier"); ok {
+		opts.BGWriterLRUMultiplier = godo.PtrTo(v.(float32))
+	}
+
+	if v, ok := d.GetOk("deadlock_timeout"); ok {
+		opts.DeadlockTimeoutMillis = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("default_toast_compression"); ok {
+		opts.DefaultToastCompression = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("idle_in_transaction_session_timeout"); ok {
+		opts.IdleInTransactionSessionTimeout = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("jit"); ok {
+		opts.JIT = godo.PtrTo(v.(bool))
+	}
+
+	if v, ok := d.GetOk("log_autovacuum_min_duration"); ok {
+		opts.LogAutovacuumMinDuration = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("log_error_verbosity"); ok {
+		opts.LogErrorVerbosity = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("log_line_prefix"); ok {
+		opts.LogLinePrefix = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("log_min_duration_statement"); ok {
+		opts.LogMinDurationStatement = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_files_per_process"); ok {
+		opts.MaxFilesPerProcess = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_prepared_transactions"); ok {
+		opts.MaxPreparedTransactions = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_pred_locks_per_transaction"); ok {
+		opts.MaxPredLocksPerTransaction = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_locks_per_transaction"); ok {
+		opts.MaxLocksPerTransaction = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_stack_depth"); ok {
+		opts.MaxStackDepth = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_standby_archive_delay"); ok {
+		opts.MaxStandbyArchiveDelay = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_standby_streaming_delay"); ok {
+		opts.MaxStandbyStreamingDelay = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_replication_slots"); ok {
+		opts.MaxReplicationSlots = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_logical_replication_workers"); ok {
+		opts.MaxLogicalReplicationWorkers = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_parallel_workers"); ok {
+		opts.MaxParallelWorkers = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_parallel_workers_per_gather"); ok {
+		opts.MaxParallelWorkersPerGather = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("max_worker_processes"); ok {
+		opts.MaxWorkerProcesses = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("pg_partman_bgw_role"); ok {
+		opts.PGPartmanBGWRole = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("pg_partman_bgw_interval"); ok {
+		opts.PGPartmanBGWInterval = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("pg_stat_statements_track"); ok {
+		opts.PGStatStatementsTrack = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("temp_file_limit"); ok {
+		opts.TempFileLimit = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("timezone"); ok {
+		opts.Timezone = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("track_activity_query_size"); ok {
+		opts.TrackActivityQuerySize = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("track_commit_timestamp"); ok {
+		opts.TrackCommitTimestamp = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("track_functions"); ok {
+		opts.TrackFunctions = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("track_io_timing"); ok {
+		opts.TrackIOTiming = godo.PtrTo(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_wal_senders"); ok {
+		opts.MaxWalSenders = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("wal_sender_timeout"); ok {
+		opts.WalSenderTimeout = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("wal_writer_delay"); ok {
+		opts.WalWriterDelay = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("shared_buffers_percentage"); ok {
+		opts.SharedBuffersPercentage = godo.PtrTo(v.(float32))
+	}
+
+	if v, ok := d.GetOk("pgbouncer"); ok {
+		opts.PgBouncer = godo.PtrTo(v.(godo.PostgreSQLBouncerConfig))
+	}
+
+	if v, ok := d.GetOk("backup_hour"); ok {
+		opts.BackupHour = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("backup_minute"); ok {
+		opts.BackupMinute = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("work_mem"); ok {
+		opts.WorkMem = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("timescaledb"); ok {
+		opts.TimeScaleDB = godo.PtrTo(v.(godo.PostgreSQLTimeScaleDBConfig))
+	}
+
+	log.Printf("[DEBUG] PostgreSQL configuration: %s", godo.Stringify(opts))
+
+	if _, err := client.Databases.UpdatePostgreSQLConfig(ctx, clusterID, opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanDatabasePostgreSQLConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	config, resp, err := client.Databases.GetPostgreSQLConfig(ctx, clusterID)
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error retrieving PostgreSQL configuration: %s", err)
+	}
+
+	d.Set("autovacuum_freeze_max_age", config.AutovacuumFreezeMaxAge)
+	d.Set("autovacuum_max_workers", config.AutovacuumMaxWorkers)
+	d.Set("autovacuum_naptime", config.AutovacuumNaptime)
+	d.Set("autovacuum_vacuum_threshold", config.AutovacuumVacuumThreshold)
+	d.Set("autovacuum_analyze_threshold", config.AutovacuumAnalyzeThreshold)
+	d.Set("autovacuum_vacuum_scale_factor", config.AutovacuumVacuumScaleFactor)
+	d.Set("autovacuum_analyze_scale_factor", config.AutovacuumAnalyzeScaleFactor)
+	d.Set("autovacuum_vacuum_cost_delay", config.AutovacuumVacuumCostDelay)
+	d.Set("autovacuum_vacuum_cost_limit", config.AutovacuumVacuumCostLimit)
+	d.Set("bgwriter_delay", config.BGWriterDelay)
+	d.Set("bgwriter_flush_after", config.BGWriterFlushAfter)
+	d.Set("bgwriter_lru_maxpages", config.BGWriterLRUMaxpages)
+	d.Set("bgwriter_lru_multiplier", config.BGWriterLRUMultiplier)
+	d.Set("deadlock_timeout", config.DeadlockTimeoutMillis)
+	d.Set("default_toast_compression", config.DefaultToastCompression)
+	d.Set("idle_in_transaction_session_timeout", config.IdleInTransactionSessionTimeout)
+	d.Set("jit", config.JIT)
+	d.Set("log_autovacuum_min_duration", config.LogAutovacuumMinDuration)
+	d.Set("log_error_verbosity", config.LogErrorVerbosity)
+	d.Set("log_line_prefix", config.LogLinePrefix)
+	d.Set("log_min_duration_statement", config.LogMinDurationStatement)
+	d.Set("max_files_per_process", config.MaxFilesPerProcess)
+	d.Set("max_prepared_transactions", config.MaxPreparedTransactions)
+	d.Set("max_pred_locks_per_transaction", config.MaxPredLocksPerTransaction)
+	d.Set("max_locks_per_transaction", config.MaxLocksPerTransaction)
+	d.Set("max_stack_depth", config.MaxStackDepth)
+	d.Set("max_standby_archive_delay", config.MaxStandbyArchiveDelay)
+	d.Set("max_standby_streaming_delay", config.MaxStandbyStreamingDelay)
+	d.Set("max_replication_slots", config.MaxReplicationSlots)
+	d.Set("max_logical_replication_workers", config.MaxLogicalReplicationWorkers)
+	d.Set("max_parallel_workers", config.MaxParallelWorkers)
+	d.Set("max_parallel_workers_per_gather", config.MaxParallelWorkersPerGather)
+	d.Set("max_worker_processes", config.MaxWorkerProcesses)
+	d.Set("pg_partman_bgw_role", config.PGPartmanBGWRole)
+	d.Set("pg_partman_bgw_interval", config.PGPartmanBGWInterval)
+	d.Set("pg_stat_statements_track", config.PGStatStatementsTrack)
+	d.Set("temp_file_limit", config.TempFileLimit)
+	d.Set("timezone", config.Timezone)
+	d.Set("track_activity_query_size", config.TrackActivityQuerySize)
+	d.Set("track_commit_timestamp", config.TrackCommitTimestamp)
+	d.Set("track_functions", config.TrackFunctions)
+	d.Set("track_io_timing", config.TrackIOTiming)
+	d.Set("max_wal_senders", config.MaxWalSenders)
+	d.Set("wal_sender_timeout", config.WalSenderTimeout)
+	d.Set("wal_writer_delay", config.WalWriterDelay)
+	d.Set("shared_buffers_percentage", config.SharedBuffersPercentage)
+	d.Set("pgbouncer", config.PgBouncer)
+	d.Set("backup_hour", config.BackupHour)
+	d.Set("backup_minute", config.BackupMinute)
+	d.Set("work_mem", config.WorkMem)
+	d.Set("timescaledb", config.TimeScaleDB)
+
+	return nil
+}
+
+func resourceDigitalOceanDatabasePostgreSQLConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+
+	warn := []diag.Diagnostic{
+		{
+			Severity: diag.Warning,
+			Summary:  "digitalocean_database_postgresql_config removed from state",
+			Detail:   "Database configurations are only removed from state when destroyed. The remote configuration is not unset.",
+		},
+	}
+
+	return warn
+}
+
+func resourceDigitalOceanDatabasePostgreSQLConfigImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	clusterID := d.Id()
+
+	d.SetId(makeDatabasePostgreSQLConfigID(clusterID))
+	d.Set("cluster_id", clusterID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func makeDatabasePostgreSQLConfigID(clusterID string) string {
+	return fmt.Sprintf("%s/postgresql-config", clusterID)
+}

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -43,9 +43,9 @@ const testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic = `
 %s
 
 resource "digitalocean_database_postgresql_config" "foobar" {
-  cluster_id                 = digitalocean_database_cluster.foobar.id
-  jit                        = %t
-  timezone                   = "%s"
-  shared_buffers_percentage  = %f
-  work_mem                   = %d
+  cluster_id                = digitalocean_database_cluster.foobar.id
+  jit                       = %t
+  timezone                  = "%s"
+  shared_buffers_percentage = %f
+  work_mem                  = %d
 }`

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -1,0 +1,51 @@
+package database_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDigitalOceanDatabasePostgreSQLConfig_Basic(t *testing.T) {
+	name := acceptance.RandomTestName()
+	dbConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterPostgreSQL, name, "8.5")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, false, "UTC", 30.5, 32),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "false"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "UTC"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "shared_buffers_percentage", "30.5"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "work_mem", "32"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, true, "SYSTEM", 20.0, 16),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "SYSTEM"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "shared_buffers_percentage", "20"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "work_mem", "16"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic = `
+%s
+
+resource "digitalocean_database_postgresql_config" "foobar" {
+  cluster_id                 = digitalocean_database_cluster.foobar.id
+  jit                        = %t
+  timezone                   = "%s"
+  shared_buffers_percentage  = %f
+  work_mem                   = %d
+}`

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -47,5 +47,5 @@ resource "digitalocean_database_postgresql_config" "foobar" {
   timezone                  = "%s"
   shared_buffers_percentage = %f
   work_mem                  = %d
-  jit						= %t
+  jit                       = %t
 }`

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccDigitalOceanDatabasePostgreSQLConfig_Basic(t *testing.T) {
 	name := acceptance.RandomTestName()
-	dbConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterPostgreSQL, name, "8.5")
+	dbConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterPostgreSQL, name, "15")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -18,18 +18,18 @@ func TestAccDigitalOceanDatabasePostgreSQLConfig_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, "UTC", 30.5, 32),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, "UTC", 30.5, 32, false),
 				Check: resource.ComposeTestCheckFunc(
-					//resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "false"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "false"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "UTC"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "shared_buffers_percentage", "30.5"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "work_mem", "32"),
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, "UTC", 20.0, 16),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, "UTC", 20.0, 16, true),
 				Check: resource.ComposeTestCheckFunc(
-					//resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "true"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "UTC"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "shared_buffers_percentage", "20"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "work_mem", "16"),
@@ -47,4 +47,5 @@ resource "digitalocean_database_postgresql_config" "foobar" {
   timezone                  = "%s"
   shared_buffers_percentage = %f
   work_mem                  = %d
+  jit						= %t
 }`

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -18,19 +18,19 @@ func TestAccDigitalOceanDatabasePostgreSQLConfig_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, false, "UTC", 30.5, 32),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, "UTC", 30.5, 32),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "false"),
+					//resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "false"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "UTC"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "shared_buffers_percentage", "30.5"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "work_mem", "32"),
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, true, "SYSTEM", 20.0, 16),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic, dbConfig, "UTC", 20.0, 16),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "true"),
-					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "SYSTEM"),
+					//resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "jit", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "timezone", "UTC"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "shared_buffers_percentage", "20"),
 					resource.TestCheckResourceAttr("digitalocean_database_postgresql_config.foobar", "work_mem", "16"),
 				),
@@ -44,7 +44,6 @@ const testAccCheckDigitalOceanDatabasePostgreSQLConfigConfigBasic = `
 
 resource "digitalocean_database_postgresql_config" "foobar" {
   cluster_id                = digitalocean_database_cluster.foobar.id
-  jit                       = %t
   timezone                  = "%s"
   shared_buffers_percentage = %f
   work_mem                  = %d

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -148,6 +148,7 @@ func Provider() *schema.Provider {
 			"digitalocean_database_replica":                      database.ResourceDigitalOceanDatabaseReplica(),
 			"digitalocean_database_user":                         database.ResourceDigitalOceanDatabaseUser(),
 			"digitalocean_database_redis_config":                 database.ResourceDigitalOceanDatabaseRedisConfig(),
+			"digitalocean_database_postgresql_config":            database.ResourceDigitalOceanDatabasePostgreSQLConfig(),
 			"digitalocean_database_mysql_config":                 database.ResourceDigitalOceanDatabaseMySQLConfig(),
 			"digitalocean_database_kafka_topic":                  database.ResourceDigitalOceanDatabaseKafkaTopic(),
 			"digitalocean_domain":                                domain.ResourceDigitalOceanDomain(),

--- a/docs/resources/database_postgresql_config.md
+++ b/docs/resources/database_postgresql_config.md
@@ -13,9 +13,9 @@ options for a DigitalOcean managed PostgreSQL database cluster.
 
 ```hcl
 resource "digitalocean_database_postgresql_config" "example" {
-  cluster_id      = digitalocean_database_cluster.example.id
-  timezone       = "UTC"
-  work_mem        = 16
+  cluster_id = digitalocean_database_cluster.example.id
+  timezone   = "UTC"
+  work_mem   = 16
 }
 
 resource "digitalocean_database_cluster" "example" {

--- a/docs/resources/database_postgresql_config.md
+++ b/docs/resources/database_postgresql_config.md
@@ -1,0 +1,100 @@
+---
+page_title: "DigitalOcean: digitalocean_database_postgresql_config"
+---
+
+# digitalocean\_database\_postgresql\_config
+
+Provides a virtual resource that can be used to change advanced configuration
+options for a DigitalOcean managed PostgreSQL database cluster.
+
+-> **Note** PostgreSQL configurations are only removed from state when destroyed. The remote configuration is not unset.
+
+## Example Usage
+
+```hcl
+resource "digitalocean_database_postgresql_config" "example" {
+  cluster_id        = digitalocean_database_cluster.example.id
+  connect_timeout   = 10
+  time_zone         = "UTC"
+  work_mem          = 16
+}
+
+resource "digitalocean_database_cluster" "example" {
+  name       = "example-postgresql-cluster"
+  engine     = "pg"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+for additional details on each option.
+
+* `cluster_id` - (Required)  The ID of the target PostgreSQL cluster.
+* `autovacuum_freeze_max_age` - (Optional)  Specifies the maximum age (in transactions) that a table's pg_class.relfrozenxid field can attain before a VACUUM operation is forced to prevent transaction ID wraparound within the table. Note that the system will launch autovacuum processes to prevent wraparound even when autovacuum is otherwise disabled. This parameter will cause the server to be restarted.
+* `autovacuum_max_workers` - (Optional)  Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is three. This parameter can only be set at server start.
+* `autovacuum_naptime` - (Optional)  Specifies the minimum delay, in seconds, between autovacuum runs on any given database. The default is one minute.
+* `autovacuum_vacuum_threshold` - (Optional)  Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is 50 tuples.
+* `autovacuum_analyze_threshold` - (Optional)  Specifies the minimum number of inserted, updated, or deleted tuples needed to trigger an ANALYZE in any one table. The default is 50 tuples.
+* `autovacuum_vacuum_scale_factor` - (Optional)  Specifies a fraction, in a decimal value, of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size).
+* `autovacuum_analyze_scale_factor` - (Optional)  Specifies a fraction, in a decimal value, of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size).
+* `autovacuum_vacuum_cost_delay` - (Optional)  Specifies the cost delay value, in milliseconds, that will be used in automatic VACUUM operations. If -1, uses the regular vacuum_cost_delay value, which is 20 milliseconds.
+* `autovacuum_vacuum_cost_limit` - (Optional)  Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used.
+* `bgwriter_delay` - (Optional)  Specifies the delay, in milliseconds, between activity rounds for the background writer. Default is 200 ms.
+* `bgwriter_flush_after` - (Optional)  The amount of kilobytes that need to be written by the background writer before attempting to force the OS to issue these writes to underlying storage. Specified in kilobytes, default is 512. Setting of 0 disables forced writeback.
+* `bgwriter_lru_maxpages` - (Optional)  The maximum number of buffers that the background writer can write. Setting this to zero disables background writing. Default is 100.
+* `bgwriter_lru_multiplier` - (Optional)  The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a “just in time” policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is 2.0.
+* `deadlock_timeout` - (Optional)  The amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition.
+* `default_toast_compression` - (Optional)  Specifies the default TOAST compression method for values of compressible columns (the default is lz4). Supported values are: `lz4`, `pglz`.
+* `idle_in_transaction_session_timeout` - (Optional)  Time out sessions with open transactions after this number of milliseconds
+* `jit` - (Optional)  Activates, in a boolean, the system-wide use of Just-in-Time Compilation (JIT).
+* `log_autovacuum_min_duration` - (Optional)  Causes each action executed by autovacuum to be logged if it ran for at least the specified number of milliseconds. Setting this to zero logs all autovacuum actions. Minus-one (the default) disables logging autovacuum actions.
+* `log_error_verbosity` - (Optional)  Controls the amount of detail written in the server log for each message that is logged. Supported values are: `TERSE`, `DEFAULT`, `VERBOSE`.
+* `log_line_prefix` - (Optional)  Selects one of the available log-formats. These can support popular log analyzers like pgbadger, pganalyze, etc. Supported values are: `pid=%p,user=%u,db=%d,app=%a,client=%h`, `%m [%p] %q[user=%u,db=%d,app=%a]`, `%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h`.
+* `log_min_duration_statement` - (Optional)  Log statements that take more than this number of milliseconds to run. If -1, disables.
+* `max_files_per_process` - (Optional)  PostgreSQL maximum number of files that can be open per process.
+* `max_prepared_transactions` - (Optional)  PostgreSQL maximum prepared transactions. Once increased, this parameter cannot be lowered from its set value.
+* `max_pred_locks_per_transaction` - (Optional)  PostgreSQL maximum predicate locks per transaction.
+* `max_locks_per_transaction` - (Optional)  PostgreSQL maximum locks per transaction. Once increased, this parameter cannot be lowered from its set value.
+* `max_stack_depth` - (Optional)  Maximum depth of the stack in bytes.
+* `max_standby_archive_delay` - (Optional)  Max standby archive delay in milliseconds.
+* `max_standby_streaming_delay` - (Optional)  Max standby streaming delay in milliseconds.
+* `max_replication_slots` - (Optional)  PostgreSQL maximum replication slots.
+* `max_logical_replication_workers` - (Optional)  PostgreSQL maximum logical replication workers (taken from the pool of max_parallel_workers).
+* `max_parallel_workers` - (Optional)  Sets the maximum number of workers that the system can support for parallel queries.
+* `max_parallel_workers_per_gather` - (Optional)  Sets the maximum number of workers that can be started by a single Gather or Gather Merge node.
+* `max_worker_processes` - (Optional)  Sets the maximum number of background processes that the system can support. Once increased, this parameter cannot be lowered from its set value.
+* `pg_partman_bgw_role` - (Optional)  Controls which role to use for pg_partman's scheduled background tasks. Must consist of alpha-numeric characters, dots, underscores, or dashes. May not start with dash or dot. Maximum of 64 characters.
+* `pg_partman_bgw_interval` - (Optional)  Sets the time interval to run pg_partman's scheduled tasks.
+* `pg_stat_statements_track` - (Optional)  Controls which statements are counted. Specify 'top' to track top-level statements (those issued directly by clients), 'all' to also track nested statements (such as statements invoked within functions), or 'none' to disable statement statistics collection. The default value is top. Supported values are: `all`, `top`, `none`.
+* `temp_file_limit` - (Optional)  PostgreSQL temporary file limit in KiB. If -1, sets to unlimited.
+* `timezone` - (Optional)  PostgreSQL service timezone
+* `track_activity_query_size` - (Optional)  Specifies the number of bytes reserved to track the currently executing command for each active session.
+* `track_commit_timestamp` - (Optional)  Record commit time of transactions. The default value is top. Supported values are: `off`, `on`.
+* `track_functions` - (Optional)  Enables tracking of function call counts and time used. The default value is top. Supported values are: `all`, `pl`, `none`.
+* `track_io_timing` - (Optional)  Enables timing of database I/O calls. This parameter is off by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms. The default value is top. Supported values are: `off`, `on`.
+* `max_wal_senders` - (Optional)  PostgreSQL maximum WAL senders. Once increased, this parameter cannot be lowered from its set value.
+* `wal_sender_timeout` - (Optional)  Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to zero disables the timeout. Must be either 0 or between 5000 and 10800000.
+* `wal_writer_delay` - (Optional)  WAL flush interval in milliseconds. Note that setting this value to lower than the default 200ms may negatively impact performance
+* `shared_buffers_percentage` - (Optional)  Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the shared_buffers configuration value.
+* `pgbouncer` - (Optional)  PGBouncer connection pooling settings
+* `backup_hour` - (Optional)  The hour of day (in UTC) when backup for the service starts. New backup only starts if previous backup has already completed.
+* `backup_minute` - (Optional)  The minute of the backup hour when backup for the service starts. New backup is only started if previous backup has already completed.
+* `work_mem` - (Optional)  The maximum amount of memory, in MB, used by a query operation (such as a sort or hash table) before writing to temporary disk files. Default is 1MB + 0.075% of total RAM (up to 32MB).
+* `timescaledb` - (Optional)  TimescaleDB extension configuration values
+
+## Attributes Reference
+
+All above attributes are exported. If an attribute was set outside of Terraform, it will be computed.
+
+## Import
+
+A PostgreSQL database cluster's configuration can be imported using the `id` the parent cluster, e.g.
+
+```bash
+terraform import digitalocean_database_postgresql_config.example 52556c07-788e-4d41-b8a7-c796432197d1
+```

--- a/docs/resources/database_postgresql_config.md
+++ b/docs/resources/database_postgresql_config.md
@@ -14,15 +14,14 @@ options for a DigitalOcean managed PostgreSQL database cluster.
 ```hcl
 resource "digitalocean_database_postgresql_config" "example" {
   cluster_id      = digitalocean_database_cluster.example.id
-  connect_timeout = 10
-  time_zone       = "UTC"
+  timezone       = "UTC"
   work_mem        = 16
 }
 
 resource "digitalocean_database_cluster" "example" {
   name       = "example-postgresql-cluster"
   engine     = "pg"
-  version    = "8"
+  version    = "15"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/docs/resources/database_postgresql_config.md
+++ b/docs/resources/database_postgresql_config.md
@@ -13,10 +13,10 @@ options for a DigitalOcean managed PostgreSQL database cluster.
 
 ```hcl
 resource "digitalocean_database_postgresql_config" "example" {
-  cluster_id        = digitalocean_database_cluster.example.id
-  connect_timeout   = 10
-  time_zone         = "UTC"
-  work_mem          = 16
+  cluster_id      = digitalocean_database_cluster.example.id
+  connect_timeout = 10
+  time_zone       = "UTC"
+  work_mem        = 16
 }
 
 resource "digitalocean_database_cluster" "example" {


### PR DESCRIPTION
This pull request adds a new PostgreSQL configuration resource and a corresponding test. The resource allows users to configure various PostgreSQL settings for a DigitalOcean database cluster, similar like to MySQL.

I tried to implement all options from [godo](https://github.com/digitalocean/terraform-provider-digitalocean/blob/629bb3b8b4717cc2d6e96acf02207009d22790d7/vendor/github.com/digitalocean/godo/databases.go#L512). For the test I'm not sure if they are working correct, I guess here it will need some more work.