### PR TITLE
docs: fix typo in error codes that are retried

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ The following arguments are supported:
   to `0.0` (Defaults to the value of the `DIGITALOCEAN_REQUESTS_PER_SECOND` environment
   variable or `0.0` if unset).
 * `http_retry_max` - (Optional) This can be used to override the maximum number
-  of retries on a failed API request (client errors, 422, 500, 502...), the exponential 
+  of retries on a failed API request (client errors, 429, 500, 502...), the exponential 
   backoff can be configured by the `http_retry_wait_min` and `http_retry_wait_max` arguments 
   (Defaults to the value of the `DIGITALOCEAN_HTTP_RETRY_MAX` environment variable or
   `4` if unset).


### PR DESCRIPTION
Happened to notice a small typo here. 422 errors are not retried as they a user error. 429 errors due to rate limiting are retried after a backoff.