### PR TITLE
[ISSUE-1228] Resolve failing linter: ineffassign and enable back

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     # TODO: Enable addition linters
     # - deadcode
     # - errcheck
-    # - ineffassign
+    - ineffassign
     # - unused
 
 linters-settings:

--- a/digitalocean/certificate/resource_certificate.go
+++ b/digitalocean/certificate/resource_certificate.go
@@ -226,6 +226,9 @@ func resourceDigitalOceanCertificateCreate(ctx context.Context, d *schema.Resour
 	// We include the UUID as another computed field for use in the
 	// short-term refresh function that waits for it to be ready.
 	err = d.Set("uuid", cert.ID)
+	if err != nil {
+		return diag.Errorf("Error setting key UUID with value cert ID: %s", cert.ID)
+	}
 
 	log.Printf("[INFO] Waiting for certificate (%s) to have state 'verified'", cert.Name)
 	stateConf := &resource.StateChangeConf{

--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -669,7 +669,7 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 
 	readErr := resourceDigitalOceanDropletRead(ctx, d, meta)
 	if readErr != nil {
-		readErr = append(warnings, readErr...)
+		warnings = append(warnings, readErr...)
 	}
 
 	return warnings

--- a/digitalocean/spaces/resource_spaces_bucket.go
+++ b/digitalocean/spaces/resource_spaces_bucket.go
@@ -255,6 +255,11 @@ func resourceDigitalOceanBucketCreate(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	})
+
+	if err != nil {
+		return diag.Errorf("Error waiting for Spaces bucket: %s", err)
+	}
+
 	log.Println("Bucket created")
 
 	d.SetId(d.Get("name").(string))

--- a/digitalocean/spaces/resource_spaces_bucket.go
+++ b/digitalocean/spaces/resource_spaces_bucket.go
@@ -257,7 +257,7 @@ func resourceDigitalOceanBucketCreate(ctx context.Context, d *schema.ResourceDat
 	})
 
 	if err != nil {
-		return diag.Errorf("Error waiting for Spaces bucket: %s", err)
+		return diag.Errorf("Failed to check availability of Spaces bucket %s: %s", name, err)
 	}
 
 	log.Println("Bucket created")


### PR DESCRIPTION
Fixes issue #1228 

Output of `make lint` after enabling back `ineffassign`:
```
jameskim:~/workspace/tmux-powerline $ git branch
* main
jameskim:~/workspace/terraform-provider-digitalocean $ make lint
INFO golangci-lint has version 1.61.0 built with go1.23.1 from a1d6c56 on 2024-09-09T14:33:19Z
INFO [config_reader] Config search paths: [./ /Users/jameskim/workspace/terraform-provider-digitalocean /Users/jameskim/workspace /Users/jameskim /Users /]
INFO [config_reader] Used config file .golangci.yml
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
INFO [lintersdb] Active 7 linters: [gofmt goimports gosimple govet ineffassign staticcheck unconvert]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|imports|name|types_sizes) took 1.464015166s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 130.124224ms
INFO [linters_context/goanalysis] analyzers took 21.591862367s with top 10 stages: buildir: 5.537654569s, goimports: 3.133042126s, unconvert: 2.71021502s, gofmt: 1.30028191s, S1038: 1.234505016s, SA1012: 374.9969ms, S1039: 349.452002ms, nilness: 298.777009ms, SA6006: 293.611153ms, SA4030: 256.861288ms
INFO [runner] Issues before processing: 113, after processing: 3
INFO [runner] Processors filtering stat (in/out): cgo: 113/113, max_per_file_from_linter: 3/3, max_from_linter: 3/3, source_code: 3/3, skip_dirs: 113/113, nolint: 3/3, exclude-rules: 113/3, max_same_issues: 3/3, path_shortener: 3/3, severity-rules: 3/3, path_prefixer: 3/3, path_prettifier: 113/113, autogenerated_exclude: 113/113, skip_files: 113/113, identifier_marker: 113/113, exclude: 113/113, uniq_by_line: 3/3, diff: 3/3, fixer: 3/3, filename_unadjuster: 113/113, invalid_issue: 113/113, sort_results: 3/3
INFO [runner] processing took 18.466014ms with stages: nolint: 6.955664ms, identifier_marker: 5.346158ms, autogenerated_exclude: 2.919906ms, exclude-rules: 1.038219ms, path_prettifier: 1.018614ms, source_code: 483.527µs, skip_dirs: 360.067µs, cgo: 312.219µs, filename_unadjuster: 9.398µs, invalid_issue: 7.667µs, uniq_by_line: 5.087µs, max_from_linter: 2.433µs, path_shortener: 2.268µs, max_same_issues: 1.542µs, max_per_file_from_linter: 748ns, fixer: 492ns, skip_files: 443ns, sort_results: 404ns, diff: 399ns, exclude: 367ns, severity-rules: 216ns, path_prefixer: 176ns
INFO [runner] linters took 6.397450488s with stages: goanalysis_metalinter: 6.378329728s
digitalocean/droplet/resource_droplet.go:672:3: ineffectual assignment to readErr (ineffassign)
                readErr = append(warnings, readErr...)
                ^
digitalocean/spaces/resource_spaces_bucket.go:244:2: ineffectual assignment to err (ineffassign)
        err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
        ^
digitalocean/certificate/resource_certificate.go:228:2: ineffectual assignment to err (ineffassign)
        err = d.Set("uuid", cert.ID)
        ^
INFO File cache stats: 3 entries of total size 59.9KiB
INFO Memory: 80 samples, avg is 112.7MB, max is 293.4MB
INFO Execution took 8.036159236s
make: *** [lint] Error 1
```

Changes made in this PR:
1. add back `ineffassign` linter in .golangci.yml
2. In `digitalocean/certificate/resource_certificate.go`, add missing error handling
3. In `digitalocean/droplet/resource_droplet.go`, fix error append logic
4. In `digitalocean/spaces/resource_spaces_bucket.go`, add missing error handling


Output of `make lint` after enabling back `ineffassign`:
```
jameskim:~/workspace/terraform-provider-digitalocean $ make lint
INFO golangci-lint has version 1.61.0 built with go1.23.1 from a1d6c56 on 2024-09-09T14:33:19Z
INFO [config_reader] Config search paths: [./ /Users/jameskim/workspace/terraform-provider-digitalocean /Users/jameskim/workspace /Users/jameskim /Users /]
INFO [config_reader] Used config file .golangci.yml
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
INFO [lintersdb] Active 7 linters: [gofmt goimports gosimple govet ineffassign staticcheck unconvert]
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|files|imports|name|deps|types_sizes) took 3.775992715s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 187.386975ms
INFO [linters_context/goanalysis] analyzers took 1m3.777706597s with top 10 stages: buildir: 16.571300578s, goimports: 8.034853583s, gofmt: 4.407820529s, unconvert: 3.447695375s, S1038: 2.683924836s, SA6006: 1.214876365s, SA4030: 1.0204686s, SA1012: 1.002117174s, SA1004: 970.458974ms, SA4027: 852.017025ms
INFO [runner] Issues before processing: 108, after processing: 0
INFO [runner] Processors filtering stat (in/out): invalid_issue: 108/108, skip_files: 108/108, skip_dirs: 108/108, exclude: 108/108, path_prettifier: 108/108, identifier_marker: 108/108, cgo: 108/108, filename_unadjuster: 108/108, autogenerated_exclude: 108/108, exclude-rules: 108/0
INFO [runner] processing took 22.873521ms with stages: identifier_marker: 13.510106ms, path_prettifier: 3.932358ms, autogenerated_exclude: 2.433453ms, exclude-rules: 2.303745ms, cgo: 333.836µs, skip_dirs: 320.577µs, invalid_issue: 23.532µs, filename_unadjuster: 5.254µs, nolint: 4.111µs, max_same_issues: 1.413µs, uniq_by_line: 899ns, exclude: 524ns, skip_files: 483ns, diff: 461ns, max_from_linter: 459ns, fixer: 403ns, sort_results: 388ns, source_code: 380ns, max_per_file_from_linter: 339ns, path_prefixer: 291ns, path_shortener: 289ns, severity-rules: 220ns
INFO [runner] linters took 13.449737228s with stages: goanalysis_metalinter: 13.424248498s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 154 samples, avg is 116.0MB, max is 280.9MB
INFO Execution took 17.467412024s
```

