### PR TITLE
Fix typo in code comment

### DIFF
--- a/vendor/github.com/google/go-cmp/cmp/report_slices.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_slices.go
@@ -528,7 +528,7 @@ func coalesceInterveningIdentical(groups []diffStats, windowSize int) []diffStat
 
 // cleanupSurroundingIdentical scans through all unequal groups, and
 // moves any leading sequence of equal elements to the preceding equal group and
-// moves and trailing sequence of equal elements to the succeeding equal group.
+// moves any trailing sequence of equal elements to the succeeding equal group.
 //
 // This is necessary since coalesceInterveningIdentical may coalesce edit groups
 // together such that leading/trailing spans of equal elements becomes possible.

--- a/vendor/github.com/hashicorp/terraform-exec/tfexec/options.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfexec/options.go
@@ -79,7 +79,7 @@ func Config(path string) *ConfigOption {
 }
 
 // CopyStateOption represents the -state flag for terraform workspace new. This flag is used
-// to copy an existing state file in to the new workspace.
+// to copy an existing state file into the new workspace.
 type CopyStateOption struct {
 	path string
 }

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_importer.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_importer.go
@@ -18,7 +18,7 @@ type ResourceImporter struct {
 	// insert into the Terraform state.
 	//
 	// Deprecated: State is deprecated in favor of StateContext.
-	// Only one of the two functions can bet set.
+	// Only one of the two functions can be set.
 	State StateFunc
 
 	// StateContext is called to convert an ID to one or more InstanceState to


### PR DESCRIPTION
Minor typo fixes in comments.

Changed files:
- vendor/github.com/google/go-cmp/cmp/report_slices.go
- vendor/github.com/hashicorp/terraform-exec/tfexec/options.go
- vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_importer.go


This change does not include functional changes.