### PR TITLE
feat(kubernetes): add support to configure control plane firewall

### DIFF
--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -240,6 +240,29 @@ func expandMaintPolicyOpts(config []interface{}) (*godo.KubernetesMaintenancePol
 	return maintPolicy, nil
 }
 
+func expandControlPlaneFirewallOpts(raw []interface{}) *godo.KubernetesControlPlaneFirewall {
+	if len(raw) == 0 || raw[0] == nil {
+		return &godo.KubernetesControlPlaneFirewall{}
+	}
+	controlPlaneFirewallConfig := raw[0].(map[string]interface{})
+
+	controlPlaneFirewall := &godo.KubernetesControlPlaneFirewall{
+		Enabled:          godo.PtrTo(controlPlaneFirewallConfig["enabled"].(bool)),
+		AllowedAddresses: expandAllowedAddresses(controlPlaneFirewallConfig["allowed_addresses"].([]interface{})),
+	}
+	return controlPlaneFirewall
+}
+
+func expandAllowedAddresses(addrs []interface{}) []string {
+	var expandedAddrs []string
+	for _, item := range addrs {
+		if str, ok := item.(string); ok {
+			expandedAddrs = append(expandedAddrs, str)
+		}
+	}
+	return expandedAddrs
+}
+
 func flattenMaintPolicyOpts(opts *godo.KubernetesMaintenancePolicy) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 	item := make(map[string]interface{})
@@ -247,6 +270,17 @@ func flattenMaintPolicyOpts(opts *godo.KubernetesMaintenancePolicy) []map[string
 	item["day"] = opts.Day.String()
 	item["duration"] = opts.Duration
 	item["start_time"] = opts.StartTime
+	result = append(result, item)
+
+	return result
+}
+
+func flattenControlPlaneFirewallOpts(opts *godo.KubernetesControlPlaneFirewall) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	item := make(map[string]interface{})
+
+	item["enabled"] = opts.Enabled
+	item["allowed_addresses"] = opts.AllowedAddresses
 	result = append(result, item)
 
 	return result

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -365,6 +365,52 @@ func TestAccDigitalOceanKubernetesCluster_MaintenancePolicy(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanKubernetesCluster_ControlPlaneFirewall(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	firewall := `
+	control_plane_firewall {
+		enabled = true
+		allowed_addresses = ["1.2.3.4/16"]
+	}
+`
+
+	firewallUpdate := `
+	control_plane_firewall {
+		enabled = false
+		allowed_addresses = ["1.2.3.4/16", "5.6.7.8/16"]
+	}
+`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigControlPlaneFirewall(testClusterVersionLatest, rName, firewall),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "control_plane_firewall.0.enabled", "true"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "control_plane_firewall.0.allowed_addresses.0", "1.2.3.4/16"),
+				),
+			},
+			{
+				Config: testAccDigitalOceanKubernetesConfigControlPlaneFirewall(testClusterVersionLatest, rName, firewallUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "control_plane_firewall.0.enabled", "false"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "control_plane_firewall.0.allowed_addresses.0", "1.2.3.4/16"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "control_plane_firewall.0.allowed_addresses.1", "5.6.7.8/16"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 	rName := acceptance.RandomTestName()
 	var k8s godo.KubernetesCluster
@@ -838,6 +884,36 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   }
 }
 `, testClusterVersion, rName, policy)
+}
+
+func testAccDigitalOceanKubernetesConfigControlPlaneFirewall(testClusterVersion string, rName string, controlPlaneFirewall string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name          = "%s"
+  region        = "lon1"
+  version       = data.digitalocean_kubernetes_versions.test.latest_version
+  surge_upgrade = true
+  tags          = ["foo", "bar", "one"]
+
+%s
+
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+    tags       = ["one", "two"]
+    labels = {
+      priority = "high"
+    }
+    taint {
+      key    = "key1"
+      value  = "val1"
+      effect = "PreferNoSchedule"
+    }
+  }
+}
+`, testClusterVersion, rName, controlPlaneFirewall)
 }
 
 func testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion string, rName string) string {


### PR DESCRIPTION
This PR allows to configure https://docs.digitalocean.com/products/kubernetes/how-to/add-control-plane-firewall/