### PR TITLE
Project: return success after removing ID

### DIFF
--- a/digitalocean/project/resource_project.go
+++ b/digitalocean/project/resource_project.go
@@ -175,6 +175,7 @@ func resourceDigitalOceanProjectRead(ctx context.Context, d *schema.ResourceData
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[DEBUG] Project  (%s) was not found - removing from state", d.Id())
 			d.SetId("")
+			return nil
 		}
 
 		return diag.Errorf("Error reading Project: %s", err)


### PR DESCRIPTION
When a project is gone from DO, a refresh fails because the project cannot be found. The code detects the 404 but still returns an error, so the refresh fails, instead of saving the updated state.

Here's a log (from Pulumi):
```
[2025-01-17 03:01:35]  ~  digitalocean:index:Project project refreshing (0s) error:   sdk-v2/provider2.go:457: sdk.helper_schema: Error reading Project: GET https://api.digitalocean.com/v2/projects/7242f1c8-65fb-46bd-93e2-63b263ddd15e: 404 (request "f81512c7-d34c-4c04-ab6b-aedbad9cead9") project not found: provider=digitalocean@4.32.0
```

After erasing the resource ID, the code falls through to the error, instead of returning `nil` (which is also the behavior of many other resources in the 404 case).