### PR TITLE
opensearch_config: only send PATCH on create if values set.

### DIFF
--- a/digitalocean/database/resource_database_opensearch_config.go
+++ b/digitalocean/database/resource_database_opensearch_config.go
@@ -280,11 +280,11 @@ func updateOpensearchConfig(ctx context.Context, d *schema.ResourceData, client 
 
 	opts := &godo.OpensearchConfig{}
 
-	if v, ok := d.GetOk("ism_enabled"); ok {
+	if v, ok := d.GetOkExists("ism_enabled"); ok {
 		opts.IsmEnabled = godo.PtrTo(v.(bool))
 	}
 
-	if v, ok := d.GetOk("ism_history_enabled"); ok {
+	if v, ok := d.GetOkExists("ism_history_enabled"); ok {
 		opts.IsmHistoryEnabled = godo.PtrTo(v.(bool))
 	}
 
@@ -352,15 +352,15 @@ func updateOpensearchConfig(ctx context.Context, d *schema.ResourceData, client 
 		opts.IndicesRecoveryMaxConcurrentFileChunks = godo.PtrTo(v.(int))
 	}
 
-	if v, ok := d.GetOk("action_auto_create_index_enabled"); ok {
+	if v, ok := d.GetOkExists("action_auto_create_index_enabled"); ok {
 		opts.ActionAutoCreateIndexEnabled = godo.PtrTo(v.(bool))
 	}
 
-	if v, ok := d.GetOk("action_destructive_requires_name"); ok {
+	if v, ok := d.GetOkExists("action_destructive_requires_name"); ok {
 		opts.ActionDestructiveRequiresName = godo.PtrTo(v.(bool))
 	}
 
-	if v, ok := d.GetOk("enable_security_audit"); ok {
+	if v, ok := d.GetOkExists("enable_security_audit"); ok {
 		opts.EnableSecurityAudit = godo.PtrTo(v.(bool))
 	}
 
@@ -408,7 +408,7 @@ func updateOpensearchConfig(ctx context.Context, d *schema.ResourceData, client 
 		opts.ThreadPoolForceMergeSize = godo.PtrTo(v.(int))
 	}
 
-	if v, ok := d.GetOk("override_main_response_version"); ok {
+	if v, ok := d.GetOkExists("override_main_response_version"); ok {
 		opts.OverrideMainResponseVersion = godo.PtrTo(v.(bool))
 	}
 
@@ -424,7 +424,7 @@ func updateOpensearchConfig(ctx context.Context, d *schema.ResourceData, client 
 		opts.ClusterRoutingAllocationNodeConcurrentRecoveries = godo.PtrTo(v.(int))
 	}
 
-	if v, ok := d.GetOk("plugins_alerting_filter_by_backend_roles_enabled"); ok {
+	if v, ok := d.GetOkExists("plugins_alerting_filter_by_backend_roles_enabled"); ok {
 		opts.PluginsAlertingFilterByBackendRolesEnabled = godo.PtrTo(v.(bool))
 	}
 

--- a/digitalocean/database/resource_database_opensearch_config.go
+++ b/digitalocean/database/resource_database_opensearch_config.go
@@ -254,8 +254,10 @@ func resourceDigitalOceanDatabaseOpensearchConfigCreate(ctx context.Context, d *
 	client := meta.(*config.CombinedConfig).GodoClient()
 	clusterID := d.Get("cluster_id").(string)
 
-	if err := updateOpensearchConfig(ctx, d, client); err != nil {
-		return diag.Errorf("Error updating Opensearch configuration: %s", err)
+	if d.HasChangeExcept("cluster_id") {
+		if err := updateOpensearchConfig(ctx, d, client); err != nil {
+			return diag.Errorf("Error updating Opensearch configuration: %s", err)
+		}
 	}
 
 	d.SetId(makeDatabaseOpensearchConfigID(clusterID))

--- a/digitalocean/database/resource_database_opensearch_config_test.go
+++ b/digitalocean/database/resource_database_opensearch_config_test.go
@@ -20,17 +20,21 @@ func TestAccDigitalOceanDatabaseOpensearchConfig_Basic(t *testing.T) {
 			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseOpensearchConfigConfigBasic, dbConfig, true, 10, "1"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "enable_security_audit", "true"),
 					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_enabled", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_enabled", "true"),
 					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_max_age_hours", "10"),
 					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_max_docs", "1"),
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseOpensearchConfigConfigBasic, dbConfig, false, 1, "9223372036854775807"),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseOpensearchConfigConfigBasic, dbConfig, false, 1, "1000000000000000000"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_enabled", "false"),
+					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "enable_security_audit", "false"),
+					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_enabled", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_enabled", "true"),
 					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_max_age_hours", "1"),
-					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_max_docs", "9223372036854775807"),
+					resource.TestCheckResourceAttr("digitalocean_database_opensearch_config.foobar", "ism_history_max_docs", "1000000000000000000"),
 				),
 			},
 		},
@@ -42,7 +46,9 @@ const testAccCheckDigitalOceanDatabaseOpensearchConfigConfigBasic = `
 
 resource "digitalocean_database_opensearch_config" "foobar" {
   cluster_id                = digitalocean_database_cluster.foobar.id
-  ism_enabled               = %t
+  enable_security_audit     = %t
+  ism_enabled               = true
+  ism_history_enabled       = true
   ism_history_max_age_hours = %d
   ism_history_max_docs      = %s
 }`


### PR DESCRIPTION
As reported in https://github.com/digitalocean/terraform-provider-digitalocean/issues/1266, "creating" a `digitalocean_database_opensearch_config` without any setting leads to an error. This change protects against that by preventing sending the PATCH on create if no other values beside `cluster_id` are set.

Additionally, I ran into some issue running the acceptance test. One is a bug. We need to use `GetOkExists` when checking the value for a bool. If not, it is not correctly detected when being set to `false`.

There are also a few changes to the test that do not impact functionality which I will note inline.