### PR TITLE
Add automatically generated github release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - feature
+    - title: Updated Functionality for Existing Resources ⚙
+      labels:
+        - enhancement
+        - enhancement-provider
+    - title: Bug Fixes🧑‍🔧 🐞
+      labels:
+        - bug 
+    - title: Miscellaneous 📚
+      labels:
+        - misc
+        - docs
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Change Log
+
+Changelog moved to Release Notes in [Github Releases](https://github.com/digitalocean/terraform-provider-digitalocean/releases)
+
 ## 2.48.2
 
 BUGFIXES:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,25 +159,39 @@ Releasing the Provider
 ----------------------
 The dedicated DigitalOcean team is responsible for releasing the provider.
 
-To release the provider:
+#### To release the provider:
 
-1. Use
-   [github-changelog-generator](https://github.com/digitalocean/github-changelog-generator)
-   to list the changes since the last release and decide what kind of release
-   you are doing (bugfix, feature or breaking).
-1. Create a new commit that only contains updates to
-   [CHANGELOG.md](CHANGELOG.md) listing the respective changes for the new
-   version. Godo follows [semver](https://www.semver.org/) versioning
-   semantics.
-1. Once the CHANGELOG.md commit is merged, create a new tag on that commit with
-   the new version that will be released (be sure to pull the latest from
-   git).
+1. Pull the latest changes from the `main` branch
 
    ```bash
-   git tag -m "release $new_version" -a "$new_version"
+   git checkout main; git pull
    ```
 
-1. Push the tag:
+2. Ensure that each PR has the correct label.
+    - **bug**: For fixes related to issues or bugs.
+    - **enhancement**: For changes or improvements to existing resources.
+    - **feature**: For the addition of new resources or functionality.
+    - **misc**: For non-user-impacting changes, such as updates to tests or documentation. 
+
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; These labels categorize PRs in the [GitHub Release Notes](https://github.com/digitalocean/terraform-provider-digitalocean/releases). 
+
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; You can get a list of PRs to release with [github-changelog-generator](https://github.com/digitalocean/github-changelog-generator). It shows the changes since the last release.
+
+3. Determine the new release version.  
+   PR labels determine the release version type: *patch*, *minor*, or *major*.  
+   terraform-provider-digitalocean follows [semver](https://www.semver.org/) versioning
+   semantics.  
+   For example:
+    - bug, misc, doc: A bug fix results in a *patch* version increment (e.g., 1.2.3 → 1.2.4).
+    - feature, enhancement: A new feature results in a *minor* version increment (e.g., 1.2.3 → 1.3.0).
+    - breaking-change: A breaking change results in a *major* version increment (e.g., 1.2.3 → 2.0.0).
+4. Once all PRs to release have labels and the version increment is decided, create a new tag with the new version.  
+
+   ```bash
+   export new_version=<new-version>; git tag -m "release $new_version" -a "$new_version"
+   ```
+
+5. Push the tag:
 
    ```bash
    git push "$origin" tag "$new_version"


### PR DESCRIPTION
This change generates automatic notes on github release.

![Screenshot from 2025-02-20 10-51-00](https://github.com/user-attachments/assets/d5dbe6a9-91a1-4fd3-a173-51c4afef6910)
