### PR TITLE
Apps: Mark registry_credentials as optional

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -257,7 +257,7 @@ func appSpecImageSourceSchema() map[string]*schema.Schema {
 		},
 		"registry_credentials": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Access credentials for third-party registries",
 			Sensitive:   true,
 		},


### PR DESCRIPTION
The registry_credentials field in the spec should be optional. If the image is publicly available, things are fine without it.

Addresses #1146