### PR TITLE
Kubernetes: Add support for autoscaling to zero

### DIFF
--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -71,9 +71,8 @@ func nodePoolSchema(isResource bool) map[string]*schema.Schema {
 		},
 
 		"min_nodes": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			ValidateFunc: validation.IntAtLeast(1),
+			Type:     schema.TypeInt,
+			Optional: true,
 		},
 
 		"max_nodes": {

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -53,7 +53,8 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 }
 ```
 
-Note that, each node pool must always have at least one node and when using autoscaling the min_nodes must be greater than or equal to 1.
+Note that, currently, each node pool must always have at least one node and when using autoscaling the min_nodes must be greater than or equal to 1.
+> Autoscaling to zero (`min_nodes=0`) is in [private preview](https://docs.digitalocean.com/release-notes/kubernetes/#2025-01-07) and not available for public use.
 
 ### Auto Upgrade Example
 


### PR DESCRIPTION
This feature is in private preview and not available for public use. Will add another PR for more guardrails such asvalidating node count for a cluster is greater than 1 before allowing a min_nodes=0

```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestAccDigitalOceanKubernetesNodePool_MinNodesZero$ github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes

ok  	github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes	0.662s
```
