### PR TITLE
dbaas:  ensure password is always retained in connection URIs, replicas, and connection pools.

### DIFF
--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	mongoDBEngineSlug = "mongodb"
 	mysqlDBEngineSlug = "mysql"
 	redisDBEngineSlug = "redis"
 )

--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -640,32 +640,12 @@ func flattenMaintWindowOpts(opts godo.DatabaseMaintenanceWindow) []map[string]in
 	return result
 }
 
-func buildDBConnectionURI(database *godo.Database, d *schema.ResourceData) (string, error) {
-	if database.EngineSlug == mongoDBEngineSlug {
-		return buildMongoDBConnectionURI(database.Connection, d)
-	}
-
-	return database.Connection.URI, nil
-}
-
-func buildDBPrivateURI(database *godo.Database, d *schema.ResourceData) (string, error) {
-	if database.EngineSlug == mongoDBEngineSlug {
-		uri, err := buildMongoDBConnectionURI(database.PrivateConnection, d)
-		if err != nil {
-			return "", err
-		}
-		return uri, nil
-	}
-
-	return database.PrivateConnection.URI, nil
-}
-
 func setDatabaseConnectionInfo(database *godo.Database, d *schema.ResourceData) error {
 	if database.Connection != nil {
 		d.Set("host", database.Connection.Host)
 		d.Set("port", database.Connection.Port)
 
-		uri, err := buildDBConnectionURI(database, d)
+		uri, err := buildDBConnectionURI(database.Connection, d)
 		if err != nil {
 			return err
 		}
@@ -681,7 +661,7 @@ func setDatabaseConnectionInfo(database *godo.Database, d *schema.ResourceData) 
 	if database.PrivateConnection != nil {
 		d.Set("private_host", database.PrivateConnection.Host)
 
-		privateUri, err := buildDBPrivateURI(database, d)
+		privateUri, err := buildDBPrivateURI(database.PrivateConnection, d)
 		if err != nil {
 			return err
 		}
@@ -705,11 +685,17 @@ func setUIConnectionInfo(database *godo.Database, d *schema.ResourceData) error 
 	return nil
 }
 
+// buildDBConnectionURI constructs a connection URI using the password stored in state.
+//
 // MongoDB clusters only return their password in response to the initial POST.
 // The host for the cluster is not known until it becomes available. In order to
 // build a usable connection URI, we must save the password and then add it to
 // the URL returned latter.
-func buildMongoDBConnectionURI(conn *godo.DatabaseConnection, d *schema.ResourceData) (string, error) {
+//
+// This also protects against the password being removed from the URI if the user
+// switches to using a read-only token. All database engines redact the password
+// in that case
+func buildDBConnectionURI(conn *godo.DatabaseConnection, d *schema.ResourceData) (string, error) {
 	password := d.Get("password")
 	uri, err := url.Parse(conn.URI)
 	if err != nil {
@@ -720,6 +706,10 @@ func buildMongoDBConnectionURI(conn *godo.DatabaseConnection, d *schema.Resource
 	uri.User = userInfo
 
 	return uri.String(), nil
+}
+
+func buildDBPrivateURI(conn *godo.DatabaseConnection, d *schema.ResourceData) (string, error) {
+	return buildDBConnectionURI(conn, d)
 }
 
 func expandBackupRestore(config []interface{}) *godo.DatabaseBackupRestore {

--- a/digitalocean/database/resource_database_connection_pool_test.go
+++ b/digitalocean/database/resource_database_connection_pool_test.go
@@ -61,10 +61,6 @@ func TestAccDigitalOceanDatabaseConnectionPool_Basic(t *testing.T) {
 						"digitalocean_database_connection_pool.pool-01", "name", databaseConnectionPoolName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_connection_pool.pool-01", "mode", "session"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_connection_pool.pool-01", "user", ""),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_connection_pool.pool-01", "password", ""),
 				),
 			},
 		},


### PR DESCRIPTION
This builds on the work in https://github.com/digitalocean/terraform-provider-digitalocean/pull/1166 to also make sure the password is not overwritten in connection URIs, replicas, and connection pools.