### PR TITLE
added VALKEY as a valid DB engine for App Platform App Spec

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -1172,6 +1172,7 @@ func appSpecDatabaseSchema() *schema.Resource {
 					"MONGODB",
 					"KAFKA",
 					"OPENSEARCH",
+					"VALKEY",
 				}, false),
 				Description: "The database engine to use.",
 			},


### PR DESCRIPTION
Looks like this has been missed when we added support for Valkey.

<img width="1508" height="538" alt="image" src="https://github.com/user-attachments/assets/812cef05-90e1-422f-88c5-5d44be622db5" />
