### PR TITLE
fix kubernetes cluster autoscaler configuration no-op updates and un-…

### DIFF
--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -547,7 +547,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 			HA:                             godo.PtrTo(d.Get("ha").(bool)),
 			ControlPlaneFirewall:           expandControlPlaneFirewallOpts(d.Get(controlPlaneFirewallField).([]interface{})),
 			RoutingAgent:                   expandRoutingAgentOpts(d.Get(routingAgentField).([]interface{})),
-			ClusterAutoscalerConfiguration: expandCAConfigOptsForUpdate(d.Get("cluster_autoscaler_configuration").([]interface{})),
+			ClusterAutoscalerConfiguration: expandCAConfigOptsForUpdate(d.GetChange("cluster_autoscaler_configuration")),
 		}
 
 		if maint, ok := d.GetOk("maintenance_policy"); ok {


### PR DESCRIPTION
…setting of customizations

In TF, updates are a PUT-like operation where removal of a field should generally be interpreted as un-setting that field.
But on the backend, in k8saas api, updates are done via PATCH requests.
I tried to capture that logic for cluster_autoscaler_configuration.expanders before, but didn't quite get it right, there were a couple problems:

1. On every `update`, even if existing cluster had `nil` expanders, and the cluster being applied also had `nil` expanders, it still sent an empty array of expanders. Since the expanders are behind a feature flipper, this led to validation errors for customers that didn't have the feature enabled. In this PR, I'm ensuring that if existing expanders are empty, and the desired expanders are empty (be it nil or `[]`), we send `nil` to the api, i.e. "no update".
2. If a user had expanders configured, and later unset them, which resulted in existing cluster having an empty array of expanders, then on every subsequent TF apply, TF saw a non-empty diff `expanders = [] -> null`