### PR TITLE
[databases]: add support for Kafka advanced configuration

### DIFF
--- a/digitalocean/database/resource_database_kafka_config.go
+++ b/digitalocean/database/resource_database_kafka_config.go
@@ -1,0 +1,294 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceDigitalOceanDatabaseKafkaConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDigitalOceanDatabaseKafkaConfigCreate,
+		ReadContext:   resourceDigitalOceanDatabaseKafkaConfigRead,
+		UpdateContext: resourceDigitalOceanDatabaseKafkaConfigUpdate,
+		DeleteContext: resourceDigitalOceanDatabaseKafkaConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDigitalOceanDatabaseKafkaConfigImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"group_initial_rebalance_delay_ms": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"group_min_session_timeout_ms": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"group_max_session_timeout_ms": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"message_max_bytes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"log_cleaner_delete_retention_ms": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"log_cleaner_min_compaction_lag_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"log_flush_interval_ms": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// ValidateFunc: validation.IntAtLeast(0),
+			},
+			"log_index_interval_bytes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"log_message_downconversion_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"log_message_timestamp_difference_max_ms": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// ValidateFunc: validation.IntAtLeast(0),
+			},
+			"log_preallocate": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"log_retention_bytes": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
+			"log_retention_hours": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"log_retention_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
+			"log_roll_jitter_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"log_segment_delete_delay_ms": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"auto_create_topics_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanDatabaseKafkaConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	if err := updateKafkaConfig(ctx, d, client); err != nil {
+		return diag.Errorf("Error updating Kafka configuration: %s", err)
+	}
+
+	d.SetId(makeDatabaseKafkaConfigID(clusterID))
+
+	return resourceDigitalOceanDatabaseKafkaConfigRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanDatabaseKafkaConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	if err := updateKafkaConfig(ctx, d, client); err != nil {
+		return diag.Errorf("Error updating Kafka configuration: %s", err)
+	}
+
+	return resourceDigitalOceanDatabaseKafkaConfigRead(ctx, d, meta)
+}
+
+func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo.Client) error {
+	clusterID := d.Get("cluster_id").(string)
+
+	opts := &godo.KafkaConfig{}
+
+	if v, ok := d.GetOk("group_initial_rebalance_delay_ms"); ok {
+		opts.GroupInitialRebalanceDelayMs = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("group_min_session_timeout_ms"); ok {
+		opts.GroupMinSessionTimeoutMs = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("group_max_session_timeout_ms"); ok {
+		opts.GroupMaxSessionTimeoutMs = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("message_max_bytes"); ok {
+		opts.MessageMaxBytes = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("log_cleaner_delete_retention_ms"); ok {
+		opts.LogCleanerDeleteRetentionMs = godo.PtrTo(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("log_cleaner_min_compaction_lag_ms"); ok {
+		opts.LogCleanerMinCompactionLagMs = godo.PtrTo(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("log_flush_interval_ms"); ok {
+		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
+		opts.LogFlushIntervalMs = godo.PtrTo(uintVal)
+	}
+
+	if v, ok := d.GetOk("log_index_interval_bytes"); ok {
+		opts.LogIndexIntervalBytes = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("log_message_downconversion_enable"); ok {
+		opts.LogMessageDownconversionEnable = godo.PtrTo(v.(bool))
+	}
+
+	if v, ok := d.GetOk("log_message_timestamp_difference_max_ms"); ok {
+		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
+		opts.LogMessageTimestampDifferenceMaxMs = godo.PtrTo(uintVal)
+	}
+
+	if v, ok := d.GetOk("log_preallocate"); ok {
+		opts.LogPreallocate = godo.PtrTo(v.(bool))
+	}
+
+	if v, ok := d.GetOk("log_retention_bytes"); ok {
+		opts.LogRetentionBytes = godo.PtrTo(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("log_retention_hours"); ok {
+		opts.LogRetentionHours = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("log_retention_ms"); ok {
+		opts.LogRetentionMs = godo.PtrTo(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("log_roll_jitter_ms"); ok {
+		opts.LogRollJitterMs = godo.PtrTo(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("log_segment_delete_delay_ms"); ok {
+		opts.LogSegmentDeleteDelayMs = godo.PtrTo(v.(int))
+	}
+
+	if v, ok := d.GetOk("auto_create_topics_enable"); ok {
+		opts.AutoCreateTopicsEnable = godo.PtrTo(v.(bool))
+	}
+
+	log.Printf("[DEBUG] Kafka configuration: %s", godo.Stringify(opts))
+
+	if _, err := client.Databases.UpdateKafkaConfig(ctx, clusterID, opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseKafkaConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	config, resp, err := client.Databases.GetKafkaConfig(ctx, clusterID)
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error retrieving Kafka configuration: %s", err)
+	}
+
+	d.Set("group_initial_rebalance_delay_ms", config.GroupInitialRebalanceDelayMs)
+	d.Set("group_min_session_timeout_ms", config.GroupMinSessionTimeoutMs)
+	d.Set("group_max_session_timeout_ms", config.GroupMaxSessionTimeoutMs)
+	d.Set("message_max_bytes", config.MessageMaxBytes)
+	d.Set("log_cleaner_delete_retention_ms", config.LogCleanerDeleteRetentionMs)
+	d.Set("log_cleaner_min_compaction_lag_ms", config.LogCleanerMinCompactionLagMs)
+	d.Set("log_flush_interval_ms", config.LogFlushIntervalMs)
+	d.Set("log_index_interval_bytes", config.LogIndexIntervalBytes)
+	d.Set("log_message_downconversion_enable", config.LogMessageDownconversionEnable)
+	d.Set("log_message_timestamp_difference_max_ms", config.LogMessageTimestampDifferenceMaxMs)
+	d.Set("log_preallocate", config.LogPreallocate)
+	d.Set("log_retention_bytes", config.LogRetentionBytes)
+	d.Set("log_retention_hours", config.LogRetentionHours)
+	d.Set("log_retention_ms", config.LogRetentionMs)
+	d.Set("log_roll_jitter_ms", config.LogRollJitterMs)
+	d.Set("log_segment_delete_delay_ms", config.LogSegmentDeleteDelayMs)
+	d.Set("auto_create_topics_enable", config.AutoCreateTopicsEnable)
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseKafkaConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+
+	warn := []diag.Diagnostic{
+		{
+			Severity: diag.Warning,
+			Summary:  "digitalocean_database_kafka_config removed from state",
+			Detail:   "Database configurations are only removed from state when destroyed. The remote configuration is not unset.",
+		},
+	}
+
+	return warn
+}
+
+func resourceDigitalOceanDatabaseKafkaConfigImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	clusterID := d.Id()
+
+	d.SetId(makeDatabaseKafkaConfigID(clusterID))
+	d.Set("cluster_id", clusterID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func makeDatabaseKafkaConfigID(clusterID string) string {
+	return fmt.Sprintf("%s/kafka-config", clusterID)
+}

--- a/digitalocean/database/resource_database_kafka_config.go
+++ b/digitalocean/database/resource_database_kafka_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/big"
 	"strconv"
 
 	"github.com/digitalocean/godo"
@@ -55,16 +56,14 @@ func ResourceDigitalOceanDatabaseKafkaConfig() *schema.Resource {
 				Computed: true,
 			},
 			"log_cleaner_min_compaction_lag_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(0),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"log_flush_interval_ms": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				// ValidateFunc: validation.IntAtLeast(0),
 			},
 			"log_index_interval_bytes": {
 				Type:     schema.TypeInt,
@@ -80,7 +79,6 @@ func ResourceDigitalOceanDatabaseKafkaConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				// ValidateFunc: validation.IntAtLeast(0),
 			},
 			"log_preallocate": {
 				Type:     schema.TypeBool,
@@ -88,10 +86,9 @@ func ResourceDigitalOceanDatabaseKafkaConfig() *schema.Resource {
 				Computed: true,
 			},
 			"log_retention_bytes": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(-1),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"log_retention_hours": {
 				Type:     schema.TypeInt,
@@ -99,16 +96,14 @@ func ResourceDigitalOceanDatabaseKafkaConfig() *schema.Resource {
 				Computed: true,
 			},
 			"log_retention_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(-1),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"log_roll_jitter_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(0),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"log_segment_delete_delay_ms": {
 				Type:     schema.TypeInt,
@@ -173,7 +168,8 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_cleaner_min_compaction_lag_ms"); ok {
-		opts.LogCleanerMinCompactionLagMs = godo.PtrTo(int64(v.(int)))
+		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
+		opts.LogCleanerMinCompactionLagMs = godo.PtrTo(uintVal)
 	}
 
 	if v, ok := d.GetOk("log_flush_interval_ms"); ok {
@@ -199,7 +195,8 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_retention_bytes"); ok {
-		opts.LogRetentionBytes = godo.PtrTo(int64(v.(int)))
+		bigInt, _ := new(big.Int).SetString(v.(string), 10)
+		opts.LogRetentionBytes = bigInt
 	}
 
 	if v, ok := d.GetOk("log_retention_hours"); ok {
@@ -207,11 +204,13 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_retention_ms"); ok {
-		opts.LogRetentionMs = godo.PtrTo(int64(v.(int)))
+		bigInt, _ := new(big.Int).SetString(v.(string), 10)
+		opts.LogRetentionMs = bigInt
 	}
 
 	if v, ok := d.GetOk("log_roll_jitter_ms"); ok {
-		opts.LogRollJitterMs = godo.PtrTo(int64(v.(int)))
+		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
+		opts.LogRollJitterMs = godo.PtrTo(uintVal)
 	}
 
 	if v, ok := d.GetOk("log_segment_delete_delay_ms"); ok {

--- a/digitalocean/database/resource_database_kafka_config.go
+++ b/digitalocean/database/resource_database_kafka_config.go
@@ -168,13 +168,17 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_cleaner_min_compaction_lag_ms"); ok {
-		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
-		opts.LogCleanerMinCompactionLagMs = godo.PtrTo(uintVal)
+		v, err := strconv.ParseUint(v.(string), 10, 64)
+		if err == nil {
+			opts.LogCleanerMinCompactionLagMs = godo.PtrTo(v)
+		}
 	}
 
 	if v, ok := d.GetOk("log_flush_interval_ms"); ok {
-		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
-		opts.LogFlushIntervalMs = godo.PtrTo(uintVal)
+		v, err := strconv.ParseUint(v.(string), 10, 64)
+		if err == nil {
+			opts.LogFlushIntervalMs = godo.PtrTo(v)
+		}
 	}
 
 	if v, ok := d.GetOk("log_index_interval_bytes"); ok {
@@ -186,8 +190,10 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_message_timestamp_difference_max_ms"); ok {
-		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
-		opts.LogMessageTimestampDifferenceMaxMs = godo.PtrTo(uintVal)
+		v, err := strconv.ParseUint(v.(string), 10, 64)
+		if err == nil {
+			opts.LogMessageTimestampDifferenceMaxMs = godo.PtrTo(v)
+		}
 	}
 
 	if v, ok := d.GetOk("log_preallocate"); ok {
@@ -195,8 +201,9 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_retention_bytes"); ok {
-		bigInt, _ := new(big.Int).SetString(v.(string), 10)
-		opts.LogRetentionBytes = bigInt
+		if v, ok := new(big.Int).SetString(v.(string), 10); ok {
+			opts.LogRetentionBytes = v
+		}
 	}
 
 	if v, ok := d.GetOk("log_retention_hours"); ok {
@@ -204,13 +211,16 @@ func updateKafkaConfig(ctx context.Context, d *schema.ResourceData, client *godo
 	}
 
 	if v, ok := d.GetOk("log_retention_ms"); ok {
-		bigInt, _ := new(big.Int).SetString(v.(string), 10)
-		opts.LogRetentionMs = bigInt
+		if v, ok := new(big.Int).SetString(v.(string), 10); ok {
+			opts.LogRetentionMs = v
+		}
 	}
 
 	if v, ok := d.GetOk("log_roll_jitter_ms"); ok {
-		uintVal, _ := strconv.ParseUint(v.(string), 10, 64)
-		opts.LogRollJitterMs = godo.PtrTo(uintVal)
+		v, err := strconv.ParseUint(v.(string), 10, 64)
+		if err == nil {
+			opts.LogRollJitterMs = godo.PtrTo(v)
+		}
 	}
 
 	if v, ok := d.GetOk("log_segment_delete_delay_ms"); ok {

--- a/digitalocean/database/resource_database_kafka_config_test.go
+++ b/digitalocean/database/resource_database_kafka_config_test.go
@@ -41,8 +41,8 @@ const testAccCheckDigitalOceanDatabaseKafkaConfigConfigBasic = `
 %s
 
 resource "digitalocean_database_kafka_config" "foobar" {
-  cluster_id                         = digitalocean_database_cluster.foobar.id
-  group_initial_rebalance_delay_ms = %d
-  log_message_downconversion_enable" = %t
+  cluster_id                              = digitalocean_database_cluster.foobar.id
+  group_initial_rebalance_delay_ms        = %d
+  log_message_downconversion_enable       = %t
   log_message_timestamp_difference_max_ms = %s
 }`

--- a/digitalocean/database/resource_database_kafka_config_test.go
+++ b/digitalocean/database/resource_database_kafka_config_test.go
@@ -1,0 +1,48 @@
+package database_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDigitalOceanDatabaseKafkaConfig_Basic(t *testing.T) {
+	name := acceptance.RandomTestName()
+	dbConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterKafka, name, "3.7")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseKafkaConfigConfigBasic, dbConfig, 3000, true, "9223372036854776000"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_database_kafka_config.foobar", "group_initial_rebalance_delay_ms", "3000"),
+					resource.TestCheckResourceAttr("digitalocean_database_kafka_config.foobar", "log_message_downconversion_enable", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_kafka_config.foobar", "log_message_timestamp_difference_max_ms", "9223372036854776000"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseKafkaConfigConfigBasic, dbConfig, 300000, false, "0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_database_kafka_config.foobar", "group_initial_rebalance_delay_ms", "300000"),
+					resource.TestCheckResourceAttr("digitalocean_database_kafka_config.foobar", "log_message_downconversion_enable", "false"),
+					resource.TestCheckResourceAttr("digitalocean_database_kafka_config.foobar", "log_message_timestamp_difference_max_ms", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckDigitalOceanDatabaseKafkaConfigConfigBasic = `
+%s
+
+resource "digitalocean_database_kafka_config" "foobar" {
+  cluster_id                         = digitalocean_database_cluster.foobar.id
+  group_initial_rebalance_delay_ms = %d
+  log_message_downconversion_enable" = %t
+  log_message_timestamp_difference_max_ms = %s
+}`

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -153,6 +153,7 @@ func Provider() *schema.Provider {
 			"digitalocean_database_postgresql_config":            database.ResourceDigitalOceanDatabasePostgreSQLConfig(),
 			"digitalocean_database_mysql_config":                 database.ResourceDigitalOceanDatabaseMySQLConfig(),
 			"digitalocean_database_mongodb_config":               database.ResourceDigitalOceanDatabaseMongoDBConfig(),
+			"digitalocean_database_kafka_config":                 database.ResourceDigitalOceanDatabaseKafkaConfig(),
 			"digitalocean_database_kafka_topic":                  database.ResourceDigitalOceanDatabaseKafkaTopic(),
 			"digitalocean_domain":                                domain.ResourceDigitalOceanDomain(),
 			"digitalocean_droplet":                               droplet.ResourceDigitalOceanDroplet(),

--- a/docs/resources/database_kafka_config.md
+++ b/docs/resources/database_kafka_config.md
@@ -13,24 +13,24 @@ options for a DigitalOcean managed Kafka database cluster.
 
 ```hcl
 resource "digitalocean_database_kafka_config" "example" {
-  cluster_id                         = digitalocean_database_cluster.example.id
-  group_initial_rebalance_delay_ms = 3000
-  group_min_session_timeout_ms = 6000
-  group_max_session_timeout_ms = 1800000
-  message_max_bytes = 1048588
-  log_cleaner_delete_retention_ms = 86400000
-  log_cleaner_min_compaction_lag_ms = 0
-  log_flush_interval_ms = 9223372036854775807
-  log_index_interval_bytes = 4096
-  log_message_downconversion_enable = true
+  cluster_id                              = digitalocean_database_cluster.example.id
+  group_initial_rebalance_delay_ms        = 3000
+  group_min_session_timeout_ms            = 6000
+  group_max_session_timeout_ms            = 1800000
+  message_max_bytes                       = 1048588
+  log_cleaner_delete_retention_ms         = 86400000
+  log_cleaner_min_compaction_lag_ms       = 0
+  log_flush_interval_ms                   = 9223372036854775807
+  log_index_interval_bytes                = 4096
+  log_message_downconversion_enable       = true
   log_message_timestamp_difference_max_ms = 9223372036854775807
-  log_preallocate = false
-  log_retention_bytes = -1
-  log_retention_hours = 168
-  log_retention_ms = 604800000
-  log_roll_jitter_ms = 0
-  log_segment_delete_delay_ms = 60000
-  auto_create_topics_enable = true
+  log_preallocate                         = false
+  log_retention_bytes                     = -1
+  log_retention_hours                     = 168
+  log_retention_ms                        = 604800000
+  log_roll_jitter_ms                      = 0
+  log_segment_delete_delay_ms             = 60000
+  auto_create_topics_enable               = true
 }
 
 resource "digitalocean_database_cluster" "example" {

--- a/docs/resources/database_kafka_config.md
+++ b/docs/resources/database_kafka_config.md
@@ -1,0 +1,81 @@
+---
+page_title: "DigitalOcean: digitalocean_database_kafka_config"
+---
+
+# digitalocean\_database\_kafka\_config
+
+Provides a virtual resource that can be used to change advanced configuration
+options for a DigitalOcean managed Kafka database cluster.
+
+-> **Note** Kafka configurations are only removed from state when destroyed. The remote configuration is not unset.
+
+## Example Usage
+
+```hcl
+resource "digitalocean_database_kafka_config" "example" {
+  cluster_id                         = digitalocean_database_cluster.example.id
+  group_initial_rebalance_delay_ms = 3000
+  group_min_session_timeout_ms = 6000
+  group_max_session_timeout_ms = 1800000
+  message_max_bytes = 1048588
+  log_cleaner_delete_retention_ms = 86400000
+  log_cleaner_min_compaction_lag_ms = 0
+  log_flush_interval_ms = 9223372036854775807
+  log_index_interval_bytes = 4096
+  log_message_downconversion_enable = true
+  log_message_timestamp_difference_max_ms = 9223372036854775807
+  log_preallocate = false
+  log_retention_bytes = -1
+  log_retention_hours = 168
+  log_retention_ms = 604800000
+  log_roll_jitter_ms = 0
+  log_segment_delete_delay_ms = 60000
+  auto_create_topics_enable = true
+}
+
+resource "digitalocean_database_cluster" "example" {
+  name       = "example-kafka-cluster"
+  engine     = "kafka"
+  version    = "3.7"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc3"
+  node_count = 3
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+for additional details on each option.
+
+* `cluster_id` - (Required)  The ID of the target Kafka cluster.
+* `group_initial_rebalance_delay_ms` - (Optional) The amount of time, in milliseconds, the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins. The default value for this is 3 seconds. During development and testing it might be desirable to set this to 0 in order to not delay test execution time.
+* `group_min_session_timeout_ms` - (Optional) The minimum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
+* `group_max_session_timeout_ms` - (Optional) The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
+* `message_max_bytes` - (Optional) The maximum size of message that the server can receive.
+* `log_cleaner_delete_retention_ms` - (Optional) How long are delete records retained?
+* `log_cleaner_min_compaction_lag_ms` - (Optional) The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
+* `log_flush_interval_ms` - (Optional) The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used.
+* `log_index_interval_bytes` - (Optional) The interval with which Kafka adds an entry to the offset index.
+* `log_message_downconversion_enable` - (Optional) This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests.
+* `log_message_timestamp_difference_max_ms` - (Optional) The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message.
+* `log_preallocate` - (Optional) Controls whether to preallocate a file when creating a new segment.
+* `log_retention_bytes` - (Optional) The maximum size of the log before deleting messages.
+* `log_retention_hours` - (Optional) The number of hours to keep a log file before deleting it.
+* `log_retention_ms` - (Optional) The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used. If set to -1, no time limit is applied.
+* `log_roll_jitter_ms` - (Optional) The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used.
+* `log_segment_delete_delay_ms` - (Optional) The amount of time to wait before deleting a file from the filesystem.
+* `auto_create_topics_enable` - (Optional) Enable auto creation of topics.
+
+## Attributes Reference
+
+All above attributes are exported. If an attribute was set outside of Terraform, it will be computed.
+
+## Import
+
+A Kafka database cluster's configuration can be imported using the `id` the parent cluster, e.g.
+
+```
+terraform import digitalocean_database_kafka_config.example 4b62829a-9c42-465b-aaa3-84051048e712
+```

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e
+	github.com/digitalocean/godo v1.125.1-0.20240920194833-57fbfebd23d4
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.125.0
+	github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e h1:OLJvmWtP0YT3FE4+SIBOKrNMbLPB1EvumRiBqOwXzNQ=
-github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
+github.com/digitalocean/godo v1.125.1-0.20240920194833-57fbfebd23d4 h1:G/lf5YrNl4bDJyp3yJRld3J5BTFpQStYJHEnE6SxigY=
+github.com/digitalocean/godo v1.125.1-0.20240920194833-57fbfebd23d4/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.125.0 h1:wGPBQRX9Wjo0qCF0o8d25mT3A84Iw8rfHnZOPyvHcMQ=
-github.com/digitalocean/godo v1.125.0/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
+github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e h1:OLJvmWtP0YT3FE4+SIBOKrNMbLPB1EvumRiBqOwXzNQ=
+github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e/go.mod h1:PU8JB6I1XYkQIdHFop8lLAY9ojp6M0XcU0TWaQSxbrc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -3,6 +3,7 @@ package godo
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"net/http"
 	"strings"
 	"time"
@@ -663,23 +664,23 @@ type MongoDBConfig struct {
 
 // KafkaConfig holds advanced configurations for Kafka database clusters.
 type KafkaConfig struct {
-	GroupInitialRebalanceDelayMs       *int    `json:"group_initial_rebalance_delay_ms,omitempty"`
-	GroupMinSessionTimeoutMs           *int    `json:"group_min_session_timeout_ms,omitempty"`
-	GroupMaxSessionTimeoutMs           *int    `json:"group_max_session_timeout_ms,omitempty"`
-	MessageMaxBytes                    *int    `json:"message_max_bytes,omitempty"`
-	LogCleanerDeleteRetentionMs        *int64  `json:"log_cleaner_delete_retention_ms,omitempty"`
-	LogCleanerMinCompactionLagMs       *int64  `json:"log_cleaner_min_compaction_lag_ms,omitempty"`
-	LogFlushIntervalMs                 *uint64 `json:"log_flush_interval_ms,omitempty"`
-	LogIndexIntervalBytes              *int    `json:"log_index_interval_bytes,omitempty"`
-	LogMessageDownconversionEnable     *bool   `json:"log_message_downconversion_enable,omitempty"`
-	LogMessageTimestampDifferenceMaxMs *uint64 `json:"log_message_timestamp_difference_max_ms,omitempty"`
-	LogPreallocate                     *bool   `json:"log_preallocate,omitempty"`
-	LogRetentionBytes                  *int64  `json:"log_retention_bytes,omitempty"`
-	LogRetentionHours                  *int    `json:"log_retention_hours,omitempty"`
-	LogRetentionMs                     *int64  `json:"log_retention_ms,omitempty"`
-	LogRollJitterMs                    *int64  `json:"log_roll_jitter_ms,omitempty"`
-	LogSegmentDeleteDelayMs            *int    `json:"log_segment_delete_delay_ms,omitempty"`
-	AutoCreateTopicsEnable             *bool   `json:"auto_create_topics_enable,omitempty"`
+	GroupInitialRebalanceDelayMs       *int     `json:"group_initial_rebalance_delay_ms,omitempty"`
+	GroupMinSessionTimeoutMs           *int     `json:"group_min_session_timeout_ms,omitempty"`
+	GroupMaxSessionTimeoutMs           *int     `json:"group_max_session_timeout_ms,omitempty"`
+	MessageMaxBytes                    *int     `json:"message_max_bytes,omitempty"`
+	LogCleanerDeleteRetentionMs        *int64   `json:"log_cleaner_delete_retention_ms,omitempty"`
+	LogCleanerMinCompactionLagMs       *uint64  `json:"log_cleaner_min_compaction_lag_ms,omitempty"`
+	LogFlushIntervalMs                 *uint64  `json:"log_flush_interval_ms,omitempty"`
+	LogIndexIntervalBytes              *int     `json:"log_index_interval_bytes,omitempty"`
+	LogMessageDownconversionEnable     *bool    `json:"log_message_downconversion_enable,omitempty"`
+	LogMessageTimestampDifferenceMaxMs *uint64  `json:"log_message_timestamp_difference_max_ms,omitempty"`
+	LogPreallocate                     *bool    `json:"log_preallocate,omitempty"`
+	LogRetentionBytes                  *big.Int `json:"log_retention_bytes,omitempty"`
+	LogRetentionHours                  *int     `json:"log_retention_hours,omitempty"`
+	LogRetentionMs                     *big.Int `json:"log_retention_ms,omitempty"`
+	LogRollJitterMs                    *uint64  `json:"log_roll_jitter_ms,omitempty"`
+	LogSegmentDeleteDelayMs            *int     `json:"log_segment_delete_delay_ms,omitempty"`
+	AutoCreateTopicsEnable             *bool    `json:"auto_create_topics_enable,omitempty"`
 }
 
 type databaseUserRoot struct {

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -153,10 +153,12 @@ type DatabasesService interface {
 	GetRedisConfig(context.Context, string) (*RedisConfig, *Response, error)
 	GetMySQLConfig(context.Context, string) (*MySQLConfig, *Response, error)
 	GetMongoDBConfig(context.Context, string) (*MongoDBConfig, *Response, error)
+	GetKafkaConfig(context.Context, string) (*KafkaConfig, *Response, error)
 	UpdatePostgreSQLConfig(context.Context, string, *PostgreSQLConfig) (*Response, error)
 	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
 	UpdateMySQLConfig(context.Context, string, *MySQLConfig) (*Response, error)
 	UpdateMongoDBConfig(context.Context, string, *MongoDBConfig) (*Response, error)
+	UpdateKafkaConfig(context.Context, string, *KafkaConfig) (*Response, error)
 	ListOptions(todo context.Context) (*DatabaseOptions, *Response, error)
 	UpgradeMajorVersion(context.Context, string, *UpgradeVersionRequest) (*Response, error)
 	ListTopics(context.Context, string, *ListOptions) ([]DatabaseTopic, *Response, error)
@@ -659,6 +661,27 @@ type MongoDBConfig struct {
 	Verbosity                       *int    `json:"verbosity,omitempty"`
 }
 
+// KafkaConfig holds advanced configurations for Kafka database clusters.
+type KafkaConfig struct {
+	GroupInitialRebalanceDelayMs       *int    `json:"group_initial_rebalance_delay_ms,omitempty"`
+	GroupMinSessionTimeoutMs           *int    `json:"group_min_session_timeout_ms,omitempty"`
+	GroupMaxSessionTimeoutMs           *int    `json:"group_max_session_timeout_ms,omitempty"`
+	MessageMaxBytes                    *int    `json:"message_max_bytes,omitempty"`
+	LogCleanerDeleteRetentionMs        *int64  `json:"log_cleaner_delete_retention_ms,omitempty"`
+	LogCleanerMinCompactionLagMs       *int64  `json:"log_cleaner_min_compaction_lag_ms,omitempty"`
+	LogFlushIntervalMs                 *uint64 `json:"log_flush_interval_ms,omitempty"`
+	LogIndexIntervalBytes              *int    `json:"log_index_interval_bytes,omitempty"`
+	LogMessageDownconversionEnable     *bool   `json:"log_message_downconversion_enable,omitempty"`
+	LogMessageTimestampDifferenceMaxMs *uint64 `json:"log_message_timestamp_difference_max_ms,omitempty"`
+	LogPreallocate                     *bool   `json:"log_preallocate,omitempty"`
+	LogRetentionBytes                  *int64  `json:"log_retention_bytes,omitempty"`
+	LogRetentionHours                  *int    `json:"log_retention_hours,omitempty"`
+	LogRetentionMs                     *int64  `json:"log_retention_ms,omitempty"`
+	LogRollJitterMs                    *int64  `json:"log_roll_jitter_ms,omitempty"`
+	LogSegmentDeleteDelayMs            *int    `json:"log_segment_delete_delay_ms,omitempty"`
+	AutoCreateTopicsEnable             *bool   `json:"auto_create_topics_enable,omitempty"`
+}
+
 type databaseUserRoot struct {
 	User *DatabaseUser `json:"user"`
 }
@@ -701,6 +724,10 @@ type databaseMySQLConfigRoot struct {
 
 type databaseMongoDBConfigRoot struct {
 	Config *MongoDBConfig `json:"config"`
+}
+
+type databaseKafkaConfigRoot struct {
+	Config *KafkaConfig `json:"config"`
 }
 
 type databaseBackupsRoot struct {
@@ -1533,6 +1560,38 @@ func (svc *DatabasesServiceOp) GetMongoDBConfig(ctx context.Context, databaseID 
 func (svc *DatabasesServiceOp) UpdateMongoDBConfig(ctx context.Context, databaseID string, config *MongoDBConfig) (*Response, error) {
 	path := fmt.Sprintf(databaseConfigPath, databaseID)
 	root := &databaseMongoDBConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetKafkaConfig retrieves the config for a Kafka database cluster.
+func (svc *DatabasesServiceOp) GetKafkaConfig(ctx context.Context, databaseID string) (*KafkaConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseKafkaConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateKafkaConfig updates the config for a Kafka database cluster.
+func (svc *DatabasesServiceOp) UpdateKafkaConfig(ctx context.Context, databaseID string, config *KafkaConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseKafkaConfigRoot{
 		Config: config,
 	}
 	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.125.0
+# github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e
 ## explicit; go 1.22
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.125.1-0.20240924143755-3b8d0fdd306e
+# github.com/digitalocean/godo v1.125.1-0.20240920194833-57fbfebd23d4
 ## explicit; go 1.22
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
This PR adds a support for Kafka advanced configuration.

Terraform config example:

```
terraform {
  required_providers {
    digitalocean = {
      source  = "digitalocean/digitalocean"
      version = ">= 2.4.0"
    }
  }
}

provider "digitalocean" {
  token = "dop_v1_<your-token>"
}

resource "digitalocean_database_cluster" "new-kafka-tf-example" {
  name       = "kafka-cluster-test"
  engine     = "kafka"
  version    = "3.7"
  size       = "db-s-2vcpu-2gb"
  region     = "nyc1"
  node_count = 3
  tags       = ["production"]
}

resource "digitalocean_database_kafka_config" "new-tf-example-cfg" {
  cluster_id                              = digitalocean_database_cluster.new-kafka-tf-example.id
  group_initial_rebalance_delay_ms        = 7000
  log_flush_interval_ms                   = 10
}
```