### PR TITLE
Force replace nat gateway with vpc update

### DIFF
--- a/digitalocean/vpcnatgateway/resource_vpc_nat_gateway.go
+++ b/digitalocean/vpcnatgateway/resource_vpc_nat_gateway.go
@@ -66,6 +66,7 @@ func ResourceDigitalOceanVPCNATGateway() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "ID of the ingress VPC",
+							ForceNew:    true,
 						},
 						"gateway_ip": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
Enforce dependency between NAT gateway and VPC in the resources schema: we currently don't support updating the vpc in place for existing gateways (also don't support add/removing ingresses) so we'll need to force new creates (teardown and replace) any existing gateways if their ingresses are tied to a vpc which is also being replaced. 