### PR TITLE
Fix Postgres Config TimescaleDB configuration

### DIFF
--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -381,9 +381,11 @@ func ResourceDigitalOceanDatabasePostgreSQLConfig() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
+				MinItems: 1,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"timescaledb": {
+						"max_background_workers": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						}},

--- a/digitalocean/database/resource_database_postgres_config_test.go
+++ b/digitalocean/database/resource_database_postgres_config_test.go
@@ -48,4 +48,7 @@ resource "digitalocean_database_postgresql_config" "foobar" {
   shared_buffers_percentage = %f
   work_mem                  = %d
   jit                       = %t
+  timescaledb {
+    max_background_workers = 1
+  }
 }`


### PR DESCRIPTION
Fix Postgres Config TimescaleDB configuration. Until now it expect a list of objects but the godo library expect it as a single object. Also, the fixing the attribute key for TimescaleDB configuration.

I'm not sure if I implemented this correct, since I'm not really sure how to test this.