### PR TITLE
Enabled Linting errcheck and fixed linting issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     - gosimple
     # TODO: Enable addition linters
     # - deadcode
-    # - errcheck
+    - errcheck
     - ineffassign
     - unused
 

--- a/digitalocean/acceptance/droplets.go
+++ b/digitalocean/acceptance/droplets.go
@@ -113,7 +113,10 @@ func takeSnapshotOfDroplet(snapName string, intSuffix int, droplet *godo.Droplet
 	if err != nil {
 		return err
 	}
-	util.WaitForAction(client, action)
+	err = util.WaitForAction(client, action)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/digitalocean/droplet/import_droplet_test.go
+++ b/digitalocean/droplet/import_droplet_test.go
@@ -108,7 +108,10 @@ func takeDropletSnapshot(t *testing.T, name string, droplet *godo.Droplet, snaps
 		if err != nil {
 			return err
 		}
-		util.WaitForAction(client, action)
+		err = util.WaitForAction(client, action)
+		if err != nil {
+			return err
+		}
 
 		retrieveDroplet, _, err := client.Droplets.Get(context.Background(), (*droplet).ID)
 		if err != nil {

--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -665,7 +665,8 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 		for volumeID := range leftDiff(oldIDSet, newIDSet) {
 			err := detachVolumeIDOnDroplet(d, volumeID, meta)
 			if err != nil {
-				return nil
+				return diag.Errorf("Error detaching volume %q on droplet %s: %s", volumeID, d.Id(), err)
+
 			}
 		}
 	}

--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -663,7 +663,10 @@ func resourceDigitalOceanDropletUpdate(ctx context.Context, d *schema.ResourceDa
 			}
 		}
 		for volumeID := range leftDiff(oldIDSet, newIDSet) {
-			detachVolumeIDOnDroplet(d, volumeID, meta)
+			err := detachVolumeIDOnDroplet(d, volumeID, meta)
+			if err != nil {
+				return nil
+			}
 		}
 	}
 
@@ -849,7 +852,10 @@ func detachVolumesFromDroplet(d *schema.ResourceData, meta interface{}) error {
 	if attr, ok := d.GetOk("volume_ids"); ok {
 		errors = make([]error, 0, attr.(*schema.Set).Len())
 		for _, volumeID := range attr.(*schema.Set).List() {
-			detachVolumeIDOnDroplet(d, volumeID.(string), meta)
+			err := detachVolumeIDOnDroplet(d, volumeID.(string), meta)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/digitalocean/registry/resource_container_registry_test.go
+++ b/digitalocean/registry/resource_container_registry_test.go
@@ -193,7 +193,10 @@ func TestRevokeOAuthToken(t *testing.T) {
 			t.Errorf("auth header  = %v, expected %v", authHeader, expectedAuth)
 		}
 
-		r.ParseForm()
+		err := r.ParseForm()
+		if err != nil {
+			return
+		}
 		bodyToken := r.Form.Get("token")
 		if token != bodyToken {
 			t.Errorf("token  = %v, expected %v", bodyToken, token)


### PR DESCRIPTION
Fixes issue #1227 

The following files were modified. They all had the same issue of not checking errors before assigning values:

digitalocean/acceptance/droplets.go
digitalocean/droplet/import_droplet_test.go
digitalocean/droplet/resource_droplet.go
digitalocean/registry/resource_container_registry_test.go

I am also attaching the following image showing that there are no existing linting issues now:

![image](https://github.com/user-attachments/assets/6726978c-7a9b-4339-9457-0a3e5b876e77)
