### PR TITLE
apps: update examples to remove environment_slug

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -20,7 +20,6 @@ resource "digitalocean_app" "golang-sample" {
 
     service {
       name               = "go-service"
-      environment_slug   = "go"
       instance_count     = 1
       instance_size_slug = "professional-xs"
 
@@ -73,8 +72,7 @@ resource "digitalocean_app" "mono-repo-example" {
     # Build a Go project in the api/ directory that listens on port 3000
     # and serves it at https://foo.example.com/api
     service {
-      name               = "api"
-      environment_slug   = "go"
+      name               = "go-api"
       instance_count     = 2
       instance_size_slug = "professional-xs"
 
@@ -160,7 +158,6 @@ resource "digitalocean_app" "golang-sample" {
 
     service {
       name               = "go-service"
-      environment_slug   = "go"
       instance_count     = 1
       instance_size_slug = "professional-xs"
 

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -21,7 +21,7 @@ resource "digitalocean_app" "golang-sample" {
     service {
       name               = "go-service"
       instance_count     = 1
-      instance_size_slug = "professional-xs"
+      instance_size_slug = "apps-s-1vcpu-1gb"
 
       git {
         repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
@@ -74,7 +74,7 @@ resource "digitalocean_app" "mono-repo-example" {
     service {
       name               = "go-api"
       instance_count     = 2
-      instance_size_slug = "professional-xs"
+      instance_size_slug = "apps-s-1vcpu-1gb"
 
       github {
         branch         = "main"
@@ -159,7 +159,7 @@ resource "digitalocean_app" "golang-sample" {
     service {
       name               = "go-service"
       instance_count     = 1
-      instance_size_slug = "professional-xs"
+      instance_size_slug = "apps-s-1vcpu-1gb"
 
       git {
         repo_clone_url = "https://github.com/digitalocean/sample-golang.git"


### PR DESCRIPTION
We've seen a few questions about `environment_slug` recently. As it has no real effect anymore and will be deprecated at some point in the future, this removes it from the examples. While I'm in here, I also updated the example `instance_size_slug` to use the new style slugs.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1206