### PR TITLE
apps: protect against panic when CORS has no allow_origins

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -2063,17 +2063,20 @@ func expandAppCORSPolicy(config []interface{}) *godo.AppCORSPolicy {
 
 	appCORSConfig := config[0].(map[string]interface{})
 	allowOriginsConfig := appCORSConfig["allow_origins"].([]interface{})
-	allowOriginsMap := allowOriginsConfig[0].(map[string]interface{})
 
 	var allowOrigins []*godo.AppStringMatch
-	if allowOriginsMap["exact"] != "" {
-		allowOrigins = append(allowOrigins, &godo.AppStringMatch{Exact: allowOriginsMap["exact"].(string)})
-	}
-	if allowOriginsMap["prefix"] != "" {
-		allowOrigins = append(allowOrigins, &godo.AppStringMatch{Prefix: allowOriginsMap["prefix"].(string)})
-	}
-	if allowOriginsMap["regex"] != "" {
-		allowOrigins = append(allowOrigins, &godo.AppStringMatch{Regex: allowOriginsMap["regex"].(string)})
+	if len(allowOriginsConfig) > 0 {
+		allowOriginsMap := allowOriginsConfig[0].(map[string]interface{})
+
+		if allowOriginsMap["exact"] != "" {
+			allowOrigins = append(allowOrigins, &godo.AppStringMatch{Exact: allowOriginsMap["exact"].(string)})
+		}
+		if allowOriginsMap["prefix"] != "" {
+			allowOrigins = append(allowOrigins, &godo.AppStringMatch{Prefix: allowOriginsMap["prefix"].(string)})
+		}
+		if allowOriginsMap["regex"] != "" {
+			allowOrigins = append(allowOrigins, &godo.AppStringMatch{Regex: allowOriginsMap["regex"].(string)})
+		}
 	}
 
 	var allowMethods []string

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -400,7 +400,8 @@ func appSpecCORSSchema() map[string]*schema.Schema {
 					"prefix": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Description: "Prefix-based match. ",
+						Description: "Prefix-based match.",
+						Deprecated:  "Prefix-based matching has been deprecated in favor of regex-based matching.",
 					},
 					"regex": {
 						Type:        schema.TypeString,

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -2127,9 +2127,15 @@ func flattenAppCORSPolicy(policy *godo.AppCORSPolicy) []map[string]interface{} {
 			r["allow_origins"] = append(allowOriginsResult, allowOrigins)
 		}
 
-		r["allow_methods"] = policy.AllowMethods
-		r["allow_headers"] = policy.AllowHeaders
-		r["expose_headers"] = policy.ExposeHeaders
+		if len(policy.AllowMethods) > 0 {
+			r["allow_methods"] = policy.AllowMethods
+		}
+		if len(policy.AllowHeaders) > 0 {
+			r["allow_headers"] = policy.AllowHeaders
+		}
+		if len(policy.ExposeHeaders) > 0 {
+			r["expose_headers"] = policy.ExposeHeaders
+		}
 		r["max_age"] = policy.MaxAge
 		r["allow_credentials"] = policy.AllowCredentials
 

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -44,6 +44,7 @@ func appSpecSchema(isResource bool) map[string]*schema.Schema {
 		"features": {
 			Type:        schema.TypeSet,
 			Optional:    true,
+			Computed:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Description: "List of features which is applied to the app",
 		},

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -800,20 +800,6 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: noAllowedOriginsConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
-					resource.TestCheckTypeSetElemAttr(
-						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "GET"),
-					resource.TestCheckTypeSetElemAttr(
-						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "PUT"),
-					resource.TestCheckTypeSetElemAttr(
-						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_headers.*", "X-Custom-Header"),
-					resource.TestCheckTypeSetElemAttr(
-						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_headers.*", "Upgrade-Insecure-Requests"),
-				),
-			},
-			{
 				Config: allowedOrginExactConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
@@ -835,6 +821,20 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_origins.0.regex", "https://[0-9a-z]*.digitalocean.com"),
+				),
+			},
+			{
+				Config: noAllowedOriginsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "GET"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "PUT"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_headers.*", "X-Custom-Header"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_headers.*", "Upgrade-Insecure-Requests"),
 				),
 			},
 			{

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -742,14 +742,6 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
        }
 `
 
-	allowedOrginPrefix := `
-       cors {
-         allow_origins {
-           prefix = "https://example.com"
-         }
-       }
-`
-
 	allowedOrginRegex := `
        cors {
          allow_origins {
@@ -768,7 +760,7 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 	fullConfig := `
        cors {
          allow_origins {
-           prefix = "https://example.com"
+           exact = "https://example.com"
          }
          allow_methods     = ["GET", "PUT"]
          allow_headers     = ["X-Custom-Header", "Upgrade-Insecure-Requests"]
@@ -780,9 +772,6 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 
 	allowedOrginExactConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
 		appName, allowedOrginExact,
-	)
-	allowedOrginPrefixConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
-		appName, allowedOrginPrefix,
 	)
 	allowedOrginRegexConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
 		appName, allowedOrginRegex,
@@ -805,14 +794,6 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_origins.0.exact", "https://example.com"),
-				),
-			},
-			{
-				Config: allowedOrginPrefixConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
-					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_origins.0.prefix", "https://example.com"),
 				),
 			},
 			{
@@ -842,7 +823,7 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(
-						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_origins.0.prefix", "https://example.com"),
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_origins.0.exact", "https://example.com"),
 					resource.TestCheckTypeSetElemAttr(
 						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "GET"),
 					resource.TestCheckTypeSetElemAttr(

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -758,6 +758,13 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
        }
 `
 
+	noAllowedOrigins := `
+       cors {
+         allow_methods     = ["GET", "PUT"]
+         allow_headers     = ["X-Custom-Header", "Upgrade-Insecure-Requests"]
+       }
+`
+
 	fullConfig := `
        cors {
          allow_origins {
@@ -780,6 +787,9 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 	allowedOrginRegexConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
 		appName, allowedOrginRegex,
 	)
+	noAllowedOriginsConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
+		appName, noAllowedOrigins,
+	)
 	updatedConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
 		appName, fullConfig,
 	)
@@ -789,6 +799,20 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
 		Steps: []resource.TestStep{
+			{
+				Config: noAllowedOriginsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "GET"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_methods.*", "PUT"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_headers.*", "X-Custom-Header"),
+					resource.TestCheckTypeSetElemAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.rule.0.cors.0.allow_headers.*", "Upgrade-Insecure-Requests"),
+				),
+			},
 			{
 				Config: allowedOrginExactConfig,
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
This protects against a panic when using CORs ingress rules that do not specify `allow_origins`

Resolves: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1176

While fixing this, I encountered a number of other small issues that needed to be fixed in order to get the relevant tests passing. Each commit addresses a different issue.

1. [apps: don't set empty lists to state in CORs ingres rules](https://github.com/digitalocean/terraform-provider-digitalocean/commit/97ddc6a00a659d5adc2cb98c3502b7a731fc5cd9)

We were setting empty lists to state which caused diffs like:

```
 ~ rule {
    ~ cors {
        + allow_headers     = []
        + allow_methods     = []
        + expose_headers    = []
        # (2 unchanged attributes hidden)
        
        # (1 unchanged block hidden)
    }
        
    # (2 unchanged blocks hidden)
 }
```

2. [apps: prefix based matching for CORs ingress rules is deprecated](https://github.com/digitalocean/terraform-provider-digitalocean/pull/1184/commits/8f599637c35ed9273dac2e305f720869cca6cc72)

App Platform deprecated `prefix` based matching for CORs ingress rules. It automatically converts them to `exact` on the backend. Submitting an app spec that defines an allow origin using a prefix (`ingress.rules[0].cors.allow_origins[0].prefix`), returns a response using an exact match (`ingress.rules[0].cors.allow_origins[0].exact`). This causes issues for Terraform as it will try to reconcile state but always see a difference.

3. [app: mark features as Computed](https://github.com/digitalocean/terraform-provider-digitalocean/commit/c0516dd83c987061d5a2e05cf2215e9ba553a650)

App Platform has started returning the default buildpack stack in the features array. This sets the field to `Computed` to prevent diffs like:

```
  ~ spec {
      ~ features = [
          - "buildpack-stack=ubuntu-22",
        ]
```