### PR TITLE
add routing_agent option to kubernetes cluster

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -61,6 +61,21 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				},
 			},
 
+			routingAgentField: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"version": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -53,6 +53,7 @@ data "digitalocean_kubernetes_cluster" "foobar" {
 					resource.TestCheckResourceAttrSet("data.digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.duration"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_utilization_threshold", "0.5"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_unneeded_time", "1m30s"),
+					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "routing_agent.0.enabled", "true"),
 				),
 			},
 		},
@@ -86,6 +87,10 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   cluster_autoscaler_configuration {
     scale_down_utilization_threshold = 0.5
     scale_down_unneeded_time         = "1m30s"
+  }
+
+  routing_agent {
+	enabled = true
   }
 }`, version, rName)
 }

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -90,7 +90,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   }
 
   routing_agent {
-	enabled = true
+    enabled = true
   }
 }`, version, rName)
 }

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -263,6 +263,34 @@ func expandAllowedAddresses(addrs []interface{}) []string {
 	return expandedAddrs
 }
 
+func expandRoutingAgentOpts(raw []interface{}) *godo.KubernetesRoutingAgent {
+	if len(raw) == 0 || raw[0] == nil {
+		return &godo.KubernetesRoutingAgent{}
+	}
+
+	rawRoutingAgentObj := raw[0].(map[string]interface{})
+
+	routingAgent := &godo.KubernetesRoutingAgent{
+		Enabled: godo.PtrTo(rawRoutingAgentObj["enabled"].(bool)),
+	}
+
+	return routingAgent
+}
+
+func flattenRoutingAgentOpts(opts *godo.KubernetesRoutingAgent) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	if opts == nil {
+		return result
+	}
+
+	item := make(map[string]interface{})
+	item["enabled"] = opts.Enabled
+
+	result = append(result, item)
+
+	return result
+}
+
 func flattenMaintPolicyOpts(opts *godo.KubernetesMaintenancePolicy) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 	item := make(map[string]interface{})

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -96,6 +96,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "destroy_all_associated_resources", "false"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_utilization_threshold"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.scale_down_unneeded_time"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "routing_agent.0.enabled", "false"),
 				),
 			},
 			// Update: remove default node_pool taints
@@ -893,6 +894,26 @@ func TestAccDigitalOceanKubernetesCluster_VPCNative(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanKubernetesCluster_RoutingAgentEnabled(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigRoutingAgentEnabled(testClusterVersionPrevious, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "routing_agent.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDigitalOceanKubernetesConfigBasic(testClusterVersion string, rName string) string {
 	return fmt.Sprintf(`%s
 
@@ -1169,6 +1190,25 @@ func testAccCheckDigitalOceanKubernetesClusterDestroy(s *terraform.State) error 
 	}
 
 	return nil
+}
+
+func testAccDigitalOceanKubernetesConfigRoutingAgentEnabled(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name           = "%s"
+  region         = "nyc1"
+  version        = data.digitalocean_kubernetes_versions.test.latest_version
+  routing_agent  = {
+	enabled = true
+  } 
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
 }
 
 func testAccCheckDigitalOceanKubernetesClusterExists(n string, cluster *godo.KubernetesCluster) resource.TestCheckFunc {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -1196,12 +1196,12 @@ func testAccDigitalOceanKubernetesConfigRoutingAgentEnabled(testClusterVersion s
 	return fmt.Sprintf(`%s
 
 resource "digitalocean_kubernetes_cluster" "foobar" {
-  name           = "%s"
-  region         = "nyc1"
-  version        = data.digitalocean_kubernetes_versions.test.latest_version
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
   routing_agent {
-	enabled = true
-  } 
+    enabled = true
+  }
   node_pool {
     name       = "default"
     size       = "s-1vcpu-2gb"

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -1199,7 +1199,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name           = "%s"
   region         = "nyc1"
   version        = data.digitalocean_kubernetes_versions.test.latest_version
-  routing_agent  = {
+  routing_agent {
 	enabled = true
   } 
   node_pool {


### PR DESCRIPTION
Tested manually:
- [x] create new cluster w/ routing-agent enabled
- [x] create new cluster w/o routing-agent enabled and update to having routing-agent enabled
- [x] import existing cluster w/ routing-agent enabled


Acceptance tests:
- [x] ran from local env `make testacc TESTARGS='-run=TestAccDigitalOceanKubernetesCluster_RoutingAgentEnabled'` (success)
- [ ] running `make testacc PKG_NAME=digitalocean/kubernetes` had varying errors, vpc subnet overlay, no duplicate registry per project allowed..., which makes me think this should really not run in my dev account :-) LMK if this is not good to go as is, I wasn't able to validate the changed `TestAccDataSourceDigitalOceanKubernetesCluster_Basic`, it's failing with a terraform provider version error, pasting below.

```
=== NAME  TestAccDataSourceDigitalOceanKubernetesCluster_Basic
    datasource_kubernetes_cluster_test.go:26: TestCase error running init: exit status 1

        Error: Incompatible provider version

        Provider registry.terraform.io/hashicorp/kubernetes v1.13.2 does not have a
        package available for your current platform, darwin_arm64.

        Provider releases are separate from Terraform CLI releases, so not all
        providers are available for all platforms. Other versions of this provider
        may have different platforms supported.
```