### PR TITLE
apps: support Bitbucket as a source.

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -237,6 +237,10 @@ func appSpecGitLabSourceSchema() map[string]*schema.Schema {
 	return appSpecGitServiceSourceSchema()
 }
 
+func appSpeBitBucketSourceSchema() map[string]*schema.Schema {
+	return appSpecGitServiceSourceSchema()
+}
+
 func appSpecImageSourceSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"registry_type": {
@@ -550,6 +554,14 @@ func appSpecComponentBase(componentType appSpecComponentType) map[string]*schema
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: appSpecGitLabSourceSchema(),
+			},
+		},
+		"bitbucket": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: appSpeBitBucketSourceSchema(),
 			},
 		},
 		"env": {
@@ -1633,6 +1645,34 @@ func flattenAppGitLabSourceSpec(spec *godo.GitLabSourceSpec) []interface{} {
 	return result
 }
 
+func expandAppBitBucketSourceSpec(config []interface{}) *godo.BitbucketSourceSpec {
+	bitBucketSourceConfig := config[0].(map[string]interface{})
+
+	bitBucketSource := &godo.BitbucketSourceSpec{
+		Repo:         bitBucketSourceConfig["repo"].(string),
+		Branch:       bitBucketSourceConfig["branch"].(string),
+		DeployOnPush: bitBucketSourceConfig["deploy_on_push"].(bool),
+	}
+
+	return bitBucketSource
+}
+
+func flattenAppBitBucketSourceSpec(spec *godo.BitbucketSourceSpec) []interface{} {
+	result := make([]interface{}, 0)
+
+	if spec != nil {
+
+		r := make(map[string]interface{})
+		r["repo"] = (*spec).Repo
+		r["branch"] = (*spec).Branch
+		r["deploy_on_push"] = (*spec).DeployOnPush
+
+		result = append(result, r)
+	}
+
+	return result
+}
+
 func expandAppGitSourceSpec(config []interface{}) *godo.GitSourceSpec {
 	gitSourceConfig := config[0].(map[string]interface{})
 
@@ -1862,6 +1902,11 @@ func expandAppSpecServices(config []interface{}) []*godo.AppServiceSpec {
 			s.GitLab = expandAppGitLabSourceSpec(gitlab)
 		}
 
+		bitbucket := service["bitbucket"].([]interface{})
+		if len(bitbucket) > 0 {
+			s.Bitbucket = expandAppBitBucketSourceSpec(bitbucket)
+		}
+
 		git := service["git"].([]interface{})
 		if len(git) > 0 {
 			s.Git = expandAppGitSourceSpec(git)
@@ -1929,6 +1974,7 @@ func flattenAppSpecServices(services []*godo.AppServiceSpec) []map[string]interf
 		r["build_command"] = s.BuildCommand
 		r["github"] = flattenAppGitHubSourceSpec(s.GitHub)
 		r["gitlab"] = flattenAppGitLabSourceSpec(s.GitLab)
+		r["bitbucket"] = flattenAppBitBucketSourceSpec(s.Bitbucket)
 		r["internal_ports"] = flattenAppServiceInternalPortsSpec(s.InternalPorts)
 		r["git"] = flattenAppGitSourceSpec(s.Git)
 		r["image"] = flattenAppImageSourceSpec(s.Image)
@@ -1982,6 +2028,11 @@ func expandAppSpecStaticSites(config []interface{}) []*godo.AppStaticSiteSpec {
 			s.GitLab = expandAppGitLabSourceSpec(gitlab)
 		}
 
+		bitbucket := site["bitbucket"].([]interface{})
+		if len(bitbucket) > 0 {
+			s.Bitbucket = expandAppBitBucketSourceSpec(bitbucket)
+		}
+
 		git := site["git"].([]interface{})
 		if len(git) > 0 {
 			s.Git = expandAppGitSourceSpec(git)
@@ -2013,6 +2064,7 @@ func flattenAppSpecStaticSites(sites []*godo.AppStaticSiteSpec) []map[string]int
 		r["build_command"] = s.BuildCommand
 		r["github"] = flattenAppGitHubSourceSpec(s.GitHub)
 		r["gitlab"] = flattenAppGitLabSourceSpec(s.GitLab)
+		r["bitbucket"] = flattenAppBitBucketSourceSpec(s.Bitbucket)
 		r["git"] = flattenAppGitSourceSpec(s.Git)
 		r["routes"] = flattenAppRoutes(s.Routes)
 		r["dockerfile_path"] = s.DockerfilePath
@@ -2071,6 +2123,11 @@ func expandAppSpecWorkers(config []interface{}) []*godo.AppWorkerSpec {
 			s.GitLab = expandAppGitLabSourceSpec(gitlab)
 		}
 
+		bitbucket := worker["bitbucket"].([]interface{})
+		if len(bitbucket) > 0 {
+			s.Bitbucket = expandAppBitBucketSourceSpec(bitbucket)
+		}
+
 		git := worker["git"].([]interface{})
 		if len(git) > 0 {
 			s.Git = expandAppGitSourceSpec(git)
@@ -2118,6 +2175,7 @@ func flattenAppSpecWorkers(workers []*godo.AppWorkerSpec) []map[string]interface
 		r["build_command"] = w.BuildCommand
 		r["github"] = flattenAppGitHubSourceSpec(w.GitHub)
 		r["gitlab"] = flattenAppGitLabSourceSpec(w.GitLab)
+		r["bitbucket"] = flattenAppBitBucketSourceSpec(w.Bitbucket)
 		r["git"] = flattenAppGitSourceSpec(w.Git)
 		r["image"] = flattenAppImageSourceSpec(w.Image)
 		r["dockerfile_path"] = w.DockerfilePath
@@ -2166,6 +2224,11 @@ func expandAppSpecJobs(config []interface{}) []*godo.AppJobSpec {
 			s.GitLab = expandAppGitLabSourceSpec(gitlab)
 		}
 
+		bitbucket := job["bitbucket"].([]interface{})
+		if len(bitbucket) > 0 {
+			s.Bitbucket = expandAppBitBucketSourceSpec(bitbucket)
+		}
+
 		git := job["git"].([]interface{})
 		if len(git) > 0 {
 			s.Git = expandAppGitSourceSpec(git)
@@ -2208,6 +2271,7 @@ func flattenAppSpecJobs(jobs []*godo.AppJobSpec) []map[string]interface{} {
 		r["build_command"] = j.BuildCommand
 		r["github"] = flattenAppGitHubSourceSpec(j.GitHub)
 		r["gitlab"] = flattenAppGitLabSourceSpec(j.GitLab)
+		r["bitbucket"] = flattenAppBitBucketSourceSpec(j.Bitbucket)
 		r["git"] = flattenAppGitSourceSpec(j.Git)
 		r["image"] = flattenAppImageSourceSpec(j.Image)
 		r["dockerfile_path"] = j.DockerfilePath
@@ -2247,6 +2311,11 @@ func expandAppSpecFunctions(config []interface{}) []*godo.AppFunctionsSpec {
 		gitlab := fn["gitlab"].([]interface{})
 		if len(gitlab) > 0 {
 			f.GitLab = expandAppGitLabSourceSpec(gitlab)
+		}
+
+		bitbucket := fn["bitbucket"].([]interface{})
+		if len(bitbucket) > 0 {
+			f.Bitbucket = expandAppBitBucketSourceSpec(bitbucket)
 		}
 
 		git := fn["git"].([]interface{})
@@ -2290,6 +2359,7 @@ func flattenAppSpecFunctions(functions []*godo.AppFunctionsSpec) []map[string]in
 		r["source_dir"] = fn.SourceDir
 		r["github"] = flattenAppGitHubSourceSpec(fn.GitHub)
 		r["gitlab"] = flattenAppGitLabSourceSpec(fn.GitLab)
+		r["bitbucket"] = flattenAppBitBucketSourceSpec(fn.Bitbucket)
 		r["git"] = flattenAppGitSourceSpec(fn.Git)
 		r["routes"] = flattenAppRoutes(fn.Routes)
 		r["cors"] = flattenAppCORSPolicy(fn.CORS)

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -237,7 +237,7 @@ func appSpecGitLabSourceSchema() map[string]*schema.Schema {
 	return appSpecGitServiceSourceSchema()
 }
 
-func appSpeBitBucketSourceSchema() map[string]*schema.Schema {
+func appSpecBitBucketSourceSchema() map[string]*schema.Schema {
 	return appSpecGitServiceSourceSchema()
 }
 
@@ -561,7 +561,7 @@ func appSpecComponentBase(componentType appSpecComponentType) map[string]*schema
 			Optional: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
-				Schema: appSpeBitBucketSourceSchema(),
+				Schema: appSpecBitBucketSourceSchema(),
 			},
 		},
 		"env": {

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -57,18 +57,22 @@ A `service` can contain:
 * `instance_count` - The amount of instances that this component should be scaled to.
 * `http_port` - The internal port on which this service's run command will listen.
 * `internal_ports` - A list of ports on which this service will listen for internal traffic.
-* `git` - A Git repo to use as component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `git` - A Git repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
 * `github` - A GitHub repo to use as component's source. Only one of `git`, `github` or `gitlab`  may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `gitlab` - A Gitlab repo to use as component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `bitbucket` - A Bitbucket repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `image` - An image to use as the component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `gitlab` - A Gitlab repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `image` - An image to use as the component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `registry_type` - The registry type. One of `DOCR` (DigitalOcean container registry) or `DOCKER_HUB`.
   - `registry` - The registry name. Must be left empty for the `DOCR` registry type. Required for the `DOCKER_HUB` registry type.
   - `repository` - The repository name.
@@ -128,14 +132,18 @@ A `static_site` can contain:
 * `index_document` - The name of the index document to use when serving this static site.
 * `error_document` - The name of the error document to use when serving this static site.
 * `catchall_document` - The name of the document to use as the fallback for any requests to documents that are not found when serving this static site.
-* `git` - A Git repo to use as component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `git` - A Git repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
 * `github` - A GitHub repo to use as component's source. Only one of `git`, `github` or `gitlab`  may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `gitlab` - A Gitlab repo to use as component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `bitbucket` - A Bitbucket repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `gitlab` - A Gitlab repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
@@ -158,18 +166,22 @@ A `worker` can contain:
 * `environment_slug` - An environment slug describing the type of this app.
 * `instance_size_slug` - The instance size to use for this component.
 * `instance_count` - The amount of instances that this component should be scaled to.
-* `git` - A Git repo to use as component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `git` - A Git repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
 * `github` - A GitHub repo to use as component's source. Only one of `git`, `github` or `gitlab`  may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `gitlab` - A Gitlab repo to use as component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `bitbucket` - A Bitbucket repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `image` - An image to use as the component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `gitlab` - A Gitlab repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `image` - An image to use as the component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `registry_type` - The registry type. One of `DOCR` (DigitalOcean container registry) or `DOCKER_HUB`.
   - `registry` - The registry name. Must be left empty for the `DOCR` registry type. Required for the `DOCKER_HUB` registry type.
   - `repository` - The repository name.
@@ -225,15 +237,19 @@ A `job` can contain:
 * `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication.  Only one of `git`, `github` or `gitlab`  may be set.
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
-* `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `bitbucket` - A Bitbucket repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `image` - An image to use as the component's source. Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `image` - An image to use as the component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `registry_type` - The registry type. One of `DOCR` (DigitalOcean container registry) or `DOCKER_HUB`.
   - `registry` - The registry name. Must be left empty for the `DOCR` registry type. Required for the `DOCKER_HUB` registry type.
   - `repository` - The repository name.
@@ -272,11 +288,15 @@ A `function` component can contain:
 * `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication.  Only one of `git`, `github` or `gitlab`  may be set.
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
-* `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-* `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+* `bitbucket` - A Bitbucket repo to use as component's source. Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+* `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -259,7 +259,7 @@ A `service` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/bitbucket/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
@@ -343,7 +343,7 @@ A `static_site` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/bitbucket/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
@@ -378,7 +378,7 @@ A `worker` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/bitbucket/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
@@ -453,7 +453,7 @@ A `job` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/bitbucket/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
@@ -511,7 +511,7 @@ A `function` component can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
-- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/bitbucket/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -109,7 +109,7 @@ resource "digitalocean_app" "mono-repo-example" {
       name          = "web"
       build_command = "npm run build"
 
-      github {
+      bitbucket {
         branch         = "main"
         deploy_on_push = true
         repo           = "username/repo"
@@ -259,6 +259,10 @@ A `service` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
 - `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
@@ -339,6 +343,10 @@ A `static_site` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
 - `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
@@ -367,6 +375,10 @@ A `worker` can contain:
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
 - `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
@@ -441,6 +453,10 @@ A `job` can contain:
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
 - `gitlab` - A Gitlab repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/gitlab/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
@@ -492,6 +508,10 @@ A `function` component can contain:
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.
 - `github` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `gitlab`, or `image` may be set.
+  - `repo` - The name of the repo in the format `owner/repo`.
+  - `branch` - The name of the branch to use.
+  - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.
+- `bitbucket` - A GitHub repo to use as the component's source. DigitalOcean App Platform must have [access to the repository](https://cloud.digitalocean.com/apps/github/install). Only one of `git`, `github`, `bitbucket`, `gitlab`, or `image` may be set.
   - `repo` - The name of the repo in the format `owner/repo`.
   - `branch` - The name of the branch to use.
   - `deploy_on_push` - Whether to automatically deploy new commits made to the repo.


### PR DESCRIPTION
This adds support for Bitbucket as an app component source. It includes the docs from @dbrian57 in https://github.com/digitalocean/terraform-provider-digitalocean/pull/1303.

Note, like GitHub and GitLab, there are no acceptance tests. We only have ones using unauthenticated git clones so as to not require an account beyond a DigitalOcean one to run these tests. 