### PR TITLE
docs(digitalocean_vpc_peering): VPC Peering is GA

### DIFF
--- a/docs/data-sources/vpc_peering.md
+++ b/docs/data-sources/vpc_peering.md
@@ -5,8 +5,6 @@ subcategory: "Networking"
 
 # digitalocean_vpc_peering
 
--> VPC peering is currently in alpha. If you are not a member of the alpha group for this feature, you will not be able to use it until it has been more widely released. Please follow the official [DigitalOcean changelog](https://docs.digitalocean.com/release-notes/) for updates.
-
 Retrieve information about a VPC Peering for use in other resources.
 
 This data source provides all of the VPC Peering's properties as configured on your 

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -5,8 +5,6 @@ subcategory: "Networking"
 
 # digitalocean_vpc_peering
 
--> VPC peering is currently in alpha. If you are not a member of the alpha group for this feature, you will not be able to use it until it has been more widely released. Please follow the official [DigitalOcean changelog](https://docs.digitalocean.com/release-notes/) for updates.
-
 Provides a [DigitalOcean VPC Peering](#digitalocean_vpc_peering) resource.
 
 VPC Peerings are used to connect two VPC networks allowing resources in each 


### PR DESCRIPTION
This pull request makes a small documentation update to the VPC Peering data source. The change removes a note about the alpha status of VPC peering, reflecting that the feature is now [generally available](https://www.digitalocean.com/blog/vpc-peering-ga).