### PR TITLE
Added support for opensearch configuration on log_destination block

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1392,8 +1392,8 @@ func expandAppOpensearchBasicAuth(config []interface{}) *godo.OpenSearchBasicAut
 	basicAuthConfig := config[0].(map[string]interface{})
 
 	basicAuth := &godo.OpenSearchBasicAuth{
-		User:     string(basicAuthConfig["user"].(string)),
-		Password: string(basicAuthConfig["password"].(string)),
+		User:     basicAuthConfig["user"].(string),
+		Password: basicAuthConfig["password"].(string),
 	}
 
 	return basicAuth

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1292,32 +1292,11 @@ func expandAppLogDestinations(config []interface{}) []*godo.AppLogDestinationSpe
 		open_search := destination["open_search"].([]interface{})
 		if len(open_search) > 0 {
 			openSearchConfig := open_search[0].(map[string]interface{})
-			if openSearchConfig["endpoint"] != nil && openSearchConfig["cluster_name"] != nil {
-				panic("cluster_name is not allowed when endpoint is set")
-			}
-
-			if openSearchConfig["endpoint"] != nil {
-				d.OpenSearch = &godo.AppLogDestinationSpecOpenSearch{
-					Endpoint: (openSearchConfig["endpoint"].(string)),
-					BasicAuth: &godo.OpenSearchBasicAuth{
-						User:     (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["user"].(string)),
-						Password: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["password"].(string)),
-					},
-					IndexName: (openSearchConfig["index_name"].(string)),
-				}
-			}
-
-			if openSearchConfig["cluster_name"] != nil {
-				if openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["password"] != nil {
-					panic("password is not allowed when cluster_name is set")
-				}
-				d.OpenSearch = &godo.AppLogDestinationSpecOpenSearch{
-					BasicAuth: &godo.OpenSearchBasicAuth{
-						User: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["user"].(string)),
-					},
-					IndexName:   (openSearchConfig["index_name"].(string)),
-					ClusterName: (openSearchConfig["cluster_name"].(string)),
-				}
+			d.OpenSearch = &godo.AppLogDestinationSpecOpenSearch{
+				Endpoint:    (openSearchConfig["endpoint"].(string)),
+				BasicAuth:   expandAppOpensearchBasicAuth(openSearchConfig["basic_auth"].([]interface{})),
+				IndexName:   (openSearchConfig["index_name"].(string)),
+				ClusterName: (openSearchConfig["cluster_name"].(string)),
 			}
 		}
 

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -901,7 +901,7 @@ func appSpecLogDestinations() *schema.Resource {
 									},
 									"password": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
 										Sensitive:   true,
 										Description: "Password for basic authentication.",
 									},
@@ -1308,10 +1308,12 @@ func expandAppLogDestinations(config []interface{}) []*godo.AppLogDestinationSpe
 			}
 
 			if openSearchConfig["cluster_name"] != nil {
+				if openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["password"] != nil {
+					panic("password is not allowed when cluster_name is set")
+				}
 				d.OpenSearch = &godo.AppLogDestinationSpecOpenSearch{
 					BasicAuth: &godo.OpenSearchBasicAuth{
-						User:     (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["user"].(string)),
-						Password: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["password"].(string)),
+						User: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["user"].(string)),
 					},
 					IndexName:   (openSearchConfig["index_name"].(string)),
 					ClusterName: (openSearchConfig["cluster_name"].(string)),
@@ -1402,6 +1404,9 @@ func flattenAppLogDestinations(destinations []*godo.AppLogDestinationSpec) []map
 			}
 
 			if d.OpenSearch.ClusterName != "" {
+				if d.OpenSearch.BasicAuth.Password != "" {
+					panic("password is not allowed when cluster_name is set")
+				}
 				openSearch[0] = map[string]interface{}{
 					"cluster_name": d.OpenSearch.ClusterName,
 					"index_name":   d.OpenSearch.IndexName,

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1388,6 +1388,17 @@ func flattenAppLogDestinations(destinations []*godo.AppLogDestinationSpec) []map
 	return result
 }
 
+func expandAppOpensearchBasicAuth(config []interface{}) *godo.OpenSearchBasicAuth {
+	basicAuthConfig := config[0].(map[string]interface{})
+
+	basicAuth := &godo.OpenSearchBasicAuth{
+		User:     string(basicAuthConfig["user"].(string)),
+		Password: string(basicAuthConfig["password"].(string)),
+	}
+
+	return basicAuth
+}
+
 func expandAppAutoscaling(config []interface{}) *godo.AppAutoscalingSpec {
 	autoscalingConfig := config[0].(map[string]interface{})
 

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1289,7 +1289,7 @@ func expandAppLogDestinations(config []interface{}) []*godo.AppLogDestinationSpe
 			Name: (destination["name"].(string)),
 		}
 
-		open_search := destination["opensearch"].([]interface{})
+		open_search := destination["open_search"].([]interface{})
 		if len(open_search) > 0 {
 			openSearchConfig := open_search[0].(map[string]interface{})
 			if openSearchConfig["endpoint"] != nil && openSearchConfig["cluster_name"] != nil {

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1365,39 +1365,21 @@ func flattenAppLogDestinations(destinations []*godo.AppLogDestinationSpec) []map
 		}
 
 		if d.OpenSearch != nil {
-			if d.OpenSearch.Endpoint != "" && d.OpenSearch.ClusterName != "" {
-				panic("cluster_name is not allowed when endpoint is set")
-			}
 			openSearch := make([]interface{}, 1)
 
-			if d.OpenSearch.Endpoint != "" {
-				openSearch[0] = map[string]interface{}{
-					"endpoint":   d.OpenSearch.Endpoint,
-					"index_name": d.OpenSearch.IndexName,
-					"basic_auth": []interface{}{
-						map[string]string{
-							"user": d.OpenSearch.BasicAuth.User,
-						},
+			openSearch[0] = map[string]interface{}{
+				"endpoint":     d.OpenSearch.Endpoint,
+				"cluster_name": d.OpenSearch.ClusterName,
+				"index_name":   d.OpenSearch.IndexName,
+				"basic_auth": []interface{}{
+					map[string]string{
+						"user":     d.OpenSearch.BasicAuth.User,
+						"password": d.OpenSearch.BasicAuth.Password,
 					},
-				}
+				},
 			}
 
-			if d.OpenSearch.ClusterName != "" {
-				if d.OpenSearch.BasicAuth.Password != "" {
-					panic("password is not allowed when cluster_name is set")
-				}
-				openSearch[0] = map[string]interface{}{
-					"cluster_name": d.OpenSearch.ClusterName,
-					"index_name":   d.OpenSearch.IndexName,
-					"basic_auth": []interface{}{
-						map[string]string{
-							"user": d.OpenSearch.BasicAuth.User,
-						},
-					},
-				}
-			}
-
-			r["opensearch"] = openSearch
+			r["open_search"] = openSearch
 		}
 
 		result[i] = r

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -896,7 +896,7 @@ func appSpecLogDestinations() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"user": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
 										Description: "user for basic authentication.",
 									},
 									"password": {

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -884,7 +883,7 @@ func appSpecLogDestinations() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"endpoint": {
 							Type:        schema.TypeString,
-							Required:    false,
+							Optional:    true,
 							Description: "OpenSearch endpoint.",
 						},
 						"basic_auth": {
@@ -910,12 +909,12 @@ func appSpecLogDestinations() *schema.Resource {
 						},
 						"index_name": {
 							Type:        schema.TypeString,
-							Required:    false,
+							Optional:    true,
 							Description: "OpenSearch index name.",
 						},
 						"cluster_name": {
 							Type:        schema.TypeString,
-							Required:    false,
+							Optional:    true,
 							Description: "OpenSearch cluster name.",
 						},
 					},
@@ -1300,7 +1299,7 @@ func expandAppLogDestinations(config []interface{}) []*godo.AppLogDestinationSpe
 				d.OpenSearch = &godo.AppLogDestinationSpecOpenSearch{
 					Endpoint: (openSearchConfig["endpoint"].(string)),
 					BasicAuth: &godo.OpenSearchBasicAuth{
-						Username: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["username"].(string)),
+						User:     (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["user"].(string)),
 						Password: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["password"].(string)),
 					},
 					IndexName: (openSearchConfig["index_name"].(string)),
@@ -1310,7 +1309,7 @@ func expandAppLogDestinations(config []interface{}) []*godo.AppLogDestinationSpe
 			if openSearchConfig["cluster_name"] != nil {
 				d.OpenSearch = &godo.AppLogDestinationSpecOpenSearch{
 					BasicAuth: &godo.OpenSearchBasicAuth{
-						Username: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["username"].(string)),
+						User:     (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["user"].(string)),
 						Password: (openSearchConfig["basic_auth"].([]interface{})[0].(map[string]interface{})["password"].(string)),
 					},
 					IndexName:   (openSearchConfig["index_name"].(string)),
@@ -1395,7 +1394,7 @@ func flattenAppLogDestinations(destinations []*godo.AppLogDestinationSpec) []map
 					"index_name": d.OpenSearch.IndexName,
 					"basic_auth": []interface{}{
 						map[string]string{
-							"user": d.OpenSearch.BasicAuth.user,
+							"user": d.OpenSearch.BasicAuth.User,
 						},
 					},
 				}
@@ -1407,7 +1406,7 @@ func flattenAppLogDestinations(destinations []*godo.AppLogDestinationSpec) []map
 					"index_name":   d.OpenSearch.IndexName,
 					"basic_auth": []interface{}{
 						map[string]string{
-							"user": d.OpenSearch.BasicAuth.user,
+							"user": d.OpenSearch.BasicAuth.User,
 						},
 					},
 				}

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1,11 +1,12 @@
 package app
 
 import (
+	"log"
+	"net/http"
+
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
-	"net/http"
 )
 
 type appSpecComponentType string

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -247,6 +247,11 @@ A `function` component can contain:
     - `api_key` - Datadog API key.
   - `logtail` - Logtail configuration.
     - `token` - Logtail token.
+  - `opensearch` - OpenSearch configuration
+    - `endpoint` - OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. 
+    - `basic_auth` - OpenSearch basic auth
+    - `index_name` - The index name to use for the logs. If not set, the default index name is \"logs\".
+
 
 A `database` can contain:
 

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -250,6 +250,8 @@ A `function` component can contain:
   - `opensearch` - OpenSearch configuration
     - `endpoint` - OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. 
     - `basic_auth` - OpenSearch basic auth
+        - `user` - Username to authenticate with. Only required when endpoint is set. Defaults to doadmin when cluster_name is set.
+        - `password` - Password for user defined in User. Is required when endpoint is set. Cannot be set if using a DigitalOcean DBaaS OpenSearch cluster.
     - `index_name` - The index name to use for the logs. If not set, the default index name is \"logs\".
     -`cluster_name` - The name of a DigitalOcean DBaaS OpenSearch cluster to use as a log forwarding destination. Cannot be specified if endpoint is also specified.
 

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -251,6 +251,7 @@ A `function` component can contain:
     - `endpoint` - OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. 
     - `basic_auth` - OpenSearch basic auth
     - `index_name` - The index name to use for the logs. If not set, the default index name is \"logs\".
+    -`cluster_name` - The name of a DigitalOcean DBaaS OpenSearch cluster to use as a log forwarding destination. Cannot be specified if endpoint is also specified.
 
 
 A `database` can contain:

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -151,6 +151,39 @@ resource "digitalocean_app" "mono-repo-example" {
 }
 ```
 
+### Log Destination Example with Opensearch
+```
+resource "digitalocean_app" "golang-sample" {
+  spec {
+    name   = "golang-sample"
+    region = "ams"
+
+    service {
+      name               = "go-service"
+      environment_slug   = "go"
+      instance_count     = 1
+      instance_size_slug = "professional-xs"
+
+      git {
+        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+        branch         = "main"
+      }
+
+      log_destination {
+        name = "MyLogs"
+        open_search {
+          endpoint = "https://something:1234"
+          basic_auth {
+            user = "user"
+            password = "hi"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -454,6 +454,11 @@ A `function` component can contain:
     - `api_key` - Datadog API key.
   - `logtail` - Logtail configuration.
     - `token` - Logtail token.
+  - `opensearch` - OpenSearch configuration
+    - `endpoint` - OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. 
+    - `basic_auth` - OpenSearch basic auth
+    - `index_name` - The index name to use for the logs. If not set, the default index name is \"logs\".
+
 
 A `database` can contain:
 

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -458,6 +458,7 @@ A `function` component can contain:
     - `endpoint` - OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. 
     - `basic_auth` - OpenSearch basic auth
     - `index_name` - The index name to use for the logs. If not set, the default index name is \"logs\".
+    -`cluster_name` - The name of a DigitalOcean DBaaS OpenSearch cluster to use as a log forwarding destination. Cannot be specified if endpoint is also specified.
 
 
 A `database` can contain:

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -457,6 +457,8 @@ A `function` component can contain:
   - `opensearch` - OpenSearch configuration
     - `endpoint` - OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. 
     - `basic_auth` - OpenSearch basic auth
+        - `user` - Username to authenticate with. Only required when endpoint is set. Defaults to doadmin when cluster_name is set.
+        - `password` - Password for user defined in User. Is required when endpoint is set. Cannot be set if using a DigitalOcean DBaaS OpenSearch cluster.
     - `index_name` - The index name to use for the logs. If not set, the default index name is \"logs\".
     -`cluster_name` - The name of a DigitalOcean DBaaS OpenSearch cluster to use as a log forwarding destination. Cannot be specified if endpoint is also specified.
 


### PR DESCRIPTION
WIth this PR we would like to add support for OpenShift using the **log_destination** block. 
based on the spec of digital ocean we should have something like this:
```
log_destination: 
  -name: app-staging-opensearch
  open_search:
   basic_auth:
          user: username
   cluster_name: cluster_name
   ndex_name: logs
 ```
 
 In the specification created setting the forward from digital ocean from the UI there is no field for `password` in the `basic_auth` and im not sure if i have to include it or not 