### PR TITLE
Re-introduce d.GetOkExists usage.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,11 @@ run:
 issues:
   max-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    # TODO: Enable failing staticchecks
+    - linters:
+        - staticcheck
+      text: "SA1019: d.GetOkExists"
 
 linters:
   disable-all: true

--- a/digitalocean/database/resource_database_mysql_config.go
+++ b/digitalocean/database/resource_database_mysql_config.go
@@ -242,7 +242,7 @@ func updateMySQLConfig(ctx context.Context, d *schema.ResourceData, client *godo
 		opts.SQLMode = godo.PtrTo(v.(string))
 	}
 
-	if v, ok := d.GetOk("sql_require_primary_key"); ok {
+	if v, ok := d.GetOkExists("sql_require_primary_key"); ok {
 		opts.SQLRequirePrimaryKey = godo.PtrTo(v.(bool))
 	}
 
@@ -270,11 +270,11 @@ func updateMySQLConfig(ctx context.Context, d *schema.ResourceData, client *godo
 		opts.InnodbFtServerStopwordTable = godo.PtrTo(v.(string))
 	}
 
-	if v, ok := d.GetOk("innodb_print_all_deadlocks"); ok {
+	if v, ok := d.GetOkExists("innodb_print_all_deadlocks"); ok {
 		opts.InnodbPrintAllDeadlocks = godo.PtrTo(v.(bool))
 	}
 
-	if v, ok := d.GetOk("innodb_rollback_on_timeout"); ok {
+	if v, ok := d.GetOkExists("innodb_rollback_on_timeout"); ok {
 		opts.InnodbRollbackOnTimeout = godo.PtrTo(v.(bool))
 	}
 

--- a/digitalocean/database/resource_database_postgres_config.go
+++ b/digitalocean/database/resource_database_postgres_config.go
@@ -487,7 +487,7 @@ func updatePostgreSQLConfig(ctx context.Context, d *schema.ResourceData, client 
 		opts.IdleInTransactionSessionTimeout = godo.PtrTo(v.(int))
 	}
 
-	if v, ok := d.GetOk("jit"); ok {
+	if v, ok := d.GetOkExists("jit"); ok {
 		opts.JIT = godo.PtrTo(v.(bool))
 	}
 

--- a/digitalocean/database/resource_database_redis_config.go
+++ b/digitalocean/database/resource_database_redis_config.go
@@ -165,11 +165,11 @@ func updateRedisConfig(ctx context.Context, d *schema.ResourceData, client *godo
 		opts.RedisLFUDecayTime = godo.PtrTo(v.(int))
 	}
 
-	if v, ok := d.GetOk("ssl"); ok {
+	if v, ok := d.GetOkExists("ssl"); ok {
 		opts.RedisSSL = godo.PtrTo(v.(bool))
 	}
 
-	if v, ok := d.GetOk("timeout"); ok {
+	if v, ok := d.GetOkExists("timeout"); ok {
 		opts.RedisTimeout = godo.PtrTo(v.(int))
 	}
 

--- a/digitalocean/domain/resource_record.go
+++ b/digitalocean/domain/resource_record.go
@@ -163,7 +163,7 @@ func resourceDigitalOceanRecordCreate(ctx context.Context, d *schema.ResourceDat
 
 	newRecord.Type = d.Get("type").(string)
 
-	_, hasPort := d.GetOk("port")
+	_, hasPort := d.GetOkExists("port")
 	if newRecord.Type == "SRV" && !hasPort {
 		return diag.Errorf("`port` is required for when type is `SRV`")
 	}

--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -306,7 +306,7 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 		opts.Monitoring = attr.(bool)
 	}
 
-	if attr, ok := d.GetOk("droplet_agent"); ok {
+	if attr, ok := d.GetOkExists("droplet_agent"); ok {
 		opts.WithDropletAgent = godo.PtrTo(attr.(bool))
 	}
 
@@ -812,7 +812,7 @@ func dropletStateRefreshFunc(
 		}
 
 		// See if we can access our attribute
-		if attr, ok := d.GetOk(attribute); ok {
+		if attr, ok := d.GetOkExists(attribute); ok {
 			switch attr := attr.(type) {
 			case bool:
 				return &droplet, strconv.FormatBool(attr), nil


### PR DESCRIPTION
In #1237, a number of deprecated methods were update to allow for enabling additional staticchecks including usage of the deprecated `GetOkExists` method. Unfortunately, `GetOk` is not a drop in replacement. There is an important difference in its functionality.

> This is nearly the same function as `GetOk`, yet it does not check for the zero value of the attribute's type. This allows for attributes without a default, to fully check for a literal assignment, regardless of the zero-value for that type. This should only be used if absolutely required/needed.

https://pkg.go.dev/github.com/hashicorp/terraform/helper/schema#ResourceData.GetOkExists

Because of this change, Droplets can not currently be destroyed with main. It always timeouts waiting for the `locked` attribute to move to `false` despite already being so.

This reverts the changes related to `GetOkExists` and adds an exception in for it `.golangci.yml`