### PR TITLE
spaces: add support for bucket logging

### DIFF
--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -189,6 +189,7 @@ func Provider() *schema.Provider {
 			"digitalocean_spaces_bucket_object":                  spaces.ResourceDigitalOceanSpacesBucketObject(),
 			"digitalocean_spaces_bucket_policy":                  spaces.ResourceDigitalOceanSpacesBucketPolicy(),
 			"digitalocean_spaces_key":                            spaces.ResourceDigitalOceanSpacesKey(),
+			"digitalocean_spaces_bucket_logging":                 spaces.ResourceDigitalOceanSpacesBucketLogging(),
 			"digitalocean_ssh_key":                               sshkey.ResourceDigitalOceanSSHKey(),
 			"digitalocean_tag":                                   tag.ResourceDigitalOceanTag(),
 			"digitalocean_uptime_check":                          uptime.ResourceDigitalOceanUptimeCheck(),

--- a/digitalocean/spaces/import_spaces_bucket_logging_test.go
+++ b/digitalocean/spaces/import_spaces_bucket_logging_test.go
@@ -1,0 +1,54 @@
+package spaces_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDigitalOceanSpacesBucketLogging_importBasic(t *testing.T) {
+	resourceName := "digitalocean_spaces_bucket_logging.example"
+	name := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanSpacesBucketLogging(name, "logs/"),
+			},
+
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s,", accessLoggingTestRegion),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "bucket",
+				ExpectError:       regexp.MustCompile(`importing a Spaces Bucket access logging configuration requires the format: <region>,<bucket>`),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "nyc2,",
+				ExpectError:       regexp.MustCompile(`importing a Spaces Bucket access logging configuration requires the format: <region>,<bucket>`),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     ",bucket",
+				ExpectError:       regexp.MustCompile(`importing a Spaces Bucket access logging configuration requires the format: <region>,<bucket>`),
+			},
+		},
+	})
+}

--- a/digitalocean/spaces/resource_spaces_bucket_logging.go
+++ b/digitalocean/spaces/resource_spaces_bucket_logging.go
@@ -1,0 +1,204 @@
+package spaces
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceDigitalOceanSpacesBucketLogging() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSpacesBucketLoggingCreate,
+		ReadContext:   resourceSpacesBucketLoggingRead,
+		UpdateContext: resourceSpacesBucketLoggingUpdate,
+		DeleteContext: resourceSpacesBucketLoggingDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDigitalOceanAccessLoggingImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(SpacesRegions, true),
+			},
+			"target_bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_prefix": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceSpacesBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	region := d.Get("region").(string)
+	client, err := meta.(*config.CombinedConfig).SpacesClient(region)
+	if err != nil {
+		return diag.Errorf("Error creating Spaces client: %s", err)
+	}
+
+	svc := s3.New(client)
+
+	bucket := d.Get("bucket").(string)
+	input := &s3.PutBucketLoggingInput{
+		Bucket: aws.String(bucket),
+		BucketLoggingStatus: &s3.BucketLoggingStatus{
+			LoggingEnabled: &s3.LoggingEnabled{
+				TargetBucket: aws.String(d.Get("target_bucket").(string)),
+				TargetPrefix: aws.String(d.Get("target_prefix").(string)),
+			},
+		},
+	}
+
+	err = retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
+		log.Printf("[DEBUG] Trying to enable access logging for Spaces Bucket (%s)", bucket)
+		_, err := svc.PutBucketLogging(input)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFound" {
+				log.Printf("[DEBUG] Waiting for Spaces Bucket (%s) to be available, retrying: %v", bucket, awsErr.Message())
+				return retry.RetryableError(err)
+			}
+		}
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return diag.Errorf("Error enabling Spaces access logging: %s", err)
+	}
+
+	d.SetId(bucket)
+
+	return resourceSpacesBucketLoggingRead(ctx, d, meta)
+}
+
+func resourceSpacesBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	region := d.Get("region").(string)
+	client, err := meta.(*config.CombinedConfig).SpacesClient(region)
+	if err != nil {
+		return diag.Errorf("Error creating Spaces client: %s", err)
+	}
+
+	svc := s3.New(client)
+	bucket := d.Id()
+	input := &s3.GetBucketLoggingInput{
+		Bucket: aws.String(bucket),
+	}
+
+	response, err := svc.GetBucketLogging(input)
+	if err != nil {
+		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
+			log.Printf("[WARN] Spaces Bucket (%s) not found; removing access logging from state", d.Id())
+			d.SetId("")
+			return nil
+		} else {
+			return diag.Errorf("Error reading access logging for Spaces Bucket (%s): %s", d.Id(), err)
+		}
+	}
+
+	d.Set("bucket", bucket)
+	if response.LoggingEnabled != nil {
+		d.Set("target_bucket", response.LoggingEnabled.TargetBucket)
+		d.Set("target_prefix", response.LoggingEnabled.TargetPrefix)
+	} else {
+		d.Set("target_bucket", "")
+		d.Set("target_prefix", "")
+	}
+
+	return nil
+}
+
+func resourceSpacesBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	region := d.Get("region").(string)
+	client, err := meta.(*config.CombinedConfig).SpacesClient(region)
+	if err != nil {
+		return diag.Errorf("Error creating Spaces client: %s", err)
+	}
+
+	svc := s3.New(client)
+	bucket := d.Id()
+
+	input := &s3.PutBucketLoggingInput{
+		Bucket: aws.String(bucket),
+		BucketLoggingStatus: &s3.BucketLoggingStatus{
+			LoggingEnabled: &s3.LoggingEnabled{
+				TargetBucket: aws.String(d.Get("target_bucket").(string)),
+				TargetPrefix: aws.String(d.Get("target_prefix").(string)),
+			},
+		},
+	}
+
+	_, err = svc.PutBucketLogging(input)
+	if err != nil {
+		return diag.Errorf("Error updating Spaces Bucket (%s) logging: %s", bucket, err)
+	}
+
+	return nil
+}
+
+func resourceSpacesBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	region := d.Get("region").(string)
+	client, err := meta.(*config.CombinedConfig).SpacesClient(region)
+	if err != nil {
+		return diag.Errorf("Error creating Spaces client: %s", err)
+	}
+
+	svc := s3.New(client)
+	bucket := d.Id()
+
+	input := &s3.PutBucketLoggingInput{
+		Bucket:              aws.String(bucket),
+		BucketLoggingStatus: &s3.BucketLoggingStatus{},
+	}
+
+	_, err = svc.PutBucketLogging(input)
+	if err != nil {
+		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
+			log.Printf("[WARN] Spaces Bucket (%s) not found; removing access logging from state", d.Id())
+			d.SetId("")
+			return nil
+		} else {
+			return diag.Errorf("Error disabling access logging for Spaces Bucket (%s): %s", d.Id(), err)
+		}
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanAccessLoggingImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if strings.Contains(d.Id(), ",") {
+		s := strings.Split(d.Id(), ",")
+
+		d.SetId(s[1])
+		d.Set("region", s[0])
+	}
+
+	if d.Id() == "" || d.Get("region") == "" {
+		return nil, fmt.Errorf("importing a Spaces Bucket access logging configuration requires the format: <region>,<bucket>")
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/digitalocean/spaces/resource_spaces_bucket_logging_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_logging_test.go
@@ -23,7 +23,7 @@ func TestAccDigitalOceanSpacesBucketLogging_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
+		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketLoggingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDigitalOceanSpacesBucketLogging(name, "logs/"),
@@ -46,7 +46,7 @@ func TestAccDigitalOceanSpacesBucketLogging_update(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
+		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketLoggingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDigitalOceanSpacesBucketLogging(name, initialPrefix),

--- a/digitalocean/spaces/resource_spaces_bucket_logging_test.go
+++ b/digitalocean/spaces/resource_spaces_bucket_logging_test.go
@@ -1,0 +1,138 @@
+package spaces_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	accessLoggingTestRegion = "nyc3"
+)
+
+func TestAccDigitalOceanSpacesBucketLogging_basic(t *testing.T) {
+	name := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanSpacesBucketLogging(name, "logs/"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "region", accessLoggingTestRegion),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "bucket", name+"-source"),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "target_bucket", name+"-target"),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "target_prefix", "logs/"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanSpacesBucketLogging_update(t *testing.T) {
+	name := acceptance.RandomTestName()
+	initialPrefix := "logs/"
+	updatedPrefix := "updated/"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanSpacesBucketPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanSpacesBucketLogging(name, initialPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "region", accessLoggingTestRegion),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "bucket", name+"-source"),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "target_bucket", name+"-target"),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "target_prefix", initialPrefix),
+				),
+			},
+			{
+				Config: testAccDigitalOceanSpacesBucketLogging(name, updatedPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "region", accessLoggingTestRegion),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "bucket", name+"-source"),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "target_bucket", name+"-target"),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket_logging.example", "target_prefix", updatedPrefix),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanSpacesBucketLoggingDestroy(s *terraform.State) error {
+	s3conn, err := testAccGetS3LoggingConn()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "digitalocean_spaces_bucket_logging":
+			_, err := s3conn.GetBucketLogging(&s3.GetBucketLoggingInput{
+				Bucket: aws.String(rs.Primary.Attributes["bucket"]),
+			})
+			if err == nil {
+				return fmt.Errorf("Spaces Bucket logging still exists: %s", rs.Primary.ID)
+			}
+
+		case "digitalocean_spaces_bucket":
+			_, err = s3conn.HeadBucket(&s3.HeadBucketInput{
+				Bucket: aws.String(rs.Primary.ID),
+			})
+			if err == nil {
+				return fmt.Errorf("Spaces Bucket still exists: %s", rs.Primary.ID)
+			}
+
+		default:
+			continue
+		}
+	}
+
+	return nil
+}
+
+func testAccGetS3LoggingConn() (*s3.S3, error) {
+	client, err := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).SpacesClient(accessLoggingTestRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	s3conn := s3.New(client)
+
+	return s3conn, nil
+}
+
+func testAccDigitalOceanSpacesBucketLogging(name, prefix string) string {
+	return fmt.Sprintf(`
+resource "digitalocean_spaces_bucket" "source" {
+  region        = "%s"
+  name          = "%s-source"
+  force_destroy = true
+}
+
+resource "digitalocean_spaces_bucket" "target" {
+  region        = "%s"
+  name          = "%s-target"
+  force_destroy = true
+}
+
+resource "digitalocean_spaces_bucket_logging" "example" {
+  region = "%s"
+  bucket = digitalocean_spaces_bucket.source.id
+
+  target_bucket = digitalocean_spaces_bucket.target.id
+  target_prefix = "%s"
+}
+`, accessLoggingTestRegion, name, accessLoggingTestRegion, name, accessLoggingTestRegion, prefix)
+}

--- a/docs/resources/spaces_bucket.md
+++ b/docs/resources/spaces_bucket.md
@@ -19,9 +19,9 @@ the provider's `spaces_access_id` and `spaces_secret_key` arguments to the
 access ID and secret you generate via the DigitalOcean control panel. For
 example:
 
-```
+```hcl
 provider "digitalocean" {
-  token             = var.digitalocean_token
+  token = var.digitalocean_token
 
   spaces_access_id  = var.access_id
   spaces_secret_key = var.secret_key

--- a/docs/resources/spaces_bucket_cors_configuration.md
+++ b/docs/resources/spaces_bucket_cors_configuration.md
@@ -20,9 +20,9 @@ the provider's `spaces_access_id` and `spaces_secret_key` arguments to the
 access ID and secret you generate via the DigitalOcean control panel. For
 example:
 
-```
+```hcl
 provider "digitalocean" {
-  token             = var.digitalocean_token
+  token = var.digitalocean_token
 
   spaces_access_id  = var.access_id
   spaces_secret_key = var.secret_key

--- a/docs/resources/spaces_bucket_logging.md
+++ b/docs/resources/spaces_bucket_logging.md
@@ -1,0 +1,81 @@
+---
+page_title: "DigitalOcean: digitalocean_spaces_bucket_logging"
+subcategory: "Spaces Object Storage"
+---
+
+# digitalocean\_spaces\_bucket\_logging
+
+Provides a bucket logging resource for Spaces, DigitalOcean's object storage product.
+The `digitalocean_spaces_bucket_logging` resource allows Terraform to configure access
+logging for Spaces buckets. For more information, see:
+[How to Configure Spaces Access Logs](https://docs.digitalocean.com/products/spaces/how-to/access-logs/)
+
+The [Spaces API](https://docs.digitalocean.com/reference/api/spaces-api/) was
+designed to be interoperable with Amazon's AWS S3 API. This allows users to
+interact with the service while using the tools they already know. Spaces
+mirrors S3's authentication framework and requests to Spaces require a key pair
+similar to Amazon's Access ID and Secret Key.
+
+The authentication requirement can be met by either setting the
+`SPACES_ACCESS_KEY_ID` and `SPACES_SECRET_ACCESS_KEY` environment variables or
+the provider's `spaces_access_id` and `spaces_secret_key` arguments to the
+access ID and secret you generate via the DigitalOcean control panel. For
+example:
+
+```hcl
+provider "digitalocean" {
+  token = var.digitalocean_token
+
+  spaces_access_id  = var.access_id
+  spaces_secret_key = var.secret_key
+}
+
+resource "digitalocean_spaces_bucket" "static-assets" {
+  # ...
+}
+```
+
+
+## Example Usage
+
+
+```hcl
+resource "digitalocean_spaces_bucket" "assets" {
+  name   = "assets"
+  region = "nyc3"
+}
+
+resource "digitalocean_spaces_bucket" "logs" {
+  name   = "logs"
+  region = "nyc3"
+}
+
+resource "digitalocean_spaces_bucket_logging" "example" {
+  region = "%s"
+  bucket = digitalocean_spaces_bucket.assets.id
+
+  target_bucket = digitalocean_spaces_bucket.logs.id
+  target_prefix = "access-logs/"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region where the bucket resides.
+* `bucket` - (Required) The name of the bucket which will be logged.
+* `target_bucket` - (Required) The name of the bucket which will store the logs.
+* `target_prefix` - (Required) The prefix for the log files.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+Spaces bucket logging can be imported using the `region` and `bucket` attributes (delimited by a comma):
+
+```
+terraform import digitalocean_spaces_bucket_logging.example `region`,`bucket`
+```

--- a/docs/resources/spaces_bucket_object.md
+++ b/docs/resources/spaces_bucket_object.md
@@ -21,9 +21,9 @@ the provider's `spaces_access_id` and `spaces_secret_key` arguments to the
 access ID and secret you generate via the DigitalOcean control panel. For
 example:
 
-```
+```hcl
 provider "digitalocean" {
-  token             = var.digitalocean_token
+  token = var.digitalocean_token
 
   spaces_access_id  = var.access_id
   spaces_secret_key = var.secret_key

--- a/docs/resources/spaces_bucket_policy.md
+++ b/docs/resources/spaces_bucket_policy.md
@@ -21,9 +21,9 @@ the provider's `spaces_access_id` and `spaces_secret_key` arguments to the
 access ID and secret you generate via the DigitalOcean control panel. For
 example:
 
-```
+```hcl
 provider "digitalocean" {
-  token             = var.digitalocean_token
+  token = var.digitalocean_token
 
   spaces_access_id  = var.access_id
   spaces_secret_key = var.secret_key


### PR DESCRIPTION
https://docs.digitalocean.com/products/spaces/how-to/access-logs/

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanSpacesBucketLogging -count=1'
=== RUN   TestAccDigitalOceanSpacesBucketLogging_importBasic
=== PAUSE TestAccDigitalOceanSpacesBucketLogging_importBasic
=== RUN   TestAccDigitalOceanSpacesBucketLogging_basic
=== PAUSE TestAccDigitalOceanSpacesBucketLogging_basic
=== RUN   TestAccDigitalOceanSpacesBucketLogging_update
=== PAUSE TestAccDigitalOceanSpacesBucketLogging_update
=== CONT  TestAccDigitalOceanSpacesBucketLogging_importBasic
=== CONT  TestAccDigitalOceanSpacesBucketLogging_update
--- PASS: TestAccDigitalOceanSpacesBucketLogging_update (14.46s)
=== CONT  TestAccDigitalOceanSpacesBucketLogging_basic
--- PASS: TestAccDigitalOceanSpacesBucketLogging_importBasic (15.36s)
--- PASS: TestAccDigitalOceanSpacesBucketLogging_basic (10.88s)
PASS
ok  	github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces	25.378s
```