### PR TITLE
Update Terraform provider to include new opensearch acl changes

### DIFF
--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -260,6 +260,69 @@ func TestAccDigitalOceanDatabaseUser_KafkaACLs(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseUser_OpenSearchACLs(t *testing.T) {
+	var databaseUser godo.DatabaseUser
+	databaseClusterName := acceptance.RandomTestName()
+	databaseUserName := acceptance.RandomTestName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseUserConfigOpenSearchACL, databaseClusterName, databaseUserName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseUserExists("digitalocean_database_user.foobar_user", &databaseUser),
+					testAccCheckDigitalOceanDatabaseUserAttributes(&databaseUser, databaseUserName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "name", databaseUserName),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "role"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "password"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.0.index", "index-1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.0.permission", "admin"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.1.index", "topic-2"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.1.permission", "readwrite"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.2.index", "index-*"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.2.permission", "write"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.3.index", "index-*"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.3.permission", "read"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.4.index", "index-*"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.4.permission", "deny"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseUserConfigOpenSearchACLUpdate, databaseClusterName, databaseUserName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseUserExists("digitalocean_database_user.foobar_user", &databaseUser),
+					testAccCheckDigitalOceanDatabaseUserAttributes(&databaseUser, databaseUserName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "name", databaseUserName),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "role"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "password"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.0.index", "index-1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.0.permission", "readwrite"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanDatabaseUserDestroy(s *terraform.State) error {
 	client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
 
@@ -494,6 +557,64 @@ resource "digitalocean_database_user" "foobar_user" {
     acl {
       topic      = "topic-1"
       permission = "produceconsume"
+    }
+  }
+}`
+
+const testAccCheckDigitalOceanDatabaseUserConfigOpenSearchACL = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "openserach"
+  version    = "2"
+  size       = "db-s-2vcpu-2gb"
+  region     = "nyc1"
+  node_count = 3
+}
+
+resource "digitalocean_database_user" "foobar_user" {
+  cluster_id = digitalocean_database_cluster.foobar.id
+  name       = "%s"
+  settings {
+    opensearch_acl {
+      index      = "index-1"
+      permission = "admin"
+    }
+    opensearch_acl {
+      index      = "index-2"
+      permission = "readwrite"
+    }
+    opensearch_acl {
+      index      = "index-*"
+      permission = "write"
+    }
+    opensearch_acl {
+      index      = "index-*"
+      permission = "read"
+    }
+	opensearch_acl {
+      index      = "index-*"
+      permission = "deny"
+    }
+  }
+}`
+
+const testAccCheckDigitalOceanDatabaseUserConfigOpenSearchACLUpdate = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "opensearch"
+  version    = "2"
+  size       = "db-s-2vcpu-2gb"
+  region     = "nyc1"
+  node_count = 3
+}
+
+resource "digitalocean_database_user" "foobar_user" {
+  cluster_id = digitalocean_database_cluster.foobar.id
+  name       = "%s"
+  settings {
+    opensearch_acl {
+      index      = "index-1"
+      permission = "readwrite"
     }
   }
 }`

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -296,10 +296,6 @@ func TestAccDigitalOceanDatabaseUser_OpenSearchACLs(t *testing.T) {
 						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.3.index", "index-*"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.3.permission", "read"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.4.index", "index-*"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.4.permission", "deny"),
 				),
 			},
 			{
@@ -590,10 +586,6 @@ resource "digitalocean_database_user" "foobar_user" {
     opensearch_acl {
       index      = "index-*"
       permission = "read"
-    }
-	opensearch_acl {
-      index      = "index-*"
-      permission = "deny"
     }
   }
 }`

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -560,7 +560,7 @@ resource "digitalocean_database_user" "foobar_user" {
 const testAccCheckDigitalOceanDatabaseUserConfigOpenSearchACL = `
 resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
-  engine     = "openserach"
+  engine     = "opensearch"
   version    = "2"
   size       = "db-s-2vcpu-2gb"
   region     = "nyc1"

--- a/digitalocean/database/resource_database_user_test.go
+++ b/digitalocean/database/resource_database_user_test.go
@@ -285,7 +285,7 @@ func TestAccDigitalOceanDatabaseUser_OpenSearchACLs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.0.permission", "admin"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.1.index", "topic-2"),
+						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.1.index", "index-2"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_user.foobar_user", "settings.0.opensearch_acl.1.permission", "readwrite"),
 					resource.TestCheckResourceAttr(
@@ -562,7 +562,7 @@ resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "opensearch"
   version    = "2"
-  size       = "db-s-2vcpu-2gb"
+  size       = "db-s-2vcpu-4gb"
   region     = "nyc1"
   node_count = 3
 }
@@ -595,7 +595,7 @@ resource "digitalocean_database_cluster" "foobar" {
   name       = "%s"
   engine     = "opensearch"
   version    = "2"
-  size       = "db-s-2vcpu-2gb"
+  size       = "db-s-2vcpu-4gb"
   region     = "nyc1"
   node_count = 3
 }


### PR DESCRIPTION
This PR aims at adding support for opensearch acl changes to DO's Terraform Provider.

##### Testing instructions(for future references):
```
make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseUser_OpenSearchACLs'

```