### PR TITLE
App Platform: Add autoscale alert rules to appSpec and documentation

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -199,6 +199,8 @@ func appSpecAppLevelAlerts() *schema.Resource {
 					string(godo.AppAlertSpecRule_DeploymentCanceled),
 					string(godo.AppAlertSpecRule_DomainFailed),
 					string(godo.AppAlertSpecRule_DomainLive),
+					string(godo.AppAlertSpecRule_AutoscaleFailed),
+					string(godo.AppAlertSpecRule_AutoscaleSucceeded),
 				}, false),
 			},
 			"disabled": {

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -253,7 +253,7 @@ The following arguments are supported:
   - `scope` - The visibility scope of the environment variable. One of `RUN_TIME`, `BUILD_TIME`, or `RUN_AND_BUILD_TIME` (default).
   - `type` - The type of the environment variable, `GENERAL` or `SECRET`.
 * `alert` - Describes an alert policy for the app.
-  - `rule` - The type of the alert to configure. Top-level app alert policies can be: `DEPLOYMENT_CANCELLED`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_LIVE`, `DEPLOYMENT_STARTED`, `DOMAIN_FAILED`, or `DOMAIN_LIVE`.
+  - `rule` - The type of the alert to configure. Top-level app alert policies can be: `DEPLOYMENT_CANCELLED`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_LIVE`, `DEPLOYMENT_STARTED`, `DOMAIN_FAILED`, `DOMAIN_LIVE`, `AUTOSCALE_FAILED`, or `AUTOSCALE_SUCCEEDED`.
   - `disabled` - Determines whether the alert is disabled (default: `false`).
   - `destinations` - Specification for alert destination.
     - `emails` - Determines which emails receive alerts. The emails must be team members. If not set, the team's email is used by default.


### PR DESCRIPTION
This PR adds a new alert for autoscale succeeded to app platform.

This PR depends on https://github.com/digitalocean/godo/pull/879 being merged.