### PR TITLE
Apps: Add egress/dedicated IPs support

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -44,7 +44,6 @@ func appSpecSchema(isResource bool) map[string]*schema.Schema {
 		"features": {
 			Type:        schema.TypeSet,
 			Optional:    true,
-			Computed:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Description: "List of features which is applied to the app",
 		},
@@ -58,7 +57,6 @@ func appSpecSchema(isResource bool) map[string]*schema.Schema {
 		"service": {
 			Type:     schema.TypeList,
 			Optional: true,
-			Computed: true,
 			MinItems: 1,
 			Elem:     appSpecServicesSchema(),
 		},

--- a/digitalocean/app/datasource_app.go
+++ b/digitalocean/app/datasource_app.go
@@ -28,6 +28,34 @@ func DataSourceDigitalOceanApp() *schema.Resource {
 				Computed:    true,
 				Description: "The default URL to access the App",
 			},
+			"dedicated_ips": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "The dedicated egress IP addresses associated with the app.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: "The IP address of the dedicated egress IP.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: "The ID of the dedicated egress IP.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: "The status of the dedicated egress IP: 'UNKNOWN', 'ASSIGNING', 'ASSIGNED', or 'REMOVED'",
+						},
+					},
+				},
+			},
 			"project_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -269,6 +269,7 @@ func TestAccDigitalOceanApp_Egress(t *testing.T) {
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "created_at"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.static_site.0.catchall_document", "404.html"),
+					resource.TestCheckResourceAttr("digitalocean_app.foobar", "spec.0.egress.0.type", "DEDICATED_IP"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.match.0.path.0.prefix", "/"),
 					resource.TestCheckResourceAttr(

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -1247,9 +1247,9 @@ resource "digitalocean_app" "foobar" {
       }
     }
 
-	egress {
-		type = "DEDICATED_IP"
-	}
+    egress {
+      type = "DEDICATED_IP"
+    }
   }
 }`
 

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -221,7 +221,6 @@ func TestAccDigitalOceanApp_StaticSite(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.name", appName),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "default_ingress"),
-					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "dedicated_ips.0.ip"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "updated_at"),

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -221,6 +221,49 @@ func TestAccDigitalOceanApp_StaticSite(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.name", appName),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "default_ingress"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "dedicated_ips.0.ip"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "updated_at"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "created_at"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.static_site.0.catchall_document", "404.html"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.match.0.path.0.prefix", "/"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.component.0.preserve_path_prefix", "false"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.static_site.0.build_command", "bundle exec jekyll build -d ./public"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.static_site.0.output_dir", "/public"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.static_site.0.git.0.repo_clone_url",
+						"https://github.com/digitalocean/sample-jekyll.git"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.static_site.0.git.0.branch", "main"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanApp_Egress(t *testing.T) {
+	var app godo.App
+	appName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_Egress, appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.name", appName),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "default_ingress"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "dedicated_ips.0.ip"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "active_deployment_id"),
 					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "updated_at"),
@@ -1182,6 +1225,31 @@ resource "digitalocean_app" "foobar" {
         branch         = "main"
       }
     }
+  }
+}`
+
+var testAccCheckDigitalOceanAppConfig_Egress = `
+resource "digitalocean_app" "foobar" {
+  spec {
+    name   = "%s"
+    region = "ams"
+
+    static_site {
+      name              = "sample-jekyll"
+      build_command     = "bundle exec jekyll build -d ./public"
+      output_dir        = "/public"
+      environment_slug  = "jekyll"
+      catchall_document = "404.html"
+
+      git {
+        repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
+        branch         = "main"
+      }
+    }
+
+	egress {
+		type = "DEDICATED_IP"
+	}
   }
 }`
 

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -29,6 +29,10 @@ output "default_ingress" {
 The following attributes are exported:
 
 * `default_ingress` - The default URL to access the app.
+* `dedicated_ips` - A list of dedicated egress IP addresses associated with the app.
+  - `ip` - The IP address of the dedicated egress IP.
+  - `id` - The ID of the dedicated egress IP.
+  - `status` - The status of the dedicated egress IP.
 * `live_url` - The live URL of the app.
 * `active_deployment_id` - The ID the app's currently active deployment.
 * `urn` - The uniform resource identifier for the app.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -175,6 +175,8 @@ The following arguments are supported:
  - `alert` - Describes an alert policy for the app.
      * `rule` - The type of the alert to configure. Top-level app alert policies can be: `DEPLOYMENT_FAILED`, `DEPLOYMENT_LIVE`, `DOMAIN_FAILED`, or `DOMAIN_LIVE`.
      * `disabled` - Determines whether or not the alert is disabled (default: `false`).
+ - `egress` - Specification for app egress configurations.
+      * `type` - The app egress type: `AUTOASSIGN`, `DEDICATED_IP`
  - `ingress` - Specification for component routing, rewrites, and redirects.
      * `rule` - Rules for configuring HTTP ingress for component routes, CORS, rewrites, and redirects.
          - `component` - The component to route to. Only one of `component` or `redirect` may be set.


### PR DESCRIPTION
Addresses #1151

API reference:
[https://docs.digitalocean.com/reference/api/api-reference/#operation/apps_create](https://docs.digitalocean.com/reference/api/api-reference/#operation/apps_create
)

Example config:
```
resource "digitalocean_app" "foobar" {
  spec {
    name   = "%s"
    region = "ams"

    static_site {
      name              = "sample-jekyll"
      build_command     = "bundle exec jekyll build -d ./public"
      output_dir        = "/public"
      environment_slug  = "jekyll"
      catchall_document = "404.html"

      git {
        repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
        branch         = "main"
      }
    }

    egress {
      type = "DEDICATED_IP"
    }
  }
}
```


Tests passing:
```
x@x terraform-provider-digitalocean % TF_ACC=1 go test -v -run TestAccDigitalOceanApp_Egress ./digitalocean/app
=== RUN   TestAccDigitalOceanApp_Egress
=== PAUSE TestAccDigitalOceanApp_Egress
=== CONT  TestAccDigitalOceanApp_Egress
--- PASS: TestAccDigitalOceanApp_Egress (215.39s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/app        216.154s
```