### PR TITLE
chore: remove go.mod replace for old unused pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,4 @@ require (
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 
-replace github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => github.com/keybase/go-crypto v0.0.0-20190416182011-b785b22cc757
-
 go 1.21

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -441,4 +441,3 @@ gopkg.in/yaml.v2
 ## explicit
 gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
-# github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => github.com/keybase/go-crypto v0.0.0-20190416182011-b785b22cc757


### PR DESCRIPTION
## Context

I am working on [Crossplane DigitalOcean No Fork Upjet Provider](https://github.com/straw-hat-team/provider-digitalocean/pull/4) that requires me to add this package as a dependency. I noticed this old package being pinned to an old version, so I had to deal with adding the `replace` statement to then realize that this package does not seem to be used.