### PR TITLE
GLB fix domains certificate id/name on loadbalancers_resources

### DIFF
--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -475,6 +475,11 @@ func resourceDigitalOceanLoadBalancerV0() *schema.Resource {
 							ValidateFunc: validation.NoZeroValues,
 							Description:  "name of certificate required for TLS handshaking",
 						},
+						"certificate_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "certificate ID for TLS handshaking",
+						},
 						"verification_error_reasons": {
 							Type:        schema.TypeList,
 							Computed:    true,

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -161,7 +161,8 @@ the backend service. Default value is `false`.
 
 * `name` - (Required) The domain name to be used for ingressing traffic to a Global Load Balancer.
 * `is_managed` - (Optional) Control flag to specify whether the domain is managed by DigitalOcean.
-* `certificate_id` - (Optional) The certificate ID to be used for TLS handshaking.
+* `certificate_name` - (Optional) The certificate name to be used for TLS handshaking.
+* `certificate_id` - (Read Only) The certificate id associated with the domain used for TLS handshaking.
 
 `glb_settings` supports the following:
 


### PR DESCRIPTION
certificate_id is a read only attribute on the GLB domains. As such we should only be setting it on the datasources call to flatten domains as it doesnt exist in the resources schema.