### PR TITLE
Prep v2.39.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.39.2
+
+MISC:
+
+- #1171 - @apinonformoso - docs: add vpc peering alpha only note
+
 ## 2.39.1
 
 BUG FIXES:


### PR DESCRIPTION
While this release contains no code changes, a release is needed to update the live documentation at registry.terraform.io