### PR TITLE
Update for goreleaser 2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,11 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@
 #
 # Artifacts must be produced matching the layout described at:
 # https://www.terraform.io/docs/registry/providers/publishing.html
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -52,4 +53,4 @@ signs:
 release:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Similar to https://github.com/digitalocean/packer-plugin-digitalocean/pull/150, this updates our goreleaser usage for 2.0. 

- the `--rm-dist` flag was replaced by `--clean`
- `changelog.skip` was replaced by `changelog.disable`
- configures the action to use 2.x to prevent future breakage

https://goreleaser.com/blog/goreleaser-v2/#upgrading