### PR TITLE
dbaas: initial valkey support

### DIFF
--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -33,12 +33,12 @@ resource "digitalocean_database_cluster" "mysql-example" {
 }
 ```
 
-### Create a new Redis database cluster
+### Create a new Valkey database cluster
 ```hcl
-resource "digitalocean_database_cluster" "redis-example" {
-  name       = "example-redis-cluster"
-  engine     = "redis"
-  version    = "7"
+resource "digitalocean_database_cluster" "valkey-example" {
+  name       = "example-valkey-cluster"
+  engine     = "valkey"
+  version    = "8"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -117,7 +117,7 @@ resource "digitalocean_database_cluster" "doby_backup" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the database cluster.
-* `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL, `mysql` for MySQL, `redis` for Redis, `mongodb` for MongoDB, or `kafka` for Kafka).
+* `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL, `mysql` for MySQL, `valkey` for Valkey, `mongodb` for MongoDB, or `kafka` for Kafka).
 * `size` - (Required) Database Droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`). See the DigitalOcean API for a [list of valid size slugs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Databases/operation/databases_list_options).
 * `region` - (Required) DigitalOcean region where the cluster will reside.
 * `node_count` - (Required) Number of nodes that will be included in the cluster. For `kafka` clusters, this must be 3.
@@ -126,7 +126,7 @@ The following arguments are supported:
 * `tags` - (Optional) A list of tag names to be applied to the database cluster.
 * `private_network_uuid` - (Optional) The ID of the VPC where the database cluster will be located.
 * `project_id` - (Optional) The ID of the project that the database cluster is assigned to. If excluded when creating a new database cluster, it will be assigned to your default project.
-* `eviction_policy` - (Optional) A string specifying the eviction policy for a Redis cluster. Valid values are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
+* `eviction_policy` - (Optional) A string specifying the eviction policy for a Valkey cluster. Valid values are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
 * `sql_mode` - (Optional) A comma separated string specifying the  SQL modes for a MySQL cluster.
 * `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
 * `storage_size_mib` - (Optional) Defines the disk size, in MiB, allocated to the cluster. This can be adjusted on MySQL and PostreSQL clusters based on predefined ranges for each slug/droplet size.


### PR DESCRIPTION
This treats `valkey` like `redis` in the `digitalocean_database_cluster` resource. It updates the validation for using `eviction_policy` and the `DiffSuppressFunc` that deals with the forced version upgrades to both work with Valkey as well.

There is still additional work to be done around Valkey support:

- Addition of a Valkey advanced configuration resource (`digitalocean_database_valkey_config`)
- Handle the path for converting existing Redis instances to Valkey

Those can come at a later date. This will unblock basic use cases.

Fixes: #1362