### PR TITLE
databases: set replica size to state on read.

### DIFF
--- a/digitalocean/database/import_database_replica_test.go
+++ b/digitalocean/database/import_database_replica_test.go
@@ -40,8 +40,6 @@ func TestAccDigitalOceanDatabaseReplica_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				// Requires passing both the cluster ID and replica name
 				ImportStateIdFunc: testAccDatabaseReplicaImportID(resourceName),
-				// The DO API does not return the size on read, but it is required on create
-				ImportStateVerifyIgnore: []string{"size"},
 			},
 			// Test importing non-existent resource provides expected error.
 			{

--- a/digitalocean/database/resource_database_replica.go
+++ b/digitalocean/database/resource_database_replica.go
@@ -219,6 +219,7 @@ func resourceDigitalOceanDatabaseReplicaRead(ctx context.Context, d *schema.Reso
 		return diag.Errorf("Error retrieving DatabaseReplica: %s", err)
 	}
 
+	d.Set("size", replica.Size)
 	d.Set("region", replica.Region)
 	d.Set("tags", tag.FlattenTags(replica.Tags))
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.117.0
+	github.com/digitalocean/godo v1.119.1-0.20240726213151-e56b8a3e1755
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.117.0 h1:WVlTe09melDYTd7VCVyvHcNWbgB+uI1O115+5LOtdSw=
-github.com/digitalocean/godo v1.117.0/go.mod h1:Vk0vpCot2HOAJwc5WE8wljZGtJ3ZtWIc8MQ8rF38sdo=
+github.com/digitalocean/godo v1.119.1-0.20240726213151-e56b8a3e1755 h1:21uc6tNgFS/5MiYz+KzDhf5tVO38TN8FPO6803yNAjI=
+github.com/digitalocean/godo v1.119.1-0.20240726213151-e56b8a3e1755/go.mod h1:WQVH83OHUy6gC4gXpEVQKtxTd4L5oCp+5OialidkPLY=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [v1.119.0] - 2024-07-24
+
+- #704 - @ElanHasson - APPS-9133 - Add support for OPENSEARCH as a database engine option
+- #703 - @dependabot[bot] - Bump github.com/hashicorp/go-retryablehttp from 0.7.4 to 0.7.7
+- #699 - @ElanHasson - APPS-8790 Add support to App Platform Log Forwarding for an OpenSearch DBaaS cluster destination.
+
+## [v1.118.0] - 2024-06-04
+
+**Note**: This release contains features in closed beta (#700).
+
+- #701 - @llDrLove - Rename control plane permission to control plane firewall
+- #700 - @bbassingthwaite - Add ProxyProtocol to LoadBalancer HealthCheck
+
 ## [v1.117.0] - 2024-06-04
 
 - #696 - @llDrLove - Support specifying control plane firewall rules when creating or updating DOKS clusters

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -193,7 +193,7 @@ type AppBuildConfigCNBVersioning struct {
 
 // AppDatabaseSpec struct for AppDatabaseSpec
 type AppDatabaseSpec struct {
-	// The name. Must be unique across all components within the same app.
+	// The database's name. The name must be unique across all components within the same app and cannot use capital letters.
 	Name    string                `json:"name"`
 	Engine  AppDatabaseSpecEngine `json:"engine,omitempty"`
 	Version string                `json:"version,omitempty"`
@@ -216,12 +216,13 @@ type AppDatabaseSpecEngine string
 
 // List of AppDatabaseSpecEngine
 const (
-	AppDatabaseSpecEngine_Unset   AppDatabaseSpecEngine = "UNSET"
-	AppDatabaseSpecEngine_MySQL   AppDatabaseSpecEngine = "MYSQL"
-	AppDatabaseSpecEngine_PG      AppDatabaseSpecEngine = "PG"
-	AppDatabaseSpecEngine_Redis   AppDatabaseSpecEngine = "REDIS"
-	AppDatabaseSpecEngine_MongoDB AppDatabaseSpecEngine = "MONGODB"
-	AppDatabaseSpecEngine_Kafka   AppDatabaseSpecEngine = "KAFKA"
+	AppDatabaseSpecEngine_Unset      AppDatabaseSpecEngine = "UNSET"
+	AppDatabaseSpecEngine_MySQL      AppDatabaseSpecEngine = "MYSQL"
+	AppDatabaseSpecEngine_PG         AppDatabaseSpecEngine = "PG"
+	AppDatabaseSpecEngine_Redis      AppDatabaseSpecEngine = "REDIS"
+	AppDatabaseSpecEngine_MongoDB    AppDatabaseSpecEngine = "MONGODB"
+	AppDatabaseSpecEngine_Kafka      AppDatabaseSpecEngine = "KAFKA"
+	AppDatabaseSpecEngine_Opensearch AppDatabaseSpecEngine = "OPENSEARCH"
 )
 
 // AppDedicatedIp Represents a dedicated egress ip.
@@ -446,11 +447,13 @@ type AppLogDestinationSpecLogtail struct {
 
 // AppLogDestinationSpecOpenSearch OpenSearch configuration.
 type AppLogDestinationSpecOpenSearch struct {
-	// OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>.
-	Endpoint  string               `json:"endpoint"`
+	// OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. Cannot be specified if `cluster_name` is also specified.
+	Endpoint  string               `json:"endpoint,omitempty"`
 	BasicAuth *OpenSearchBasicAuth `json:"basic_auth,omitempty"`
 	// The index name to use for the logs. If not set, the default index name is \"logs\".
 	IndexName string `json:"index_name,omitempty"`
+	// The name of a DigitalOcean DBaaS OpenSearch cluster to use as a log forwarding destination. Cannot be specified if `endpoint` is also specified.
+	ClusterName string `json:"cluster_name,omitempty"`
 }
 
 // AppLogDestinationSpecPapertrail Papertrail configuration.
@@ -1156,7 +1159,8 @@ type AppInstanceSize struct {
 	// (Deprecated) The slug of the corresponding downgradable instance size on the lower tier.
 	TierDowngradeTo string `json:"tier_downgrade_to,omitempty"`
 	// Indicates if the tier instance size can enable autoscaling.
-	Scalable       bool `json:"scalable,omitempty"`
+	Scalable bool `json:"scalable,omitempty"`
+	// (Deprecated) Indicates if the tier instance size is in feature preview state.
 	FeaturePreview bool `json:"feature_preview,omitempty"`
 	// Indicates if the tier instance size allows more than one instance.
 	SingleInstanceOnly bool `json:"single_instance_only,omitempty"`
@@ -1184,10 +1188,10 @@ type ListBuildpacksResponse struct {
 
 // OpenSearchBasicAuth Configure Username and/or Password for Basic authentication.
 type OpenSearchBasicAuth struct {
-	// Username to authenticate with.
-	User string `json:"user"`
-	// Password for user defined in User.
-	Password string `json:"password"`
+	// Username to authenticate with. Only required when `endpoint` is set. Defaults to `doadmin` when `cluster_name` is set.
+	User string `json:"user,omitempty"`
+	// Password for user defined in User. Is required when `endpoint` is set. Cannot be set if using a DigitalOcean DBaaS OpenSearch cluster.
+	Password string `json:"password,omitempty"`
 }
 
 // AppProposeRequest struct for AppProposeRequest

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1389,6 +1389,14 @@ func (a *AppLogDestinationSpecOpenSearch) GetBasicAuth() *OpenSearchBasicAuth {
 	return a.BasicAuth
 }
 
+// GetClusterName returns the ClusterName field.
+func (a *AppLogDestinationSpecOpenSearch) GetClusterName() string {
+	if a == nil {
+		return ""
+	}
+	return a.ClusterName
+}
+
 // GetEndpoint returns the Endpoint field.
 func (a *AppLogDestinationSpecOpenSearch) GetEndpoint() string {
 	if a == nil {

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -392,6 +392,7 @@ type DatabaseReplica struct {
 	PrivateNetworkUUID string              `json:"private_network_uuid,omitempty"`
 	Tags               []string            `json:"tags,omitempty"`
 	StorageSizeMib     uint64              `json:"storage_size_mib,omitempty"`
+	Size               string              `json:"size"`
 }
 
 // DatabasePool represents a database connection pool

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.117.0"
+	libraryVersion = "1.119.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -76,20 +76,20 @@ type KubernetesClusterCreateRequest struct {
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
-	MaintenancePolicy      *KubernetesMaintenancePolicy      `json:"maintenance_policy"`
-	AutoUpgrade            bool                              `json:"auto_upgrade"`
-	SurgeUpgrade           bool                              `json:"surge_upgrade"`
-	ControlPlanePermission *KubernetesControlPlanePermission `json:"control_plane_permission,omitempty"`
+	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy"`
+	AutoUpgrade          bool                            `json:"auto_upgrade"`
+	SurgeUpgrade         bool                            `json:"surge_upgrade"`
+	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
 type KubernetesClusterUpdateRequest struct {
-	Name                   string                            `json:"name,omitempty"`
-	Tags                   []string                          `json:"tags,omitempty"`
-	MaintenancePolicy      *KubernetesMaintenancePolicy      `json:"maintenance_policy,omitempty"`
-	AutoUpgrade            *bool                             `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade           bool                              `json:"surge_upgrade,omitempty"`
-	ControlPlanePermission *KubernetesControlPlanePermission `json:"control_plane_permission,omitempty"`
+	Name                 string                          `json:"name,omitempty"`
+	Tags                 []string                        `json:"tags,omitempty"`
+	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy,omitempty"`
+	AutoUpgrade          *bool                           `json:"auto_upgrade,omitempty"`
+	SurgeUpgrade         bool                            `json:"surge_upgrade,omitempty"`
+	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
 
 	// Convert cluster to run highly available control plane
 	HA *bool `json:"ha,omitempty"`
@@ -203,11 +203,11 @@ type KubernetesCluster struct {
 
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 
-	MaintenancePolicy      *KubernetesMaintenancePolicy      `json:"maintenance_policy,omitempty"`
-	AutoUpgrade            bool                              `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade           bool                              `json:"surge_upgrade,omitempty"`
-	RegistryEnabled        bool                              `json:"registry_enabled,omitempty"`
-	ControlPlanePermission *KubernetesControlPlanePermission `json:"control_plane_permission,omitempty"`
+	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy,omitempty"`
+	AutoUpgrade          bool                            `json:"auto_upgrade,omitempty"`
+	SurgeUpgrade         bool                            `json:"surge_upgrade,omitempty"`
+	RegistryEnabled      bool                            `json:"registry_enabled,omitempty"`
+	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
@@ -243,8 +243,8 @@ type KubernetesMaintenancePolicy struct {
 	Day       KubernetesMaintenancePolicyDay `json:"day"`
 }
 
-// KubernetesControlPlanePermission represents Kubernetes cluster control plane permission.
-type KubernetesControlPlanePermission struct {
+// KubernetesControlPlaneFirewall represents Kubernetes cluster control plane firewall.
+type KubernetesControlPlaneFirewall struct {
 	Enabled          *bool    `json:"enabled"`
 	AllowedAddresses []string `json:"allowed_addresses"`
 }

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -170,6 +170,7 @@ type HealthCheck struct {
 	ResponseTimeoutSeconds int    `json:"response_timeout_seconds,omitempty"`
 	HealthyThreshold       int    `json:"healthy_threshold,omitempty"`
 	UnhealthyThreshold     int    `json:"unhealthy_threshold,omitempty"`
+	ProxyProtocol          *bool  `json:"proxy_protocol,omitempty"`
 }
 
 // String creates a human-readable description of a HealthCheck.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.117.0
+# github.com/digitalocean/godo v1.119.1-0.20240726213151-e56b8a3e1755
 ## explicit; go 1.20
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Now that `size` is available in the `GET /v2/databases/{uuid}/replicas/{name}` response, we can set it to state on read.

Resolves: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1185