### PR TITLE
Revert change moving from logging.NewTransportWithRequestLogging from logging.NewTransport.

### DIFF
--- a/digitalocean/config/config.go
+++ b/digitalocean/config/config.go
@@ -96,7 +96,12 @@ func (c *Config) Client() (*CombinedConfig, error) {
 	}
 
 	godoClient, err := godo.New(client, godoOpts...)
-	clientTransport := logging.NewSubsystemLoggingHTTPTransport("DigitalOcean", godoClient.HTTPClient.Transport)
+
+	// TODO: logging.NewTransport is deprecated and should be replaced with
+	// logging.NewTransportWithRequestLogging.
+	//
+	//nolint:staticcheck
+	clientTransport := logging.NewTransport("DigitalOcean", godoClient.HTTPClient.Transport)
 
 	godoClient.HTTPClient.Transport = clientTransport
 


### PR DESCRIPTION
In https://github.com/digitalocean/terraform-provider-digitalocean/pull/1237, a number of deprecated methods were update to allow for enabling additional staticchecks. Unfortunately, moving from `logging.NewTransport` to `logging.NewTransportWithRequestLogging` will require additional work to maintain the current level of detail in our debug logging.

Currently debug logging contains the following error message and does not include the actual details for the request and response bodies:

```
2024-10-09T10:51:36.704-0400 [DEBUG] provider.terraform-provider-digitalocean: Received HTTP Response: Date="Wed, 09 Oct 2024 14:51:36 GMT" X-Response-From=service new_logger_warning="This log was generated by a subsystem logger that wasn't created before being used. Use tflog.NewSubsystem to create this logger before it is used."
```

I've used `nolint:staticcheck` inline rather than disabling the check again.