### PR TITLE
App Platform: Add VPC integration

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -143,6 +143,11 @@ func appSpecSchema(isResource bool) map[string]*schema.Schema {
 				},
 			},
 		},
+		"vpc": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     appSpecVPCSchema(),
+		},
 	}
 
 	if isResource {
@@ -181,6 +186,31 @@ func appSpecDomainSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "If the domain uses DigitalOcean DNS and you would like App Platform to automatically manage it for you, set this to the name of the domain on your account.",
+			},
+		},
+	}
+}
+
+func appSpecVPCSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the VPC droplet.",
+			},
+			"egress_ips": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The VPC egress ip associated with the droplet.",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -166,6 +166,13 @@ resource "digitalocean_app" "mono-repo-example" {
         }
       }
     }
+
+    vpc {
+      id = “c22d8f48-4bc4-49f5-8ca0-58e7164427ac”
+      egress_ips {
+        ip: “10.0.0.1"
+      }
+    }
   }
 }
 ```
@@ -285,7 +292,10 @@ The following arguments are supported:
       - `expose_headers` - The set of HTTP response headers that browsers are allowed to access. This configures the `Access-Control-Expose-Headers` header.
       - `allow_methods` - The set of allowed HTTP methods. This configures the `Access-Control-Allow-Methods` header.
       - `allow_credentials` - Whether browsers should expose the response to the client-side JavaScript code when the request's credentials mode is `include`. This configures the `Access-Control-Allow-Credentials` header.
-
+* `vpc`: Specification for VPC droplet.
+  - `id`: The ID of the VPC droplet.
+  - `egress_ips`: A set of VPC egress ips associated with the droplet.
+    - `ip`: The VPC egress ip associated with the droplet.
 - `project_id` - The ID of the project that the app is assigned to.
 
 A spec can contain multiple components.


### PR DESCRIPTION
This PR adds vpc fields to AppSpec to allow VPC integration for App Platform.