### PR TITLE
kubernetes: protect against panic in flattenControlPlaneFirewallOpts

### DIFF
--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -277,6 +277,10 @@ func flattenMaintPolicyOpts(opts *godo.KubernetesMaintenancePolicy) []map[string
 
 func flattenControlPlaneFirewallOpts(opts *godo.KubernetesControlPlaneFirewall) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
+	if opts == nil {
+		return result
+	}
+
 	item := make(map[string]interface{})
 
 	item["enabled"] = opts.Enabled


### PR DESCRIPTION
`control_plane_firewall` is nullable. When attempting to flatten a k8s cluster without it set causes a panic. This can be seen running the acceptance tests, e.g.:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanKubernetesCluster_Basic'
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe2bcd9]

goroutine 271 [running]:
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes.flattenControlPlaneFirewallOpts(...)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes/kubernetes.go:282
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes.digitaloceanKubernetesClusterRead(0xc0009d4388, 0xc00012e240, 0xc000b46d00)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes/resource_kubernetes_cluster.go:422 +0x6f9
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes.resourceDigitalOceanKubernetesClusterRead({0xc0009d4388?, 0x123898f?}, 0xc000b46d00, {0x10d5760?, 0xc000579d70?})
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes/resource_kubernetes_cluster.go:397 +0x1c9
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes.resourceDigitalOceanKubernetesClusterCreate({0x1489770, 0xc0005b0770}, 0xc000b46d00, {0x10d5760, 0xc000579d70})
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes/resource_kubernetes_cluster.go:381 +0xd36
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc000738e00, {0x14896c8, 0xc00078cd20}, 0xc000b46d00, {0x10d5760, 0xc000579d70})
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:707 +0x10f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000738e00, {0x14896c8, 0xc00078cd20}, 0xc0006b6a90, 0xc000b46b80, {0x10d5760, 0xc000579d70})
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:837 +0xa3e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000d00420, {0x14896c8?, 0xc00078cc90?}, 0xc000c19220)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:1021 +0xd5c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00058d0e0, {0x14896c8?, 0xc00078c2a0?}, 0xc0005b0150)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go:818 +0x548
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x11e0d80, 0xc00058d0e0}, {0x14896c8, 0xc00078c2a0}, 0xc0005b00e0, 0x0)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000d83c0, {0x148f680, 0xc0001241a0}, 0xc0001fc240, 0xc00077ee40, 0x1cab7c0, 0x0)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:1335 +0xdb8
google.golang.org/grpc.(*Server).handleStream(0xc0000d83c0, {0x148f680, 0xc0001241a0}, 0xc0001fc240, 0x0)
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:1712 +0x9da
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:947 +0xaf
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 225
        /home/asb/projects/go/src/github.com/digitalocean/terraform-provider-digitalocean/vendor/google.golang.org/grpc/server.go:958 +0x136
FAIL    github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes 257.602s
```

The same test passes after this change.

Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1315