### PR TITLE
load balancers: fix importing global LBs

### DIFF
--- a/digitalocean/loadbalancer/datasource_loadbalancer.go
+++ b/digitalocean/loadbalancer/datasource_loadbalancer.go
@@ -67,6 +67,10 @@ func DataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				Computed:    true,
 				Description: "current state of the Load Balancer",
 			},
+			"ipv6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"forwarding_rule": {
 				Type:     schema.TypeSet,
 				Computed: true,

--- a/digitalocean/loadbalancer/datasource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/datasource_loadbalancer_test.go
@@ -791,8 +791,8 @@ resource "digitalocean_droplet" "foobar" {
 }
 
 resource "digitalocean_loadbalancer" "lorem" {
-  name    = "%s"
-  type    = "GLOBAL"
+  name = "%s"
+  type = "GLOBAL"
 
   healthcheck {
     port     = 80

--- a/digitalocean/loadbalancer/datasource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/datasource_loadbalancer_test.go
@@ -42,7 +42,7 @@ data "digitalocean_loadbalancer" "foobar" {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "size_unit", "1"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "type", ""),
+						"data.digitalocean_loadbalancer.foobar", "type", "REGIONAL"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(
@@ -112,7 +112,7 @@ data "digitalocean_loadbalancer" "foobar" {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "size_unit", "1"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "type", ""),
+						"data.digitalocean_loadbalancer.foobar", "type", "REGIONAL"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(
@@ -178,7 +178,7 @@ data "digitalocean_loadbalancer" "foobar" {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "size_unit", "6"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "type", ""),
+						"data.digitalocean_loadbalancer.foobar", "type", "REGIONAL"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(
@@ -242,7 +242,7 @@ data "digitalocean_loadbalancer" "foobar" {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "size_unit", "6"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "type", ""),
+						"data.digitalocean_loadbalancer.foobar", "type", "REGIONAL"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(
@@ -645,7 +645,7 @@ data "digitalocean_loadbalancer" "foobar" {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "type", "GLOBAL"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "glb_settings.0.target_protocol", "HTTP"),
+						"data.digitalocean_loadbalancer.foobar", "glb_settings.0.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "glb_settings.0.target_port", "80"),
 					resource.TestCheckResourceAttr(
@@ -793,7 +793,6 @@ resource "digitalocean_droplet" "foobar" {
 resource "digitalocean_loadbalancer" "lorem" {
   name    = "%s"
   type    = "GLOBAL"
-  network = "EXTERNAL"
 
   healthcheck {
     port     = 80

--- a/digitalocean/loadbalancer/import_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/import_loadbalancer_test.go
@@ -28,3 +28,25 @@ func TestAccDigitalOceanLoadBalancer_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDigitalOceanLoadBalancer_importGLB(t *testing.T) {
+	resourceName := "digitalocean_loadbalancer.foobar"
+	name := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanGlobalLoadbalancerConfig_basic(name),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/digitalocean/loadbalancer/loadbalancer.go
+++ b/digitalocean/loadbalancer/loadbalancer.go
@@ -324,11 +324,12 @@ func flattenDomains(client *godo.Client, domains []*godo.LBDomain) ([]map[string
 
 		r["name"] = (*domain).Name
 		r["is_managed"] = (*domain).IsManaged
-		r["certificate_id"] = (*domain).CertificateID
 		r["verification_error_reasons"] = (*domain).VerificationErrorReasons
 		r["ssl_validation_error_reasons"] = (*domain).SSLValidationErrorReasons
 
 		if domain.CertificateID != "" {
+			r["certificate_id"] = (*domain).CertificateID
+
 			// When the certificate type is lets_encrypt, the certificate
 			// ID will change when it's renewed, so we have to rely on the
 			// certificate name as the primary identifier instead.
@@ -350,7 +351,7 @@ func flattenGLBSettings(settings *godo.GLBSettings) []map[string]interface{} {
 	if settings != nil {
 		r := make(map[string]interface{})
 
-		r["target_protocol"] = (*settings).TargetProtocol
+		r["target_protocol"] = strings.ToLower((*settings).TargetProtocol)
 		r["target_port"] = (*settings).TargetPort
 
 		if settings.CDN != nil {

--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -778,45 +778,45 @@ func resourceDigitalOceanLoadbalancerRead(ctx context.Context, d *schema.Resourc
 	d.Set("disable_lets_encrypt_dns_records", loadbalancer.DisableLetsEncryptDNSRecords)
 
 	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer droplet_ids - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer droplet_ids: %#v", err)
 	}
 
 	if err := d.Set("sticky_sessions", flattenStickySessions(loadbalancer.StickySessions)); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer sticky_sessions - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer sticky_sessions: %#v", err)
 	}
 
 	if err := d.Set("healthcheck", flattenHealthChecks(loadbalancer.HealthCheck)); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer healthcheck - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer healthcheck: %#v", err)
 	}
 
 	forwardingRules, err := flattenForwardingRules(client, loadbalancer.ForwardingRules)
 	if err != nil {
-		return diag.Errorf("[DEBUG] Error building Load Balancer forwarding rules - error: %#v", err)
+		return diag.Errorf("Error building  load balancer forwarding rules: %#v", err)
 	}
 
 	if err := d.Set("forwarding_rule", forwardingRules); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer forwarding_rule - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer forwarding_rule: %#v", err)
 	}
 
 	if err := d.Set("firewall", flattenLBFirewall(loadbalancer.Firewall)); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer firewall - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer firewall: %#v", err)
 	}
 
 	domains, err := flattenDomains(client, loadbalancer.Domains)
 	if err != nil {
-		return diag.Errorf("[DEBUG] Error building Load Balancer domains - error: %#v", err)
+		return diag.Errorf("Error building  load balancer domains: %#v", err)
 	}
 
 	if err := d.Set("domains", domains); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer domains - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer domains: %#v", err)
 	}
 
 	if err := d.Set("glb_settings", flattenGLBSettings(loadbalancer.GLBSettings)); err != nil {
-		return diag.Errorf("[DEBUG] Error setting Load Balancer glb settings - error: %#v", err)
+		return diag.Errorf("Error setting  load balancer glb_settings: %#v", err)
 	}
 
 	if err := d.Set("target_load_balancer_ids", flattenLoadBalancerIds(loadbalancer.TargetLoadBalancerIDs)); err != nil {
-		return diag.Errorf("[DEBUG] Error setting target Load Balancer ids - error: %#v", err)
+		return diag.Errorf("Error setting target load balancer IDs: %#v", err)
 	}
 
 	return nil

--- a/digitalocean/loadbalancer/resource_loadbalancer_test.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer_test.go
@@ -875,8 +875,6 @@ func TestAccDigitalOceanGlobalLoadbalancer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "domains.0.name", "test-2.github.io"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.lorem", "droplet_ids.#", "1"),
-					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "target_load_balancer_ids.#", "1"),
 				),
 			},
@@ -895,19 +893,17 @@ func TestAccDigitalOceanGlobalLoadbalancer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "glb_settings.0.cdn.0.is_enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "glb_settings.0.region_priorities.%", "2"),
+						"digitalocean_loadbalancer.lorem", "glb_settings.0.region_priorities.%", "2"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "glb_settings.0.region_priorities.nyc1", "1"),
+						"digitalocean_loadbalancer.lorem", "glb_settings.0.region_priorities.nyc1", "1"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "glb_settings.0.region_priorities.nyc2", "2"),
+						"digitalocean_loadbalancer.lorem", "glb_settings.0.region_priorities.nyc2", "2"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "domains.#", "2"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "domains.1.name", "test-updated.github.io"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "domains.0.name", "test-updated-2.github.io"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.lorem", "droplet_ids.#", "1"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.lorem", "target_load_balancer_ids.#", "1"),
 				),
@@ -1402,7 +1398,6 @@ resource "digitalocean_loadbalancer" "lorem" {
     is_managed = false
   }
 
-  droplet_ids              = [digitalocean_droplet.foobar.id]
   target_load_balancer_ids = [digitalocean_loadbalancer.foobar.id]
 }`, name, name, name)
 }
@@ -1474,7 +1469,6 @@ resource "digitalocean_loadbalancer" "lorem" {
     is_managed = false
   }
 
-  droplet_ids              = [digitalocean_droplet.foobar.id]
   target_load_balancer_ids = [digitalocean_loadbalancer.foobar.id]
 }`, name, name, name)
 }


### PR DESCRIPTION
This fixes importing global load balancers. We were not setting the GLB related attributes in the read method, so they were not set on import. This required setting the `type` attribute to `Computed`. There are also some related test fix ups as well as a new test for importing GLBs. Finally, I cleaned up some of the error messages (No need to preface them with `[DEBUG]`).

Fixes: #1338