### PR TITLE
Project: Remove project from state if tf project creation plan fails

### DIFF
--- a/digitalocean/project/resource_project.go
+++ b/digitalocean/project/resource_project.go
@@ -127,8 +127,19 @@ func resourceDigitalOceanProjectCreate(ctx context.Context, d *schema.ResourceDa
 	if v, ok := d.GetOk("resources"); ok {
 
 		resources, err := assignResourcesToProject(client, project.ID, v.(*schema.Set))
+
 		if err != nil {
-			return diag.Errorf("Error creating project: %s", err)
+
+			if project.ID != "" {
+				_, err := client.Projects.Delete(context.Background(), project.ID)
+				if err != nil {
+					log.Printf("[DEBUG] Adding resources to project unsuccessful and project deletion unsuccessful: %s", project.ID)
+				}
+
+				log.Printf("[DEBUG] Adding resources to project unsuccessful, project deleted: %s", project.ID)
+			}
+
+			return diag.Errorf("Error creating Project: %s", err)
 		}
 
 		d.Set("resources", resources)


### PR DESCRIPTION
Addresses  #1143

Fixes following scenario:

1. User creates plan with a new project and adds unacceptable resources (i.e. vpc) to project
3. Terraform plan fails, project is still created but not added to terraform state
4. User fixes plan by removing unacceptable resources
5. User re-applies plan, plan fails with `project with same name already exists` error because project was never added to terraform state, so terraform thinks it doesn't exist, though the project does exist in DO.


This fix will delete a project if the adding resources to project request fails, therefore being more aligned with the terraform state. 

Terraform plan to reproduce:
```
resource "digitalocean_droplet" "web" {
  name   = "web-01"
  size   = "s-1vcpu-1gb"
  image  = "ubuntu-22-04-x64"
  region = "nyc3"
}

resource "digitalocean_vpc" "test" {
    name        = "test"
    region      = "nyc3"
    ip_range    = "10.8.0.0/16"
}

resource "digitalocean_project" "test3" {
  name = "test3"
  resources = [
    digitalocean_vpc.test.urn,
    digitalocean_droplet.web.urn
  ]
}
```