### PR TITLE
Issue-1364:- Allow node count to be zero

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -128,7 +128,6 @@ func testAccCheckDataSourceDigitalOceanKubernetesClusterExists(n string, cluster
 func TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero(t *testing.T) {
 	rName := acceptance.RandomTestName()
 	var k8s godo.KubernetesCluster
-	var k8sPool godo.KubernetesNodePool
 
 	clusterConfig := fmt.Sprintf(`%s
 resource "digitalocean_kubernetes_cluster" "foobar" {
@@ -146,32 +145,15 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 }
 `, testClusterVersionLatest, rName)
 
-	nodePoolConfig := fmt.Sprintf(`resource "digitalocean_kubernetes_node_pool" "barfoo" {
-  cluster_id = digitalocean_kubernetes_cluster.foobar.id
-
-  name       = "%s"
-  size       = "s-1vcpu-2gb"
-  auto_scale = true
-  min_nodes  = 0
-  max_nodes  = 3
-  tags       = ["three", "four"]
-}
-`, rName)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: clusterConfig + nodePoolConfig,
+				Config: clusterConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
-					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "name", rName),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "auto_scale", "true"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "min_nodes", "0"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "max_nodes", "3"),
 				),
 			},
 		},

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -124,3 +124,56 @@ func testAccCheckDataSourceDigitalOceanKubernetesClusterExists(n string, cluster
 		return nil
 	}
 }
+
+func TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+	var k8sPool godo.KubernetesNodePool
+
+	clusterConfig := fmt.Sprintf(`%s
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "lon1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  tags    = ["foo", "bar"]
+
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 0
+    tags       = ["one", "two"]
+  }
+}
+`, testClusterVersionLatest, rName)
+
+	nodePoolConfig := fmt.Sprintf(`resource "digitalocean_kubernetes_node_pool" "barfoo" {
+  cluster_id = digitalocean_kubernetes_cluster.foobar.id
+
+  name       = "%s"
+  size       = "s-1vcpu-2gb"
+  auto_scale = true
+  min_nodes  = 0
+  max_nodes  = 3
+  tags       = ["three", "four"]
+}
+`, rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: clusterConfig + nodePoolConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "name", rName),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "auto_scale", "true"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "min_nodes", "0"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "max_nodes", "3"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -34,9 +34,8 @@ func nodePoolSchema(isResource bool) map[string]*schema.Schema {
 		},
 
 		"node_count": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			ValidateFunc: validation.IntAtLeast(1),
+			Type:     schema.TypeInt,
+			Optional: true,
 			DiffSuppressFunc: func(key, old, new string, d *schema.ResourceData) bool {
 				nodeCountKey := "node_count"
 				actualNodeCountKey := "actual_node_count"


### PR DESCRIPTION
This PR has a fix for [Issue-1364](https://github.com/digitalocean/terraform-provider-digitalocean/issues/1364).

```
terraform-provider-digitalocean % TF_ACC=1 go test -v -run TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero ./digitalocean/kubernetes
=== RUN   TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero
=== PAUSE TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero
=== CONT  TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero
--- PASS: TestAccDataSourceDigitalOceanKubernetesCluster_NodeCountZero (115.33s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes 115.967s
```
