### PR TITLE
apps: expose live_domain computed attribute.

### DIFF
--- a/digitalocean/app/datasource_app.go
+++ b/digitalocean/app/datasource_app.go
@@ -64,6 +64,10 @@ func DataSourceDigitalOceanApp() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"live_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"active_deployment_id": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/digitalocean/app/resource_app.go
+++ b/digitalocean/app/resource_app.go
@@ -83,6 +83,11 @@ func ResourceDigitalOceanApp() *schema.Resource {
 				Computed: true,
 			},
 
+			"live_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			// TODO: The full Deployment should be a data source, not a resource
 			// specify the app id for the active deployment, include a deployment
 			// id for a specific one
@@ -161,6 +166,7 @@ func resourceDigitalOceanAppRead(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(app.ID)
 	d.Set("default_ingress", app.DefaultIngress)
 	d.Set("live_url", app.LiveURL)
+	d.Set("live_domain", app.LiveDomain)
 	d.Set("updated_at", app.UpdatedAt.UTC().String())
 	d.Set("created_at", app.CreatedAt.UTC().String())
 	d.Set("urn", app.URN())

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -27,6 +27,8 @@ func TestAccDigitalOceanApp_Image(t *testing.T) {
 				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_addImage, appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_url"),
+					resource.TestCheckResourceAttrSet("digitalocean_app.foobar", "live_domain"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.image.0.registry_type", "DOCKER_HUB"),
 					resource.TestCheckResourceAttr(

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -34,6 +34,7 @@ The following attributes are exported:
   - `id` - The ID of the dedicated egress IP.
   - `status` - The status of the dedicated egress IP.
 * `live_url` - The live URL of the app.
+* `live_domain` - The live domain of the app.
 * `active_deployment_id` - The ID the app's currently active deployment.
 * `urn` - The uniform resource identifier for the app.
 * `updated_at` - The date and time of when the app was last updated.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -515,6 +515,7 @@ In addition to the above attributes, the following are exported:
 - `id` - The ID of the app.
 - `default_ingress` - The default URL to access the app.
 - `live_url` - The live URL of the app.
+- `live_domain` - The live domain of the app.
 - `active_deployment_id` - The ID the app's currently active deployment.
 - `urn` - The uniform resource identifier for the app.
 - `updated_at` - The date and time of when the app was last updated.


### PR DESCRIPTION
The API exposes a `live_domain` attribute. We should support it in Terraform.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1207