### PR TITLE
spaces keys: handle 404s correctly

### DIFF
--- a/digitalocean/spaces/datasource_spaces_key_test.go
+++ b/digitalocean/spaces/datasource_spaces_key_test.go
@@ -3,6 +3,7 @@ package spaces_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
@@ -83,8 +84,11 @@ func testAccCheckDigitalOceanSpacesKeyDestroyWithProvider(s *terraform.State, pr
 
 		client := provider.Meta().(*config.CombinedConfig).GodoClient()
 
-		key, _, err := client.SpacesKeys.Get(context.Background(), rs.Primary.ID)
+		key, resp, err := client.SpacesKeys.Get(context.Background(), rs.Primary.ID)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return nil
+			}
 			return fmt.Errorf("Error listing Spaces keys: %s", err)
 		}
 		if key.AccessKey == rs.Primary.ID {


### PR DESCRIPTION
This fixes the handling of 404s in the spaces keys resource. When we receive a 404, it should be removed from state. 

Additionally, this fixes the acceptance tests for spaces keys. The test used to verify that the key is correctly destroyed after the test run errors when it receives a 404, e.g.

```
=== NAME  TestAccDigitalOceanSpacesKey_basic
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: Error listing Spaces keys: GET https://api.digitalocean.com/v2/spaces/keys/DO8018RDQRR7UYB9Q8VQ: 404 (request "fc999b4b-5a4b-49cf-8058-d2af76a9a2be") Not Found
--- FAIL: TestAccDigitalOceanSpacesKey_basic (25.18s)
```

This is the expected response in this case. All spaces keys acceptance test now pass:

```
=== RUN   TestAccDigitalOceanSpacesKey_basic
=== PAUSE TestAccDigitalOceanSpacesKey_basic
=== RUN   TestAccDigitalOceanSpacesKey_updateGrant
=== PAUSE TestAccDigitalOceanSpacesKey_updateGrant
=== RUN   TestAccDigitalOceanSpacesKey_multipleGrants
=== PAUSE TestAccDigitalOceanSpacesKey_multipleGrants
=== CONT  TestAccDigitalOceanSpacesKey_basic
=== CONT  TestAccDigitalOceanSpacesKey_multipleGrants
--- PASS: TestAccDigitalOceanSpacesKey_basic (26.37s)
=== CONT  TestAccDigitalOceanSpacesKey_updateGrant
--- PASS: TestAccDigitalOceanSpacesKey_multipleGrants (38.62s)
--- PASS: TestAccDigitalOceanSpacesKey_updateGrant (32.76s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/spaces     59.143s
```


Fixes: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1394