### PR TITLE
apps: add maintenance

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1,3 +1,4 @@
+// AppMaintenanceSpec defines maintenance settings for the app.
 package app
 
 import (
@@ -22,6 +23,13 @@ const (
 // AppSpecTermination is a type constraint for the termination attribute of an app component.
 type AppSpecTermination interface {
 	godo.AppServiceSpecTermination | godo.AppWorkerSpecTermination | godo.AppJobSpecTermination
+}
+
+// AppMaintenanceSpec defines maintenance settings for the app.
+type AppMaintenanceSpec struct {
+	Enabled        bool   `json:"enabled,omitempty"`
+	Archive        bool   `json:"archive,omitempty"`
+	OfflinePageURL string `json:"offline_page_url,omitempty"`
 }
 
 // appSpecSchema returns map[string]*schema.Schema for the App Specification.
@@ -139,6 +147,31 @@ func appSpecSchema(isResource bool) map[string]*schema.Schema {
 							"AUTOASSIGN",
 							"DEDICATED_IP",
 						}, false),
+					},
+				},
+			},
+		},
+		"maintenance": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Specification to configure maintenance settings for the app, such as maintenance mode and archiving the app.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Indicates whether maintenance mode should be enabled for the app.",
+					},
+					"archive": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Indicates whether the app should be archived. Setting this to true implies that enabled is set to true.",
+					},
+					"offline_page_url": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "A custom offline page to display when maintenance mode is enabled or the app is archived.",
 					},
 				},
 			},
@@ -1313,6 +1346,14 @@ func expandAppSpec(config []interface{}) *godo.AppSpec {
 		appSpec.Domains = expandAppDomainSpec(appSpecConfig["domains"].(*schema.Set).List())
 	}
 
+	// Handle maintenance
+	if v, ok := appSpecConfig["maintenance"]; ok {
+		maint := expandAppMaintenance(v.([]interface{}))
+		if maint != nil {
+			appSpec.Maintenance = maint
+		}
+	}
+
 	return appSpec
 }
 
@@ -1320,7 +1361,6 @@ func flattenAppSpec(d *schema.ResourceData, spec *godo.AppSpec) []map[string]int
 	result := make([]map[string]interface{}, 0, 1)
 
 	if spec != nil {
-
 		r := make(map[string]interface{})
 		r["name"] = (*spec).Name
 		r["region"] = (*spec).Region
@@ -1376,10 +1416,42 @@ func flattenAppSpec(d *schema.ResourceData, spec *godo.AppSpec) []map[string]int
 			r["egress"] = flattenAppEgress((*spec).Egress)
 		}
 
+		// Handle maintenance
+		if (*spec).Maintenance != nil {
+			r["maintenance"] = flattenAppMaintenance((*spec).Maintenance)
+		}
+
 		result = append(result, r)
 	}
 
 	return result
+}
+
+// expandAppMaintenance expands the maintenance block from the schema to AppMaintenanceSpec
+func expandAppMaintenance(config []interface{}) *godo.AppMaintenanceSpec {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+	m := config[0].(map[string]interface{})
+	return &godo.AppMaintenanceSpec{
+		Enabled:        m["enabled"].(bool),
+		Archive:        m["archive"].(bool),
+		OfflinePageURL: m["offline_page_url"].(string),
+	}
+}
+
+// flattenAppMaintenance flattens AppMaintenanceSpec to the schema format
+func flattenAppMaintenance(m *godo.AppMaintenanceSpec) []map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"enabled":          m.Enabled,
+			"archive":          m.Archive,
+			"offline_page_url": m.OfflinePageURL,
+		},
+	}
 }
 
 func expandAppAlerts(config []interface{}) []*godo.AppAlertSpec {

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -386,61 +386,61 @@ func TestAccDigitalOceanApp_Envs(t *testing.T) {
 	appName := acceptance.RandomTestName()
 
 	oneEnv := `
-      env {
-        key   = "COMPONENT_FOO"
-        value = "bar"
-      }
+	  env {
+		key   = "COMPONENT_FOO"
+		value = "bar"
+	  }
 `
 
 	twoEnvs := `
-      env {
-        key   = "COMPONENT_FOO"
-        value = "bar"
-      }
+	  env {
+		key   = "COMPONENT_FOO"
+		value = "bar"
+	  }
 
-      env {
-        key   = "COMPONENT_FIZZ"
-        value = "pop"
-        scope = "BUILD_TIME"
-      }
+	  env {
+		key   = "COMPONENT_FIZZ"
+		value = "pop"
+		scope = "BUILD_TIME"
+	  }
 `
 
 	oneEnvUpdated := `
-      env {
-        key   = "COMPONENT_FOO"
-        value = "baz"
-        scope = "RUN_TIME"
-        type  = "GENERAL"
-      }
+	  env {
+		key   = "COMPONENT_FOO"
+		value = "baz"
+		scope = "RUN_TIME"
+		type  = "GENERAL"
+	  }
 `
 
 	oneAppEnv := `
-      env {
-        key   = "APP_FOO"
-        value = "bar"
-      }
+	  env {
+		key   = "APP_FOO"
+		value = "bar"
+	  }
 `
 
 	twoAppEnvs := `
-      env {
-        key   = "APP_FOO"
-        value = "bar"
-      }
+	  env {
+		key   = "APP_FOO"
+		value = "bar"
+	  }
 
-      env {
-        key   = "APP_FIZZ"
-        value = "pop"
-        scope = "BUILD_TIME"
-      }
+	  env {
+		key   = "APP_FIZZ"
+		value = "pop"
+		scope = "BUILD_TIME"
+	  }
 `
 
 	oneAppEnvUpdated := `
-      env {
-        key   = "APP_FOO"
-        value = "baz"
-        scope = "RUN_TIME"
-        type  = "GENERAL"
-      }
+	  env {
+		key   = "APP_FOO"
+		value = "baz"
+		scope = "RUN_TIME"
+		type  = "GENERAL"
+	  }
 `
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -612,15 +612,15 @@ func TestAccDigitalOceanApp_Function(t *testing.T) {
 	fnConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_function, appName, "")
 
 	corsConfig := `
-       cors {
-         allow_origins {
-           prefix = "https://example.com"
-         }
-         allow_methods     = ["GET"]
-         allow_headers     = ["X-Custom-Header"]
-         expose_headers    = ["Content-Encoding", "ETag"]
-         max_age           = "1h"
-       }
+	   cors {
+		 allow_origins {
+		   prefix = "https://example.com"
+		 }
+		 allow_methods     = ["GET"]
+		 allow_headers     = ["X-Custom-Header"]
+		 expose_headers    = ["Content-Encoding", "ETag"]
+		 max_age           = "1h"
+	   }
 `
 	updatedFnConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_function, appName, corsConfig)
 
@@ -675,17 +675,17 @@ func TestAccDigitalOceanApp_Domain(t *testing.T) {
 	appName := acceptance.RandomTestName()
 
 	domain := fmt.Sprintf(`
-       domain {
-         name     = "%s.com"
-         wildcard = true
-       }
+	   domain {
+		 name     = "%s.com"
+		 wildcard = true
+	   }
 `, appName)
 
 	updatedDomain := fmt.Sprintf(`
-       domain {
-         name     = "%s.net"
-         wildcard = true
-       }
+	   domain {
+		 name     = "%s.net"
+		 wildcard = true
+	   }
 `, appName)
 
 	domainsConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_Domains, appName, domain)
@@ -729,18 +729,18 @@ func TestAccDigitalOceanApp_DomainsDeprecation(t *testing.T) {
 	appName := acceptance.RandomTestName()
 
 	deprecatedStyleDomain := fmt.Sprintf(`
-       domains = ["%s.com"]
+	   domains = ["%s.com"]
 `, appName)
 
 	updatedDeprecatedStyleDomain := fmt.Sprintf(`
-       domains = ["%s.net"]
+	   domains = ["%s.net"]
 `, appName)
 
 	newStyleDomain := fmt.Sprintf(`
-       domain {
-         name     = "%s.com"
-         wildcard = true
-       }
+	   domain {
+		 name     = "%s.com"
+		 wildcard = true
+	   }
 `, appName)
 
 	domainsConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_Domains, appName, deprecatedStyleDomain)
@@ -790,39 +790,39 @@ func TestAccDigitalOceanApp_CORS(t *testing.T) {
 	appName := acceptance.RandomTestName()
 
 	allowedOriginExact := `
-       cors {
-         allow_origins {
-           exact = "https://example.com"
-         }
-       }
+	   cors {
+		 allow_origins {
+		   exact = "https://example.com"
+		 }
+	   }
 `
 
 	allowedOriginRegex := `
-       cors {
-         allow_origins {
-           regex = "https://[0-9a-z]*.digitalocean.com"
-         }
-       }
+	   cors {
+		 allow_origins {
+		   regex = "https://[0-9a-z]*.digitalocean.com"
+		 }
+	   }
 `
 
 	noAllowedOrigins := `
-       cors {
-         allow_methods     = ["GET", "PUT"]
-         allow_headers     = ["X-Custom-Header", "Upgrade-Insecure-Requests"]
-       }
+	   cors {
+		 allow_methods     = ["GET", "PUT"]
+		 allow_headers     = ["X-Custom-Header", "Upgrade-Insecure-Requests"]
+	   }
 `
 
 	fullConfig := `
-       cors {
-         allow_origins {
-           exact = "https://example.com"
-         }
-         allow_methods     = ["GET", "PUT"]
-         allow_headers     = ["X-Custom-Header", "Upgrade-Insecure-Requests"]
-         expose_headers    = ["Content-Encoding", "ETag"]
-         max_age           = "1h"
-         allow_credentials = true
-       }
+	   cors {
+		 allow_origins {
+		   exact = "https://example.com"
+		 }
+		 allow_methods     = ["GET", "PUT"]
+		 allow_headers     = ["X-Custom-Header", "Upgrade-Insecure-Requests"]
+		 expose_headers    = ["Content-Encoding", "ETag"]
+		 max_age           = "1h"
+		 allow_credentials = true
+	   }
 `
 
 	allowedOriginExactConfig := fmt.Sprintf(testAccCheckDigitalOceanAppConfig_CORS,
@@ -1189,436 +1189,482 @@ func TestAccDigitalOceanApp_VPC(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanApp_Maintenance(t *testing.T) {
+	var app godo.App
+	appName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_Maintenance, appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr("digitalocean_app.foobar", "spec.0.maintenance.0.enabled", "true"),
+					resource.TestCheckResourceAttr("digitalocean_app.foobar", "spec.0.maintenance.0.archive", "true"),
+					resource.TestCheckResourceAttr("digitalocean_app.foobar", "spec.0.maintenance.0.offline_page_url", "https://example.com/offline.html"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckDigitalOceanAppConfig_Maintenance = `
+resource "digitalocean_app" "foobar" {
+  spec {
+	name   = "%s"
+	region = "nyc"
+
+	maintenance {
+	  enabled           = true
+	  archive           = true
+	  offline_page_url  = "https://example.com/offline.html"
+	}
+
+	service {
+	  name = "go-service"
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	  instance_size_slug = "basic-xxs"
+	  instance_count     = 1
+	}
+  }
+}`
+
 var testAccCheckDigitalOceanAppConfig_basic = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    alert {
-      rule = "DEPLOYMENT_FAILED"
-    }
+	alert {
+	  rule = "DEPLOYMENT_FAILED"
+	}
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      health_check {
-        http_path       = "/"
-        timeout_seconds = 10
-        port            = 1234
-      }
+	  health_check {
+		http_path       = "/"
+		timeout_seconds = 10
+		port            = 1234
+	  }
 
-      alert {
-        value    = 75
-        operator = "GREATER_THAN"
-        window   = "TEN_MINUTES"
-        rule     = "CPU_UTILIZATION"
-      }
+	  alert {
+		value    = 75
+		operator = "GREATER_THAN"
+		window   = "TEN_MINUTES"
+		rule     = "CPU_UTILIZATION"
+	  }
 
-      log_destination {
-        name = "ServiceLogs"
-        papertrail {
-          endpoint = "syslog+tls://example.com:12345"
-        }
-      }
-    }
+	  log_destination {
+		name = "ServiceLogs"
+		papertrail {
+		  endpoint = "syslog+tls://example.com:12345"
+		}
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_basic_edge_controls = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name                            = "%s"
-    region                          = "ams"
-    enhanced_threat_control_enabled = true
-    disable_edge_cache              = true
-    disable_email_obfuscation       = true
+	name                            = "%s"
+	region                          = "ams"
+	enhanced_threat_control_enabled = true
+	disable_edge_cache              = true
+	disable_email_obfuscation       = true
 
-    alert {
-      rule = "DEPLOYMENT_FAILED"
-    }
+	alert {
+	  rule = "DEPLOYMENT_FAILED"
+	}
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      health_check {
-        http_path       = "/"
-        timeout_seconds = 10
-        port            = 1234
-      }
+	  health_check {
+		http_path       = "/"
+		timeout_seconds = 10
+		port            = 1234
+	  }
 
-      alert {
-        value    = 75
-        operator = "GREATER_THAN"
-        window   = "TEN_MINUTES"
-        rule     = "CPU_UTILIZATION"
-      }
+	  alert {
+		value    = 75
+		operator = "GREATER_THAN"
+		window   = "TEN_MINUTES"
+		rule     = "CPU_UTILIZATION"
+	  }
 
-      log_destination {
-        name = "ServiceLogs"
-        papertrail {
-          endpoint = "syslog+tls://example.com:12345"
-        }
-      }
-    }
+	  log_destination {
+		name = "ServiceLogs"
+		papertrail {
+		  endpoint = "syslog+tls://example.com:12345"
+		}
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_withTimeout = `
 resource "digitalocean_app" "foobar" {
   timeouts {
-    create = "10s"
+	create = "10s"
   }
 
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    service {
-      name               = "go-service-with-timeout"
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service-with-timeout"
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_withFeatures = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name     = "%s"
-    region   = "ams"
-    features = ["buildpack-stack=ubuntu-18"]
+	name     = "%s"
+	region   = "ams"
+	features = ["buildpack-stack=ubuntu-18"]
 
-    service {
-      name               = "go-service-with-features"
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service-with-features"
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_addService = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    alert {
-      rule = "DEPLOYMENT_FAILED"
-    }
+	alert {
+	  rule = "DEPLOYMENT_FAILED"
+	}
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      alert {
-        value    = 85
-        operator = "GREATER_THAN"
-        window   = "FIVE_MINUTES"
-        rule     = "CPU_UTILIZATION"
-      }
+	  alert {
+		value    = 85
+		operator = "GREATER_THAN"
+		window   = "FIVE_MINUTES"
+		rule     = "CPU_UTILIZATION"
+	  }
 
-      log_destination {
-        name = "ServiceLogs"
-        papertrail {
-          endpoint = "syslog+tls://example.com:12345"
-        }
-      }
-    }
+	  log_destination {
+		name = "ServiceLogs"
+		papertrail {
+		  endpoint = "syslog+tls://example.com:12345"
+		}
+	  }
+	}
 
-    service {
-      name               = "python-service"
-      environment_slug   = "python"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "python-service"
+	  environment_slug   = "python"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-python.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-python.git"
+		branch         = "main"
+	  }
+	}
 
-    ingress {
-      rule {
-        component {
-          name = "go-service"
-        }
-        match {
-          path {
-            prefix = "/go"
-          }
-        }
-      }
+	ingress {
+	  rule {
+		component {
+		  name = "go-service"
+		}
+		match {
+		  path {
+			prefix = "/go"
+		  }
+		}
+	  }
 
-      rule {
-        component {
-          name                 = "python-service"
-          preserve_path_prefix = true
-        }
-        match {
-          path {
-            prefix = "/python"
-          }
-        }
-      }
-    }
+	  rule {
+		component {
+		  name                 = "python-service"
+		  preserve_path_prefix = true
+		}
+		match {
+		  path {
+			prefix = "/python"
+		  }
+		}
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_addImage = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    service {
-      name               = "image-service"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "image-service"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      image {
-        registry_type = "DOCKER_HUB"
-        registry      = "caddy"
-        repository    = "caddy"
-        tag           = "2.2.1-alpine"
-      }
+	  image {
+		registry_type = "DOCKER_HUB"
+		registry      = "caddy"
+		repository    = "caddy"
+		tag           = "2.2.1-alpine"
+	  }
 
-      http_port = 80
-    }
+	  http_port = 80
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_imageDigest = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    service {
-      name               = "image-service"
-      instance_count     = 1
-      instance_size_slug = "apps-s-1vcpu-1gb"
+	service {
+	  name               = "image-service"
+	  instance_count     = 1
+	  instance_size_slug = "apps-s-1vcpu-1gb"
 
-      image {
-        registry_type = "DOCKER_HUB"
-        registry      = "ubuntu"
-        repository    = "nginx"
-        digest        = "sha256:909169d4de5b750071dc2cbe286e18763f8ed23dd0f267b5db59ea33bdbf8853"
-      }
+	  image {
+		registry_type = "DOCKER_HUB"
+		registry      = "ubuntu"
+		repository    = "nginx"
+		digest        = "sha256:909169d4de5b750071dc2cbe286e18763f8ed23dd0f267b5db59ea33bdbf8853"
+	  }
 
-      http_port = 80
-    }
+	  http_port = 80
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_addInternalPort = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      internal_ports = [5000]
-    }
+	  internal_ports = [5000]
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_addDatabase = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    alert {
-      rule = "DEPLOYMENT_FAILED"
-    }
+	alert {
+	  rule = "DEPLOYMENT_FAILED"
+	}
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      alert {
-        value    = 85
-        operator = "GREATER_THAN"
-        window   = "FIVE_MINUTES"
-        rule     = "CPU_UTILIZATION"
-      }
+	  alert {
+		value    = 85
+		operator = "GREATER_THAN"
+		window   = "FIVE_MINUTES"
+		rule     = "CPU_UTILIZATION"
+	  }
 
-      log_destination {
-        name = "ServiceLogs"
-        papertrail {
-          endpoint = "syslog+tls://example.com:12345"
-        }
-      }
-    }
+	  log_destination {
+		name = "ServiceLogs"
+		papertrail {
+		  endpoint = "syslog+tls://example.com:12345"
+		}
+	  }
+	}
 
-    ingress {
-      rule {
-        component {
-          name = "go-service"
-        }
-        match {
-          path {
-            prefix = "/"
-          }
-        }
-      }
-    }
+	ingress {
+	  rule {
+		component {
+		  name = "go-service"
+		}
+		match {
+		  path {
+			prefix = "/"
+		  }
+		}
+	  }
+	}
 
-    database {
-      name       = "test-db"
-      engine     = "PG"
-      production = false
-    }
+	database {
+	  name       = "test-db"
+	  engine     = "PG"
+	  production = false
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_StaticSite = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    static_site {
-      name              = "sample-jekyll"
-      build_command     = "bundle exec jekyll build -d ./public"
-      output_dir        = "/public"
-      environment_slug  = "jekyll"
-      catchall_document = "404.html"
+	static_site {
+	  name              = "sample-jekyll"
+	  build_command     = "bundle exec jekyll build -d ./public"
+	  output_dir        = "/public"
+	  environment_slug  = "jekyll"
+	  catchall_document = "404.html"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_Egress = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    static_site {
-      name              = "sample-jekyll"
-      build_command     = "bundle exec jekyll build -d ./public"
-      output_dir        = "/public"
-      environment_slug  = "jekyll"
-      catchall_document = "404.html"
+	static_site {
+	  name              = "sample-jekyll"
+	  build_command     = "bundle exec jekyll build -d ./public"
+	  output_dir        = "/public"
+	  environment_slug  = "jekyll"
+	  catchall_document = "404.html"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
+		branch         = "main"
+	  }
+	}
 
-    egress {
-      type = "DEDICATED_IP"
-    }
+	egress {
+	  type = "DEDICATED_IP"
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_function = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    function {
-      name       = "example"
-      source_dir = "/"
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-functions-nodejs-helloworld.git"
-        branch         = "master"
-      }
-    }
+	function {
+	  name       = "example"
+	  source_dir = "/"
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-functions-nodejs-helloworld.git"
+		branch         = "master"
+	  }
+	}
 
-    ingress {
-      rule {
-        component {
-          name = "example"
-        }
+	ingress {
+	  rule {
+		component {
+		  name = "example"
+		}
 
-        match {
-          path {
-            prefix = "/api"
-          }
-        }
+		match {
+		  path {
+			prefix = "/api"
+		  }
+		}
 
-        %s
-      }
-    }
+		%s
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_Envs = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
 %s
-    }
+	}
 
 %s
   }
@@ -1627,157 +1673,157 @@ resource "digitalocean_app" "foobar" {
 var testAccCheckDigitalOceanAppConfig_worker = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    worker {
-      name               = "go-worker"
-      instance_count     = 1
-      instance_size_slug = "%s"
+	worker {
+	  name               = "go-worker"
+	  instance_count     = 1
+	  instance_size_slug = "%s"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
+		branch         = "main"
+	  }
 
-      log_destination {
-        name = "WorkerLogs"
-        logtail {
-          token = "test-api-token"
-        }
-      }
-    }
+	  log_destination {
+		name = "WorkerLogs"
+		logtail {
+		  token = "test-api-token"
+		}
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_addJob = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    job {
-      name               = "example-pre-job"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
-      kind               = "PRE_DEPLOY"
-      run_command        = "echo 'This is a pre-deploy job.'"
+	job {
+	  name               = "example-pre-job"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
+	  kind               = "PRE_DEPLOY"
+	  run_command        = "echo 'This is a pre-deploy job.'"
 
-      image {
-        registry_type = "DOCKER_HUB"
-        registry      = "frolvlad"
-        repository    = "alpine-bash"
-        tag           = "latest"
-      }
-    }
+	  image {
+		registry_type = "DOCKER_HUB"
+		registry      = "frolvlad"
+		repository    = "alpine-bash"
+		tag           = "latest"
+	  }
+	}
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
 
-    job {
-      name               = "example-post-job"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
-      kind               = "POST_DEPLOY"
-      run_command        = "echo 'This is a post-deploy job.'"
+	job {
+	  name               = "example-post-job"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
+	  kind               = "POST_DEPLOY"
+	  run_command        = "echo 'This is a post-deploy job.'"
 
-      image {
-        registry_type = "DOCKER_HUB"
-        registry      = "frolvlad"
-        repository    = "alpine-bash"
-        tag           = "latest"
-      }
+	  image {
+		registry_type = "DOCKER_HUB"
+		registry      = "frolvlad"
+		repository    = "alpine-bash"
+		tag           = "latest"
+	  }
 
-      log_destination {
-        name = "JobLogs"
-        datadog {
-          endpoint = "https://example.com"
-          api_key  = "test-api-key"
-        }
-      }
-    }
+	  log_destination {
+		name = "JobLogs"
+		datadog {
+		  endpoint = "https://example.com"
+		  api_key  = "test-api-key"
+		}
+	  }
+	}
 
-    job {
-      name               = "example-failed-job"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
-      kind               = "FAILED_DEPLOY"
-      run_command        = "echo 'This is a failed deploy job.'"
+	job {
+	  name               = "example-failed-job"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
+	  kind               = "FAILED_DEPLOY"
+	  run_command        = "echo 'This is a failed deploy job.'"
 
-      image {
-        registry_type = "DOCKER_HUB"
-        registry      = "frolvlad"
-        repository    = "alpine-bash"
-        tag           = "latest"
-      }
-    }
+	  image {
+		registry_type = "DOCKER_HUB"
+		registry      = "frolvlad"
+		repository    = "alpine-bash"
+		tag           = "latest"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_Domains = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    %s
+	%s
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_CORS = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
 
-    ingress {
-      rule {
-        component {
-          name = "go-service"
-        }
+	ingress {
+	  rule {
+		component {
+		  name = "go-service"
+		}
 
-        match {
-          path {
-            prefix = "/"
-          }
-        }
+		match {
+		  path {
+			prefix = "/"
+		  }
+		}
 
-        %s
-      }
-    }
+		%s
+	  }
+	}
   }
 }`
 
@@ -1789,212 +1835,212 @@ resource "digitalocean_project" "foobar" {
 resource "digitalocean_app" "foobar" {
   project_id = digitalocean_project.foobar.id
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    static_site {
-      name              = "sample-jekyll"
-      build_command     = "bundle exec jekyll build -d ./public"
-      output_dir        = "/public"
-      environment_slug  = "jekyll"
-      catchall_document = "404.html"
+	static_site {
+	  name              = "sample-jekyll"
+	  build_command     = "bundle exec jekyll build -d ./public"
+	  output_dir        = "/public"
+	  environment_slug  = "jekyll"
+	  catchall_document = "404.html"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-jekyll.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_autoScale = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_size_slug = "apps-d-1vcpu-0.5gb"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_size_slug = "apps-d-1vcpu-0.5gb"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      autoscaling {
-        min_instance_count = 2
-        max_instance_count = 4
-        metrics {
-          cpu {
-            percent = 60
-          }
-        }
-      }
-    }
+	  autoscaling {
+		min_instance_count = 2
+		max_instance_count = 4
+		metrics {
+		  cpu {
+			percent = 60
+		  }
+		}
+	  }
+	}
 
-    worker {
-      name               = "go-worker"
-      instance_size_slug = "apps-d-1vcpu-0.5gb"
+	worker {
+	  name               = "go-worker"
+	  instance_size_slug = "apps-d-1vcpu-0.5gb"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
+		branch         = "main"
+	  }
 
-      autoscaling {
-        min_instance_count = 1
-        max_instance_count = 2
-        metrics {
-          cpu {
-            percent = 80
-          }
-        }
-      }
-    }
+	  autoscaling {
+		min_instance_count = 1
+		max_instance_count = 2
+		metrics {
+		  cpu {
+			percent = 80
+		  }
+		}
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_minimalService = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    service {
-      name               = "go-service"
-      instance_count     = 1
-      instance_size_slug = "apps-d-1vcpu-0.5gb"
+	service {
+	  name               = "go-service"
+	  instance_count     = 1
+	  instance_size_slug = "apps-d-1vcpu-0.5gb"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_internalOnlyService = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    service {
-      name               = "go-service"
-      instance_count     = 1
-      instance_size_slug = "apps-d-1vcpu-0.5gb"
+	service {
+	  name               = "go-service"
+	  instance_count     = 1
+	  instance_size_slug = "apps-d-1vcpu-0.5gb"
 
-      http_port      = 0
-      internal_ports = [8080]
+	  http_port      = 0
+	  internal_ports = [8080]
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
 
-    ingress {}
+	ingress {}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_withTermination = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
-    service {
-      name               = "go-service"
-      instance_size_slug = "apps-d-1vcpu-0.5gb"
-      instance_count     = 1
-      termination {
-        drain_seconds        = 30
-        grace_period_seconds = 60
-      }
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-    }
-    worker {
-      name               = "go-worker"
-      instance_size_slug = "apps-d-1vcpu-0.5gb"
-      instance_count     = 1
-      termination {
-        grace_period_seconds = 30
-      }
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
-        branch         = "main"
-      }
-    }
+	name   = "%s"
+	region = "nyc"
+	service {
+	  name               = "go-service"
+	  instance_size_slug = "apps-d-1vcpu-0.5gb"
+	  instance_count     = 1
+	  termination {
+		drain_seconds        = 30
+		grace_period_seconds = 60
+	  }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	}
+	worker {
+	  name               = "go-worker"
+	  instance_size_slug = "apps-d-1vcpu-0.5gb"
+	  instance_count     = 1
+	  termination {
+		grace_period_seconds = 30
+	  }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
+		branch         = "main"
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_withAlerts = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "ams"
+	name   = "%s"
+	region = "ams"
 
-    alert {
-      rule = "DEPLOYMENT_FAILED"
-      destinations {
-        emails = ["email1@do.com", "email2@do.com"]
-        slack_webhooks {
-          channel = "@user1"
-          url     = "https://hooks.slack.com/services/SOME/SLACK/uniQueURL"
-        }
-      }
-    }
+	alert {
+	  rule = "DEPLOYMENT_FAILED"
+	  destinations {
+		emails = ["email1@do.com", "email2@do.com"]
+		slack_webhooks {
+		  channel = "@user1"
+		  url     = "https://hooks.slack.com/services/SOME/SLACK/uniQueURL"
+		}
+	  }
+	}
 
-    service {
-      name               = "go-service"
-      environment_slug   = "go"
-      instance_count     = 1
-      instance_size_slug = "basic-xxs"
+	service {
+	  name               = "go-service"
+	  environment_slug   = "go"
+	  instance_count     = 1
+	  instance_size_slug = "basic-xxs"
 
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
 
-      alert {
-        value    = 85
-        operator = "GREATER_THAN"
-        window   = "FIVE_MINUTES"
-        rule     = "CPU_UTILIZATION"
-        destinations {
-          emails = ["email1@do.com", "email2@do.com"]
-          slack_webhooks {
-            channel = "@user1"
-            url     = "https://hooks.slack.com/services/SOME/SLACK/uniQueURL"
-          }
-        }
-      }
-    }
+	  alert {
+		value    = 85
+		operator = "GREATER_THAN"
+		window   = "FIVE_MINUTES"
+		rule     = "CPU_UTILIZATION"
+		destinations {
+		  emails = ["email1@do.com", "email2@do.com"]
+		  slack_webhooks {
+			channel = "@user1"
+			url     = "https://hooks.slack.com/services/SOME/SLACK/uniQueURL"
+		  }
+		}
+	  }
+	}
   }
 }`
 
 var testAccCheckDigitalOceanAppConfig_withVPC = `
 resource "digitalocean_app" "foobar" {
   spec {
-    name   = "%s"
-    region = "nyc"
+	name   = "%s"
+	region = "nyc"
 
-    service {
-      name = "go-service"
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
-        branch         = "main"
-      }
-      instance_size_slug = "basic-xxs"
-      instance_count     = 1
-    }
+	service {
+	  name = "go-service"
+	  git {
+		repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+		branch         = "main"
+	  }
+	  instance_size_slug = "basic-xxs"
+	  instance_count     = 1
+	}
 
-    vpc {
-      id = "%s"
-    }
+	vpc {
+	  id = "%s"
+	}
   }
 }`


### PR DESCRIPTION
Addresses #1403

Adds support for maintenance so it is not overwritten.

Tests run and pass:

```
-----------------------------------------------------
2025-07-25T14:26:58.826-0400 [DEBUG] sdk.helper_resource: Called TestCase CheckDestroy: test_working_directory=/var/folders/b9/fr9h8t090r1_gy7gdzhlg0zw0000gp/T/plugintest3355833044 test_step_number=1 test_name=TestAccDigitalOceanApp_Maintenance test_terraform_path=/opt/homebrew/bin/terraform
2025-07-25T14:26:58.829-0400 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccDigitalOceanApp_Maintenance
--- PASS: TestAccDigitalOceanApp_Maintenance (26.18s)
PASS
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/app        26.586s
```