### PR TITLE
fix: run https://github.com/crate-ci/typos --write-changes to fix up typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -655,7 +655,7 @@ IMPROVEMENTS:
 * Run tests on pull_request not pull_request_target. ([#589](https://github.com/digitalocean/terraform-provider-digitalocean/pull/589))
 * kubernetes - enable surge upgrades by default during cluster creation ([#584](https://github.com/digitalocean/terraform-provider-digitalocean/pull/584))
 * Assign and remove project resources without unnecessary churn (Fixes: #585). ([#586](https://github.com/digitalocean/terraform-provider-digitalocean/pull/586))
-* dbaas replica: Add missing attrbutes to docs. ([#588](https://github.com/digitalocean/terraform-provider-digitalocean/pull/588))
+* dbaas replica: Add missing attributes to docs. ([#588](https://github.com/digitalocean/terraform-provider-digitalocean/pull/588))
 * Bump Kubernetes version used in documentation ([#583](https://github.com/digitalocean/terraform-provider-digitalocean/pull/583))
 
 BUG FIXES:
@@ -728,7 +728,7 @@ BUG FIXES:
 
 NOTES:
 
-* DigitalOcean Container Registry is now in general availablity and requires a [subscription plan](https://www.digitalocean.com/docs/container-registry/#plans-and-pricing). As a result, the `digitalocean_container_registry` resource now requires setting a `subscription_tier_slug`.
+* DigitalOcean Container Registry is now in general availability and requires a [subscription plan](https://www.digitalocean.com/docs/container-registry/#plans-and-pricing). As a result, the `digitalocean_container_registry` resource now requires setting a `subscription_tier_slug`.
 
 IMPROVEMENTS:
 
@@ -756,7 +756,7 @@ BUG FIXES:
 NOTES:
 
 * This release uses v2.0.3 of the Terraform Plugin SDK and now only supports Terraform v0.12 and higher.
-* The `certificate_id` attribute of the `digitalocean_cdn` and `digitalocean_loadbalancer` resources has been deprecated in favor of `certificate_name`. It will become a read-only computed attrbute in a future release.
+* The `certificate_id` attribute of the `digitalocean_cdn` and `digitalocean_loadbalancer` resources has been deprecated in favor of `certificate_name`. It will become a read-only computed attribute in a future release.
 
 FEATURES:
 

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
-	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
 )
 
 func TestAccDigitalOceanApp_Image(t *testing.T) {
@@ -734,7 +735,7 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 	var app godo.App
 	appName := acceptance.RandomTestName()
 
-	allowedOrginExact := `
+	allowedOriginExact := `
        cors {
          allow_origins {
            exact = "https://example.com"
@@ -742,7 +743,7 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
        }
 `
 
-	allowedOrginRegex := `
+	allowedOriginRegex := `
        cors {
          allow_origins {
            regex = "https://[0-9a-z]*.digitalocean.com"
@@ -770,11 +771,11 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
        }
 `
 
-	allowedOrginExactConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
-		appName, allowedOrginExact,
+	allowedOriginExactConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
+		appName, allowedOriginExact,
 	)
-	allowedOrginRegexConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
-		appName, allowedOrginRegex,
+	allowedOriginRegexConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
+		appName, allowedOriginRegex,
 	)
 	noAllowedOriginsConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
 		appName, noAllowedOrigins,
@@ -789,7 +790,7 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: allowedOrginExactConfig,
+				Config: allowedOriginExactConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(
@@ -797,7 +798,7 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 				),
 			},
 			{
-				Config: allowedOrginRegexConfig,
+				Config: allowedOriginRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
 					resource.TestCheckResourceAttr(

--- a/digitalocean/database/resource_database_kafka_topic.go
+++ b/digitalocean/database/resource_database_kafka_topic.go
@@ -363,7 +363,7 @@ func resourceDigitalOceanDatabaseKafkaTopicRead(ctx context.Context, d *schema.R
 
 	d.Set("state", topic.State)
 	d.Set("replication_factor", topic.ReplicationFactor)
-	// updating 'partition_count' is async, the number of partitions returned in the API will not be updated immeadiately in the response
+	// updating 'partition_count' is async, the number of partitions returned in the API will not be updated immediately in the response
 	// setting this property to the current state rather than the number of `partitions` returned in the GetTopic response
 	d.Set("partition_count", d.Get("partition_count").(int))
 

--- a/digitalocean/database/resource_database_user.go
+++ b/digitalocean/database/resource_database_user.go
@@ -47,7 +47,7 @@ func ResourceDigitalOceanDatabaseUser() *schema.Resource {
 					godo.SQLAuthPluginNative,
 					godo.SQLAuthPluginCachingSHA2,
 				}, false),
-				// Prevent diffs when default is used and not specificed in the config.
+				// Prevent diffs when default is used and not specified in the config.
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return old == godo.SQLAuthPluginCachingSHA2 && new == ""
 				},

--- a/digitalocean/domain/resource_record_test.go
+++ b/digitalocean/domain/resource_record_test.go
@@ -600,7 +600,7 @@ func TestAccDigitalOceanRecord_ExpectedErrors(t *testing.T) {
   weight   = 0
   value    = "srv.example.com"
 }`
-		srvNoPrirority = `resource "digitalocean_record" "pgsql_default_pub_srv" {
+		srvNoPriority = `resource "digitalocean_record" "pgsql_default_pub_srv" {
   domain = "example.com"
 
   type = "SRV"
@@ -655,7 +655,7 @@ func TestAccDigitalOceanRecord_ExpectedErrors(t *testing.T) {
 				ExpectError: regexp.MustCompile("`port` is required for when type is `SRV`"),
 			},
 			{
-				Config:      srvNoPrirority,
+				Config:      srvNoPriority,
 				ExpectError: regexp.MustCompile("`priority` is required for when type is `SRV`"),
 			},
 			{

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -1056,12 +1056,12 @@ users:
 		Token:                    "97ae2bbcfd85c34155a56b822ffa73909d6770b28eb7e5dfa78fa83e02ffc60f",
 		ExpiresAt:                time.Now(),
 	}
-	kubeConfigRenderd, err := kubernetes.RenderKubeconfig("test-cluster", "lon1", &creds)
+	kubeConfigRendered, err := kubernetes.RenderKubeconfig("test-cluster", "lon1", &creds)
 	if err != nil {
 		t.Errorf("error calling renderKubeconfig: %s", err)
 
 	}
-	got := string(kubeConfigRenderd)
+	got := string(kubeConfigRendered)
 
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("renderKubeconfig returned %+v\n, expected %+v\n", got, expected)

--- a/digitalocean/snapshot/resource_droplet_snapshot.go
+++ b/digitalocean/snapshot/resource_droplet_snapshot.go
@@ -75,7 +75,7 @@ func resourceDigitalOceanDropletSnapshotCreate(ctx context.Context, d *schema.Re
 	snapshot, err := findSnapshotInSnapshotList(context.Background(), client, *action)
 
 	if err != nil {
-		return diag.Errorf("Error retriving Droplet Snapshot: %s", err)
+		return diag.Errorf("Error retrieving Droplet Snapshot: %s", err)
 	}
 
 	d.SetId(strconv.Itoa(snapshot.ID))
@@ -125,7 +125,7 @@ func resourceDigitalOceanDropletSnapshotRead(ctx context.Context, d *schema.Reso
 func resourceDigitalOceanDropletSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig).GodoClient()
 
-	log.Printf("[INFO] Deleting snaphot: %s", d.Id())
+	log.Printf("[INFO] Deleting snapshot: %s", d.Id())
 	_, err := client.Snapshots.Delete(context.Background(), d.Id())
 	if err != nil {
 		return diag.Errorf("Error deleting snapshot: %s", err)

--- a/digitalocean/snapshot/resource_volume_snapshot.go
+++ b/digitalocean/snapshot/resource_volume_snapshot.go
@@ -126,7 +126,7 @@ func resourceDigitalOceanVolumeSnapshotRead(ctx context.Context, d *schema.Resou
 func resourceDigitalOceanVolumeSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig).GodoClient()
 
-	log.Printf("[INFO] Deleting snaphot: %s", d.Id())
+	log.Printf("[INFO] Deleting snapshot: %s", d.Id())
 	_, err := client.Snapshots.Delete(context.Background(), d.Id())
 	if err != nil {
 		return diag.Errorf("Error deleting snapshot: %s", err)

--- a/docs/data-sources/droplet.md
+++ b/docs/data-sources/droplet.md
@@ -58,7 +58,7 @@ The following attributes are exported:
 * `urn` - The uniform resource name of the Droplet
 * `region` - The region the Droplet is running in.
 * `image` - The Droplet image ID or slug.
-* `size` - The unique slug that indentifies the type of Droplet.
+* `size` - The unique slug that identifies the type of Droplet.
 * `disk` - The size of the Droplets disk in GB.
 * `vcpus` - The number of the Droplets virtual CPUs.
 * `memory` - The amount of the Droplets memory in MB.

--- a/docs/resources/database_kafka_topic.md
+++ b/docs/resources/database_kafka_topic.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 `config` supports the following:
 
-* `cleanup_policy` - (Optional) The topic cleanup policy that decribes whether messages should be deleted, compacted, or both when retention policies are violated.
+* `cleanup_policy` - (Optional) The topic cleanup policy that describes whether messages should be deleted, compacted, or both when retention policies are violated.
   This may be one of "delete", "compact", or "compact_delete".
 * `compression_type` - (Optional) The topic compression codecs used for a given topic.
   This may be one of "uncompressed", "gzip", "snappy", "lz4", "producer", "zstd". "uncompressed" indicates that there is no compression and "producer" retains the original compression codec set by the producer.

--- a/docs/resources/droplet.md
+++ b/docs/resources/droplet.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 * `image` - (Required) The Droplet image ID or slug. This could be either image ID or droplet snapshot ID.
 * `name` - (Required) The Droplet name.
 * `region` - The region where the Droplet will be created.
-* `size` - (Required) The unique slug that indentifies the type of Droplet. You can find a list of available slugs on [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#tag/Sizes).
+* `size` - (Required) The unique slug that identifies the type of Droplet. You can find a list of available slugs on [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#tag/Sizes).
 * `backups` - (Optional) Boolean controlling if backups are made. Defaults to
    false.
 * `monitoring` - (Optional) Boolean controlling whether monitoring agent is installed.

--- a/docs/resources/uptime_check.md
+++ b/docs/resources/uptime_check.md
@@ -11,7 +11,7 @@ resource. Uptime Checks provide the ability to monitor your endpoints from aroun
 ### Basic Example
 
 ```hcl
-# Create a new check for the target endpoint in a specifc region
+# Create a new check for the target endpoint in a specific region
 resource "digitalocean_uptime_check" "foobar" {
   name    = "example-europe-check"
   target  = "https://www.example.com"

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `name` - (Required) A name for the block storage volume. Must be lowercase and be composed only of numbers, letters and "-", up to a limit of 64 characters. The name must begin with a letter.
 * `size` - (Required) The size of the block storage volume in GiB. If updated, can only be expanded.
 * `description` - (Optional) A free-form text field up to a limit of 1024 bytes to describe a block storage volume.
-* `snapshot_id` - (Optional) The ID of an existing volume snapshot from which the new volume will be created. If supplied, the region and size will be limitied on creation to that of the referenced snapshot
+* `snapshot_id` - (Optional) The ID of an existing volume snapshot from which the new volume will be created. If supplied, the region and size will be limited on creation to that of the referenced snapshot
 * `initial_filesystem_type` - (Optional) Initial filesystem type (`xfs` or `ext4`) for the block storage volume.
 * `initial_filesystem_label` - (Optional) Initial filesystem label for the block storage volume.
 * `tags` - (Optional) A list of the tags to be applied to this Volume.

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -23,7 +23,7 @@ resource "digitalocean_vpc_peering" "example" {
 }
 ```
 
-### Resource Assignement
+### Resource Assignment
 
 You can use the VPC Peering resource to allow communication between resources
 in different VPCs. For example:

--- a/internal/mutexkv/mutexkv.go
+++ b/internal/mutexkv/mutexkv.go
@@ -45,7 +45,7 @@ func (m *MutexKV) get(key string) *sync.Mutex {
 	return mutex
 }
 
-// Returns a properly initalized MutexKV
+// Returns a properly initialized MutexKV
 func NewMutexKV() *MutexKV {
 	return &MutexKV{
 		store: make(map[string]*sync.Mutex),


### PR DESCRIPTION
At time of writing
```
cat _typos.toml
[files]
extend-exclude = [
  "go.mod",
  "vendor/*",
]

[default.extend-identifiers]
"reservedIPURNtoFloatingIPURN" = "reservedIPURNtoFloatingIPURN"

[default]
extend-ignore-re = [
  "(?Rms)\\s*-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----\\s*",
  "(?Rms)\\s*-----BEGIN PRIVATE KEY-----(.*)-----END PRIVATE KEY-----\\s*",
]
```