### PR TITLE
Issue 1229 linter unused

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters:
     # - deadcode
     # - errcheck
     # - ineffassign
-    # - unused
+    - unused
 
 linters-settings:
   errcheck:

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -881,25 +881,6 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 `, testClusterVersion, rName)
 }
 
-func testAccDigitalOceanKubernetesConfigBasic5(testClusterVersion string, rName string) string {
-	return fmt.Sprintf(`%s
-
-resource "digitalocean_kubernetes_cluster" "foobar" {
-  name    = "%s"
-  region  = "lon1"
-  version = data.digitalocean_kubernetes_versions.test.latest_version
-  tags    = ["one", "two"]
-
-  node_pool {
-    name       = "default"
-    size       = "s-2vcpu-4gb"
-    node_count = 1
-    tags       = ["foo", "bar"]
-  }
-}
-`, testClusterVersion, rName)
-}
-
 func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion string, rName string) string {
 	return fmt.Sprintf(`%s
 


### PR DESCRIPTION
Fixes issue https://github.com/digitalocean/terraform-provider-digitalocean/issues/1229

Output of `make lint` after adding back `unused`:

```
jameskim:~/workspace/terraform-provider-digitalocean $ make lint
INFO golangci-lint has version 1.61.0 built with go1.23.1 from a1d6c56 on 2024-09-09T14:33:19Z
INFO [config_reader] Config search paths: [./ /Users/jameskim/workspace/terraform-provider-digitalocean /Users/jameskim/workspace /Users/jameskim /Users /]
INFO [config_reader] Used config file .golangci.yml
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
INFO [lintersdb] Active 7 linters: [gofmt goimports gosimple govet staticcheck unconvert unused]
INFO [loader] Go packages loading at mode 575 (name|types_sizes|compiled_files|exports_file|imports|deps|files) took 3.105408387s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 60.098237ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 114, after processing: 1
INFO [runner] Processors filtering stat (in/out): uniq_by_line: 1/1, diff: 1/1, invalid_issue: 114/114, identifier_marker: 114/114, exclude-rules: 114/1, max_per_file_from_linter: 1/1, source_code: 1/1, path_shortener: 1/1, severity-rules: 1/1, fixer: 1/1, filename_unadjuster: 114/114, skip_files: 114/114, exclude:
 114/114, max_same_issues: 1/1, sort_results: 1/1, cgo: 114/114, path_prettifier: 114/114, nolint: 1/1, max_from_linter: 1/1, path_prefixer: 1/1, skip_dirs: 114/114, autogenerated_exclude: 114/114
INFO [runner] processing took 31.851946ms with stages: identifier_marker: 16.062064ms, invalid_issue: 5.125848ms, nolint: 3.88447ms, autogenerated_exclude: 2.265732ms, path_prettifier: 1.981865ms, exclude-rules: 1.091937ms, source_code: 915.043µs, skip_dirs: 478.295µs, cgo: 25.83µs, filename_unadjuster: 5.481µs, ma
x_from_linter: 4.065µs, uniq_by_line: 2.674µs, path_shortener: 2.445µs, max_per_file_from_linter: 2.036µs, max_same_issues: 1.395µs, exclude: 528ns, fixer: 517ns, skip_files: 493ns, sort_results: 458ns, diff: 311ns, severity-rules: 266ns, path_prefixer: 193ns
INFO [runner] linters took 428.258507ms with stages: goanalysis_metalinter: 395.938952ms
digitalocean/kubernetes/resource_kubernetes_cluster_test.go:884:6: func `testAccDigitalOceanKubernetesConfigBasic5` is unused (unused)
func testAccDigitalOceanKubernetesConfigBasic5(testClusterVersion string, rName string) string {
     ^
INFO File cache stats: 1 entries of total size 44.3KiB
INFO Memory: 38 samples, avg is 29.6MB, max is 54.2MB
INFO Execution took 3.617533898s
make: *** [lint] Error 1
```

Looking through the test, I found that essentially `testAccDigitalOceanKubernetesConfigBasic4` covers what `testAccDigitalOceanKubernetesConfigBasic5` was trying to achieve. The only difference I observed was `testAccDigitalOceanKubernetesConfigBasic4` has addition checks for `surge_upgrade` and `ha` checks.

Changes made in this PR:
1. add back `unused` linter in `.golangci.yml`
2. remove the unused function `testAccDigitalOceanKubernetesConfigBasic5` ( redundant test function )