### PR TITLE
dbaas: Use standardized name prefix in tests.

### DIFF
--- a/digitalocean/database/datasource_database_cluster_test.go
+++ b/digitalocean/database/datasource_database_cluster_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 	var database godo.Database
-	databaseName := fmt.Sprintf("foobar-test-terraform-%s", acctest.RandString(10))
+	databaseName := acceptance.RandomTestName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },


### PR DESCRIPTION
Logging into our acceptance test account showed that we had a handful of old test databases laying around from failed tests. The account sweeper failed to delete them since they were not using the standardized name prefix for acceptance tests:

https://github.com/digitalocean/terraform-provider-digitalocean/blob/78596c3e994acc58d452635ef0cdf5f1d47b75cc/digitalocean/database/sweep.go#L37

I've cleaned them up manually, but this should prevent more stranded resources in the future. 