### PR TITLE
docs: update links to API reference

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -248,7 +248,7 @@ A `service` can contain:
 - `source_dir` - An optional path to the working directory to use for the build.
 - `run_command` - An optional run command to override the component's default.
 - `environment_slug` - An environment slug describing the type of this app.
-- `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/api-reference/#operation/list_instance_sizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
+- `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Apps/operation/apps_list_instanceSizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
 - `instance_count` - The amount of instances that this component should be scaled to.
 - `http_port` - The internal port on which this service's run command will listen.
 - `internal_ports` - A list of ports on which this service will listen for internal traffic.
@@ -369,7 +369,7 @@ A `worker` can contain:
 - `source_dir` - An optional path to the working directory to use for the build.
 - `run_command` - An optional run command to override the component's default.
 - `environment_slug` - An environment slug describing the type of this app.
-- `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/api-reference/#operation/list_instance_sizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
+- `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Apps/operation/apps_list_instanceSizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
 - `instance_count` - The amount of instances that this component should be scaled to.
 - `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication. Only one of `git`, `github` or `gitlab` may be set
   - `repo_clone_url` - The clone URL of the repo.
@@ -444,7 +444,7 @@ A `job` can contain:
 - `source_dir` - An optional path to the working directory to use for the build.
 - `run_command` - An optional run command to override the component's default.
 - `environment_slug` - An environment slug describing the type of this app.
-- `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/api-reference/#operation/list_instance_sizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
+- `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Apps/operation/apps_list_instanceSizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
 - `instance_count` - The amount of instances that this component should be scaled to.
 - `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication. Only one of `git`, `github` or `gitlab` may be set
   - `repo_clone_url` - The clone URL of the repo.

--- a/docs/resources/custom_image.md
+++ b/docs/resources/custom_image.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `url` - (Required) A URL from which the custom Linux virtual machine image may be retrieved.
 * `regions` - (Required) A list of regions. (Currently only one is supported).
 * `description` - An optional description for the image.
-* `distribution` - An optional distribution name for the image. Valid values are documented [here](https://docs.digitalocean.com/reference/api/api-reference/#operation/create_custom_image)
+* `distribution` - An optional distribution name for the image. Valid values are documented [here](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Images/operation/images_create_custom)
 * `tags` - A list of optional tags for the image.
 
 ## Attributes Reference

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -118,11 +118,11 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the database cluster.
 * `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL, `mysql` for MySQL, `redis` for Redis, `mongodb` for MongoDB, or `kafka` for Kafka).
-* `size` - (Required) Database Droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`). See here for a [list of valid size slugs](https://docs.digitalocean.com/reference/api/api-reference/#tag/Databases).
+* `size` - (Required) Database Droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`). See the DigitalOcean API for a [list of valid size slugs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_list_options).
 * `region` - (Required) DigitalOcean region where the cluster will reside.
 * `node_count` - (Required) Number of nodes that will be included in the cluster. For `kafka` clusters, this must be 3.
 * `version` - (Required) Engine version used by the cluster (ex. `14` for PostgreSQL 14).
-  When this value is changed, a call to the [Upgrade major Version for a Database](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_update_major_version) API operation is made with the new version.
+  When this value is changed, a call to the [Upgrade major Version for a Database](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_update_major_version) API operation is made with the new version.
 * `tags` - (Optional) A list of tag names to be applied to the database cluster.
 * `private_network_uuid` - (Optional) The ID of the VPC where the database cluster will be located.
 * `project_id` - (Optional) The ID of the project that the database cluster is assigned to. If excluded when creating a new database cluster, it will be assigned to your default project.

--- a/docs/resources/database_kafka_config.md
+++ b/docs/resources/database_kafka_config.md
@@ -47,7 +47,7 @@ resource "digitalocean_database_cluster" "example" {
 
 ## Argument Reference
 
-The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_patch_config)
 for additional details on each option.
 
 * `cluster_id` - (Required)  The ID of the target Kafka cluster.

--- a/docs/resources/database_mongodb_config.md
+++ b/docs/resources/database_mongodb_config.md
@@ -35,7 +35,7 @@ resource "digitalocean_database_cluster" "example" {
 
 ## Argument Reference
 
-The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_patch_config)
 for additional details on each option.
 
 * `cluster_id` - (Required)  The ID of the target MongoDB cluster.

--- a/docs/resources/database_mysql_config.md
+++ b/docs/resources/database_mysql_config.md
@@ -32,7 +32,7 @@ resource "digitalocean_database_cluster" "example" {
 
 ## Argument Reference
 
-The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_patch_config)
 for additional details on each option.
 
 * `cluster_id` - (Required)  The ID of the target MySQL cluster.

--- a/docs/resources/database_opensearch_config.md
+++ b/docs/resources/database_opensearch_config.md
@@ -68,7 +68,7 @@ resource "digitalocean_database_cluster" "example" {
 
 ## Argument Reference
 
-The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_patch_config)
 for additional details on each option.
 
 * `cluster_id` - (Required) The ID of the target Opensearch cluster.

--- a/docs/resources/database_postgresql_config.md
+++ b/docs/resources/database_postgresql_config.md
@@ -31,7 +31,7 @@ resource "digitalocean_database_cluster" "example" {
 
 ## Argument Reference
 
-The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_patch_config)
 for additional details on each option.
 
 * `cluster_id` - (Required)  The ID of the target PostgreSQL cluster.

--- a/docs/resources/database_redis_config.md
+++ b/docs/resources/database_redis_config.md
@@ -33,7 +33,7 @@ resource "digitalocean_database_cluster" "example" {
 
 ## Argument Reference
 
-The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_patch_config)
+The following arguments are supported. See the [DigitalOcean API documentation](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_patch_config)
 for additional details on each option. 
 
 

--- a/docs/resources/droplet.md
+++ b/docs/resources/droplet.md
@@ -53,7 +53,7 @@ The following arguments are supported:
   is enabled. This parameter has been deprecated. Use `vpc_uuid` instead to specify a VPC network for the Droplet. If no `vpc_uuid` is provided, the Droplet will be placed in your account's default VPC for the region.
 * `ssh_keys` - (Optional) A list of SSH key IDs or fingerprints to enable in
    the format `[12345, 123456]`. To retrieve this info, use the
-   [DigitalOcean API](https://docs.digitalocean.com/reference/api/api-reference/#tag/SSH-Keys)
+   [DigitalOcean API](https://docs.digitalocean.com/reference/api/digitalocean/#tag/SSH-Keys)
    or CLI (`doctl compute ssh-key list`). Once a Droplet is created keys can not
    be added or removed via this provider. Modifying this field will prompt you
    to destroy and recreate the Droplet.

--- a/docs/resources/monitor_alert.md
+++ b/docs/resources/monitor_alert.md
@@ -5,12 +5,10 @@ subcategory: "Monitoring"
 
 # digitalocean_monitor_alert
 
-Provides a [DigitalOcean Monitoring](https://docs.digitalocean.com/reference/api/api-reference/#tag/Monitoring)
+Provides a [DigitalOcean Monitoring](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Monitoring)
 resource. Monitor alerts can be configured to alert about, e.g., disk or memory
 usage exceeding a certain threshold or traffic at a certain limit. Notifications
 can be sent to either an email address or a Slack channel.
-
--> **Note** Currently, the [DigitalOcean API](https://docs.digitalocean.com/reference/api/api-reference/#operation/create_alert_policy) only supports creating alerts for Droplets.
 
 ### Basic Example
 

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -72,4 +72,4 @@ Records can be imported using the domain name and record `id` when joined with a
 terraform import digitalocean_record.example_record example.com,12345678
 ```
 
-~>  You find the `id` of the records [using the DigitalOcean API](https://docs.digitalocean.com/reference/api/api-reference/#operation/domains_list_records) or CLI. Run the follow command to list the IDs for all DNS records on a domain: `doctl compute domain records list <domain.name>`
+~>  You find the `id` of the records [using the DigitalOcean API](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Domain-Records/operation/domains_list_records) or CLI. Run the follow command to list the IDs for all DNS records on a domain: `doctl compute domain records list <domain.name>`

--- a/docs/resources/uptime_alert.md
+++ b/docs/resources/uptime_alert.md
@@ -5,8 +5,8 @@ subcategory: "Monitoring"
 
 # digitalocean_uptime_alert
 
-Provides a [DigitalOcean Uptime Alerts](https://docs.digitalocean.com/reference/api/api-reference/#operation/uptime_alert_create)
-resource. Uptime Alerts provide the ability to add alerts to your [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/api-reference/#tag/Uptime) when your endpoints are slow, unavailable, or SSL certificates are expiring.
+Provides a [DigitalOcean Uptime Alerts](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Uptime/operation/uptime_create_alert)
+resource. Uptime Alerts provide the ability to add alerts to your [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Uptime) when your endpoints are slow, unavailable, or SSL certificates are expiring.
 
 
 ### Basic Example

--- a/docs/resources/uptime_check.md
+++ b/docs/resources/uptime_check.md
@@ -5,7 +5,7 @@ subcategory: "Monitoring"
 
 # digitalocean_uptime_check
 
-Provides a [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/api-reference/#tag/Uptime)
+Provides a [DigitalOcean Uptime Checks](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Uptime)
 resource. Uptime Checks provide the ability to monitor your endpoints from around the world, and alert you when they're slow, unavailable, or SSL certificates are expiring.
 
 

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -5,7 +5,7 @@ subcategory: "Networking"
 
 # digitalocean_vpc
 
-Provides a [DigitalOcean VPC](https://docs.digitalocean.com/reference/api/api-reference/#tag/VPCs) resource.
+Provides a [DigitalOcean VPC](https://docs.digitalocean.com/reference/api/digitalocean/#tag/VPCs) resource.
 
 VPCs are virtual networks containing resources that can communicate with each
 other in full isolation, using private IP addresses.


### PR DESCRIPTION
Working on https://github.com/digitalocean/terraform-provider-digitalocean/pull/1336, I realized there are more broken API reference links. :disappointed:  

It looks like there is a redirect in place, but it does not retain the URL fragment. For example:

`https://docs.digitalocean.com/reference/api/api-reference/#tag/VPCs` redirects to `https://docs.digitalocean.com/reference/api/digitalocean/` rather than `https://docs.digitalocean.com/reference/api/digitalocean/#tag/VPCs`