### PR TITLE
Add database metrics attributes and datasources

### DIFF
--- a/digitalocean/database/datasource_database_cluster.go
+++ b/digitalocean/database/datasource_database_cluster.go
@@ -161,6 +161,14 @@ func DataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"metrics_endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -233,6 +241,11 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 			d.Set("urn", db.URN())
 			d.Set("private_network_uuid", db.PrivateNetworkUUID)
 			d.Set("project_id", db.ProjectID)
+
+			metricsErr := setMetricsEndpoints(&db, d)
+			if metricsErr != nil {
+				return diag.Errorf("Error setting metrics endpoints for database cluster: %s", metricsErr)
+			}
 
 			break
 		}

--- a/digitalocean/database/datasource_database_cluster_test.go
+++ b/digitalocean/database/datasource_database_cluster_test.go
@@ -3,6 +3,7 @@ package database_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -47,6 +48,7 @@ func TestAccDataSourceDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 						"data.digitalocean_database_cluster.foobar", "project_id"),
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_cluster.foobar", "storage_size_mib"),
+					testAccCheckDataSourceDigitalOceanDatabaseClusterMetricsEndpoints("data.digitalocean_database_cluster.foobar"),
 					testAccCheckDigitalOceanDatabaseClusterURIPassword(
 						"digitalocean_database_cluster.foobar", "uri"),
 					testAccCheckDigitalOceanDatabaseClusterURIPassword(
@@ -72,6 +74,7 @@ func testAccCheckDataSourceDigitalOceanDatabaseClusterExists(n string, databaseC
 		client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
 
 		foundCluster, _, err := client.Databases.Get(context.Background(), rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
@@ -81,6 +84,32 @@ func testAccCheckDataSourceDigitalOceanDatabaseClusterExists(n string, databaseC
 		}
 
 		*databaseCluster = *foundCluster
+
+		return nil
+	}
+}
+
+func testAccCheckDataSourceDigitalOceanDatabaseClusterMetricsEndpoints(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		// Check that metrics_endpoints is set and has at least one element
+		count, err := strconv.Atoi(rs.Primary.Attributes["metrics_endpoints.#"])
+		if err != nil {
+			return fmt.Errorf("Error parsing metrics_endpoints count: %s", err)
+		}
+		if count == 0 {
+			return fmt.Errorf("metrics_endpoints is empty")
+		}
+
+		// Check that the first endpoint is a valid URL
+		firstEndpoint := rs.Primary.Attributes["metrics_endpoints.0"]
+		if firstEndpoint == "" {
+			return fmt.Errorf("First endpoint in metrics_endpoints is empty")
+		}
 
 		return nil
 	}

--- a/digitalocean/database/datasource_database_metrics_credentials.go
+++ b/digitalocean/database/datasource_database_metrics_credentials.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"context"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceDigitalOceanDatabaseMetricsCredentials() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDigitalOceanDatabaseMetricsCredentialsRead,
+		Schema: map[string]*schema.Schema{
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanDatabaseMetricsCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	creds, _, err := client.Databases.GetMetricsCredentials(ctx)
+	if err != nil {
+		return diag.Errorf("Error retrieving database metrics credentials: %s", err)
+	}
+
+	d.SetId("metrics-credentials")
+	d.Set("username", creds.BasicAuthUsername)
+	d.Set("password", creds.BasicAuthPassword)
+
+	return nil
+}

--- a/digitalocean/database/datasource_database_metrics_credentials_test.go
+++ b/digitalocean/database/datasource_database_metrics_credentials_test.go
@@ -1,0 +1,42 @@
+package database_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanDatabaseMetricsCredentials(t *testing.T) {
+	var database godo.Database
+	databaseName := acceptance.RandomTestName()
+	databaseConfig := fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigBasic, databaseName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseReplicaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: databaseConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+				),
+			},
+			{
+				Config: databaseConfig + testAccCheckDigitalOceanDatasourceMetricsCredentialsConfigNew,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_database_metrics_credentials.creds", "username"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_database_metrics_credentials.creds", "password"),
+				),
+			},
+		},
+	})
+}
+
+const (
+	testAccCheckDigitalOceanDatasourceMetricsCredentialsConfigNew = `
+data "digitalocean_database_metrics_credentials" "creds" {}`
+)

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -57,6 +58,7 @@ func TestAccDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 						"digitalocean_database_cluster.foobar", "project_id"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "storage_size_mib"),
+					testAccCheckDigitalOceanDatabaseClusterMetricsEndpoints("digitalocean_database_cluster.foobar"),
 					testAccCheckDigitalOceanDatabaseClusterURIPassword(
 						"digitalocean_database_cluster.foobar", "uri"),
 					testAccCheckDigitalOceanDatabaseClusterURIPassword(
@@ -674,6 +676,30 @@ func testAccCheckDigitalOceanDatabaseClusterAttributes(database *godo.Database, 
 
 		if database.Name != name {
 			return fmt.Errorf("Bad name: %s", database.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDatabaseClusterMetricsEndpoints(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		count, err := strconv.Atoi(rs.Primary.Attributes["metrics_endpoints.#"])
+		if err != nil {
+			return fmt.Errorf("Error parsing metrics_endpoints count: %s", err)
+		}
+		if count == 0 {
+			return fmt.Errorf("metrics_endpoints is empty")
+		}
+
+		firstEndpoint := rs.Primary.Attributes["metrics_endpoints.0"]
+		if firstEndpoint == "" {
+			return fmt.Errorf("First endpoint in metrics_endpoints is empty")
 		}
 
 		return nil

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -109,6 +109,7 @@ func Provider() *schema.Provider {
 			"digitalocean_database_cluster":                  database.DataSourceDigitalOceanDatabaseCluster(),
 			"digitalocean_database_connection_pool":          database.DataSourceDigitalOceanDatabaseConnectionPool(),
 			"digitalocean_database_ca":                       database.DataSourceDigitalOceanDatabaseCA(),
+			"digitalocean_database_metrics_credentials":      database.DataSourceDigitalOceanDatabaseMetricsCredentials(),
 			"digitalocean_database_replica":                  database.DataSourceDigitalOceanDatabaseReplica(),
 			"digitalocean_database_user":                     database.DataSourceDigitalOceanDatabaseUser(),
 			"digitalocean_domain":                            domain.DataSourceDigitalOceanDomain(),

--- a/docs/data-sources/database_cluster.md
+++ b/docs/data-sources/database_cluster.md
@@ -47,6 +47,7 @@ The following attributes are exported:
 * `user` - Username for the cluster's default user.
 * `password` - Password for the cluster's default user.
 * `project_id` - The ID of the project that the database cluster is assigned to.
+* `metrics_endpoints` - A list of metrics endpoints for the database cluster, providing URLs to access Prometheus-compatible metrics.
 
 `maintenance_window` supports the following:
 

--- a/docs/data-sources/database_metrics_credentials.md
+++ b/docs/data-sources/database_metrics_credentials.md
@@ -18,7 +18,7 @@ output "metrics_username" {
 
 output "metrics_password" {
   sensitive = true
-  value = data.digitalocean_database_metrics_credentials.example.password
+  value     = data.digitalocean_database_metrics_credentials.example.password
 }
 ```
 

--- a/docs/data-sources/database_metrics_credentials.md
+++ b/docs/data-sources/database_metrics_credentials.md
@@ -1,0 +1,34 @@
+---
+page_title: "DigitalOcean: digitalocean_database_metrics_credentials"
+subcategory: "Databases"
+---
+
+# digitalocean_database_metrics_credentials
+
+Provides access to the metrics credentials for DigitalOcean database clusters. These credentials are account-wide and can be used to access metrics for any database cluster in the account.
+
+## Example Usage
+
+```hcl
+data "digitalocean_database_metrics_credentials" "example" {}
+
+output "metrics_username" {
+  value = data.digitalocean_database_metrics_credentials.example.username
+}
+
+output "metrics_password" {
+  sensitive = true
+  value = data.digitalocean_database_metrics_credentials.example.password
+}
+```
+
+## Argument Reference
+
+This datasource doesn't require any arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `username` - The username for accessing database metrics.
+* `password` - The password for accessing database metrics. This is marked as sensitive.

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -159,6 +159,7 @@ In addition to the above arguments, the following attributes are exported:
 * `database` - Name of the cluster's default database.
 * `user` - Username for the cluster's default user.
 * `password` - Password for the cluster's default user.
+* `metrics_endpoints` - A list of metrics endpoints for the database cluster, providing URLs to access Prometheus-compatible metrics.
 
 OpenSearch clusters will have the following additional attributes with connection
 details for their dashboard:

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -1,0 +1,38 @@
+# DigitalOcean Database Example
+
+This example demonstrates how to create a PostgreSQL database cluster on DigitalOcean and access its metrics credentials. It showcases:
+
+1. Creating a PostgreSQL database cluster with multiple nodes on the regions default VPC
+2. Accessing the account-wide database metrics credentials
+3. Outputting the metrics endpoints and credentials
+
+## Prerequisites
+
+You need to export your DigitalOcean API Token as an environment variable:
+
+```
+export DIGITALOCEAN_TOKEN="Your API TOKEN"
+```
+
+## Configuration
+
+The example uses variables that can be customized:
+
+- `region`: DigitalOcean region (default: "sfo3")
+- `db_name`: Name for the database cluster (default: "test-pg")
+- `db_engine`: Database engine (default: "pg" for PostgreSQL)
+- `db_version`: Database version (default: "17")
+- `db_size`: Database size slug (default: "db-s-2vcpu-4gb")
+- `db_node_count`: Number of nodes (default: 2)
+
+## Run this example using:
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+
+## Notes
+
+The database metrics credentials are account-wide, not cluster-specific.

--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = "~> 1"
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2"
+    }
+  }
+}
+
+provider "digitalocean" {
+  # You need to set this in your .bashrc
+  # export DIGITALOCEAN_TOKEN="Your API TOKEN"
+}
+
+data "digitalocean_vpc" "default" {
+  region = var.region
+}
+
+data "digitalocean_database_metrics_credentials" "test" {}
+
+resource "digitalocean_database_cluster" "test" {
+  name                 = var.db_name
+  engine               = var.db_engine
+  version              = var.db_version
+  size                 = var.db_size
+  region               = var.region
+  node_count           = var.db_node_count
+  private_network_uuid = data.digitalocean_vpc.default.id
+}

--- a/examples/database/outputs.tf
+++ b/examples/database/outputs.tf
@@ -1,0 +1,15 @@
+output "monitoring_endpoints" {
+  description = "The metrics endpoints for the database cluster"
+  value       = digitalocean_database_cluster.test.metrics_endpoints
+}
+
+output "monitoring_user" {
+  description = "The username for accessing database metrics"
+  value       = data.digitalocean_database_metrics_credentials.test.username
+}
+
+output "monitoring_password" {
+  description = "The password for accessing database metrics"
+  sensitive   = true
+  value       = data.digitalocean_database_metrics_credentials.test.password
+}

--- a/examples/database/variables.tf
+++ b/examples/database/variables.tf
@@ -1,0 +1,35 @@
+variable "region" {
+  description = "DigitalOcean region where resources will be created"
+  type        = string
+  default     = "sfo3"
+}
+
+variable "db_name" {
+  description = "Name for the database cluster"
+  type        = string
+  default     = "test-pg"
+}
+
+variable "db_engine" {
+  description = "Database engine to use"
+  type        = string
+  default     = "pg"
+}
+
+variable "db_version" {
+  description = "Database version to use"
+  type        = string
+  default     = "17"
+}
+
+variable "db_size" {
+  description = "Database size slug"
+  type        = string
+  default     = "db-s-2vcpu-4gb"
+}
+
+variable "db_node_count" {
+  description = "Number of nodes in the database cluster"
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Changes
This PR adds support for retrieving database related details via Terrafrom. This is done by:

* Adding a `metrics_endpoints` attributre to the `digitalocean_database_cluster` resource and datasource
* Added a new `digitalocean_database_metrics_credentials` datasource 
* Added/Update docs to reflect changes
* database example including new attributes and datasources

## Motivation
These changes allow users to create database clusters and then generate the configurations need to monitor those database via Prometheus or other monitoring systems.

## Testing
* plan and apply with new database example
* Ran acceptance tests:
  * `TestAccDigitalOceanDatabaseCluster_Basic`
  * `TestAccDataSourceDigitalOceanDatabaseCluster_Basic`
  * `TestAccDataSourceDigitalOceanDatabaseMetricsCredentials`