### PR TITLE
fix: add opensearch_acl to data.digitalocean_database_user schema

### DIFF
--- a/digitalocean/database/datasource_database_user.go
+++ b/digitalocean/database/datasource_database_user.go
@@ -56,6 +56,11 @@ func DataSourceDigitalOceanDatabaseUser() *schema.Resource {
 							Optional: true,
 							Elem:     userACLSchema(),
 						},
+						"opensearch_acl": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     userOpenSearchACLSchema(),
+						},
 					},
 				},
 			},

--- a/digitalocean/database/datasource_database_user_test.go
+++ b/digitalocean/database/datasource_database_user_test.go
@@ -53,6 +53,11 @@ func TestAccDataSourceDigitalOceanDatabaseUser_Basic(t *testing.T) {
 						"digitalocean_database_user.foobar_user", "access_cert"),
 					resource.TestCheckNoResourceAttr(
 						"digitalocean_database_user.foobar_user", "access_key"),
+
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_user.doadmin", "name", "doadmin"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_user.doadmin", "role", "primary"),
 				),
 			},
 		},
@@ -60,6 +65,11 @@ func TestAccDataSourceDigitalOceanDatabaseUser_Basic(t *testing.T) {
 }
 
 const testAccCheckDigitalOceanDatasourceDatabaseUserConfigBasic = `
+data "digitalocean_database_user" "doadmin" {
+  cluster_id = digitalocean_database_cluster.foobar.id
+  name       = "doadmin"
+}
+
 data "digitalocean_database_user" "foobar_user" {
   cluster_id = digitalocean_database_cluster.foobar.id
   name       = "%s"


### PR DESCRIPTION
This bug was introduced when `opensearch_acl` support was added to the database cluster resource (https://github.com/digitalocean/terraform-provider-digitalocean/pull/1215). The resource and data source share the `flattenUserSettings` method. When the data source attempts to set the empty `opensearch_acl` to state, it errors as it is not part of the datasource schema. 

https://github.com/digitalocean/terraform-provider-digitalocean/blob/f27a1125229e865da2a20cb0682d57b38433ce82/digitalocean/database/resource_database_user.go#L348-L357

The acceptance test did not catch this as the user needs to have a `setting` block in the API response as the method checks it `settings` is `nil`. A brand new Postgres user does not, but a `doadmin` user does, e.g.

```
{
  "user": {
    "name": "doadmin",
    "role": "primary",
    "password": "<redacted>",
    "settings": {
      "pg_allow_replication": true
    }
  }
}
```

Updated test now passes, but before the change would fail with:

```
panic: Invalid address to set: []string{"settings", "0", "opensearch_acl"}
```

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1289
