### PR TITLE
kubernetes: add cluster autoscaler configuration fields

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -124,6 +124,23 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				},
 			},
 
+			"cluster_autoscaler_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"scale_down_utilization_threshold": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"scale_down_unneeded_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
 			"node_pool": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -51,6 +51,8 @@ data "digitalocean_kubernetes_cluster" "foobar" {
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.day", "monday"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.start_time", "00:00"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.duration"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_utilization_threshold", "0.5"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_unneeded_time", "1m30s"),
 				),
 			},
 		},
@@ -79,6 +81,11 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   maintenance_policy {
     day        = "monday"
     start_time = "00:00"
+  }
+
+  cluster_autoscaler_configuration {
+    scale_down_utilization_threshold = 0.5
+    scale_down_unneeded_time         = "1m30s"
   }
 }`, version, rName)
 }

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -419,11 +419,11 @@ func expandCAConfigOpts(config []interface{}) *godo.KubernetesClusterAutoscalerC
 	configMap := config[0].(map[string]interface{})
 
 	if v, ok := configMap["scale_down_utilization_threshold"]; ok {
-		caConfig.ScaleDownUtilizationThreshold = v.(*float64)
+		caConfig.ScaleDownUtilizationThreshold = godo.PtrTo(v.(float64))
 	}
 
 	if v, ok := configMap["scale_down_unneeded_time"]; ok {
-		caConfig.ScaleDownUnneededTime = v.(*string)
+		caConfig.ScaleDownUnneededTime = godo.PtrTo(v.(string))
 	}
 
 	return caConfig
@@ -431,8 +431,11 @@ func expandCAConfigOpts(config []interface{}) *godo.KubernetesClusterAutoscalerC
 
 func flattenCAConfigOpts(opts *godo.KubernetesClusterAutoscalerConfiguration) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
-	item := make(map[string]interface{})
+	if opts == nil {
+		return result
+	}
 
+	item := make(map[string]interface{})
 	item["scale_down_utilization_threshold"] = opts.ScaleDownUtilizationThreshold
 	item["scale_down_unneeded_time"] = opts.ScaleDownUnneededTime
 	result = append(result, item)

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -409,3 +409,29 @@ func FilterTags(tags []string) []string {
 
 	return filteredTags
 }
+
+func expandCAConfigOpts(config []interface{}) *godo.KubernetesClusterAutoscalerConfiguration {
+	caConfig := &godo.KubernetesClusterAutoscalerConfiguration{}
+	configMap := config[0].(map[string]interface{})
+
+	if v, ok := configMap["scale_down_utilization_threshold"]; ok {
+		caConfig.ScaleDownUtilizationThreshold = v.(*float64)
+	}
+
+	if v, ok := configMap["scale_down_unneeded_time"]; ok {
+		caConfig.ScaleDownUnneededTime = v.(*string)
+	}
+
+	return caConfig
+}
+
+func flattenCAConfigOpts(opts *godo.KubernetesClusterAutoscalerConfiguration) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	item := make(map[string]interface{})
+
+	item["scale_down_utilization_threshold"] = opts.ScaleDownUtilizationThreshold
+	item["scale_down_unneeded_time"] = opts.ScaleDownUnneededTime
+	result = append(result, item)
+
+	return result
+}

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -505,7 +505,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 	client := meta.(*config.CombinedConfig).GodoClient()
 
 	// Figure out the changes and then call the appropriate API methods
-	if d.HasChanges("name", "tags", "auto_upgrade", "surge_upgrade", "maintenance_policy", "ha", controlPlaneFirewallField) {
+	if d.HasChanges("name", "tags", "auto_upgrade", "surge_upgrade", "maintenance_policy", "ha", controlPlaneFirewallField, "cluster_autoscaler_configuration") {
 
 		opts := &godo.KubernetesClusterUpdateRequest{
 			Name:                 d.Get("name").(string),

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -439,6 +439,14 @@ func TestAccDigitalOceanKubernetesCluster_ClusterAutoscalerConfiguration(t *test
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
+				// regression test for configs with no cluster_autoscaler_configuration.
+				Config: testAccDigitalOceanKubernetesConfigClusterAutoscalerConfiguration(testClusterVersionLatest, rName, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
+				),
+			},
+			{
 				Config: testAccDigitalOceanKubernetesConfigClusterAutoscalerConfiguration(testClusterVersionLatest, rName, clusterAutoscalerConfiguration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
@@ -452,7 +460,6 @@ func TestAccDigitalOceanKubernetesCluster_ClusterAutoscalerConfiguration(t *test
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.day", "any"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_utilization_threshold", "0.8"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_unneeded_time", "2m"),
 				),

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -902,11 +902,11 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
       effect = "PreferNoSchedule"
     }
   }
-	
-	cluster_autoscaler_configuration {
-		scale_down_utilization_threshold = 0.5
-		scale_down_unneeded_time = "1m30s"
-	}
+
+  cluster_autoscaler_configuration {
+    scale_down_utilization_threshold = 0.5
+    scale_down_unneeded_time         = "1m30s"
+  }
 }
 `, testClusterVersion, rName)
 }
@@ -1062,10 +1062,10 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
     tags       = ["foo", "bar"]
   }
 
-	cluster_autoscaler_configuration {
-		scale_down_utilization_threshold = 0.8
-		scale_down_unneeded_time = "2m"
-	}
+  cluster_autoscaler_configuration {
+    scale_down_utilization_threshold = 0.8
+    scale_down_unneeded_time         = "2m"
+  }
 }
 `, testClusterVersion, rName)
 }


### PR DESCRIPTION
This PR adds the `ClusterAutoscalerConfiguration` with the `scale_down_utilization_threshold` and the `scale_down_unneeded_time` fields.