### PR TITLE
Add kubeconfig expiration option for credentials

### DIFF
--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -195,7 +195,6 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"kubeconfig_expire_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      0, // 0 means the kubeconfig will expire in 7 days
 				ValidateFunc: validation.IntAtLeast(0),
 			},
 		},

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -191,6 +191,13 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"kubeconfig_expire_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0, // 0 means the kubeconfig will expire in 7 days
+				ValidateFunc: validation.IntAtLeast(0),
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -424,7 +431,10 @@ func digitaloceanKubernetesClusterRead(
 		}
 	}
 	if expiresAt.IsZero() || expiresAt.Before(time.Now()) {
-		creds, _, err := client.Kubernetes.GetCredentials(context.Background(), cluster.ID, &godo.KubernetesClusterCredentialsGetRequest{})
+		expireSeconds := d.Get("kubeconfig_expire_seconds").(int)
+		creds, _, err := client.Kubernetes.GetCredentials(context.Background(), cluster.ID, &godo.KubernetesClusterCredentialsGetRequest{
+			ExpirySeconds: &expireSeconds,
+		})
 		if err != nil {
 			return diag.Errorf("Unable to fetch Kubernetes credentials: %s", err)
 		}


### PR DESCRIPTION
Introduce an option to specify the expiration time for kubeconfig credentials, enhancing the flexibility of credential management. Remove the default value for this option to allow explicit configuration.