### PR TITLE
docs(droplet) details `user_data` behavior (resource forces recreate)

### DIFF
--- a/docs/resources/droplet.md
+++ b/docs/resources/droplet.md
@@ -62,7 +62,7 @@ The following arguments are supported:
    only the Droplet's RAM and CPU will be resized. **Increasing a Droplet's disk
    size is a permanent change**. Increasing only RAM and CPU is reversible.
 * `tags` - (Optional) A list of the tags to be applied to this Droplet.
-* `user_data` (Optional) - A string of the desired User Data for the Droplet.
+* `user_data` (Optional) - A string of the desired User Data provided [during Droplet creation](https://docs.digitalocean.com/products/droplets/how-to/provide-user-data/). Changing this forces a new resource to be created.
 * `volume_ids` (Optional) - A list of the IDs of each [block storage volume](/providers/digitalocean/digitalocean/latest/docs/resources/volume) to be attached to the Droplet.
 * `droplet_agent` (Optional) - A boolean indicating whether to install the
    DigitalOcean agent used for providing access to the Droplet web console in


### PR DESCRIPTION
We [recently discovered](https://github.com/jenkins-infra/digitalocean/pull/211#issuecomment-2485170603) that `user_data` is immutable for a given Droplet and changing its value forces a resource re-creation.

It is a different behavior than other Terraform providers (Azure does not care, AWS triggers instance reboot, etc.) so it is worth documenting it.

This PR updates the `user_data` description by adding the link to official DigitalOcean documentation and specifying that changing this attribute forces a new resource.