### PR TITLE
Include slug version in Kubernetes cluster errors

### DIFF
--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -445,7 +445,7 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 
 	cluster, _, err := client.Kubernetes.Create(context.Background(), opts)
 	if err != nil {
-		return diag.Errorf("Error creating Kubernetes cluster: %s", err)
+		return diag.Errorf("Error creating Kubernetes cluster with version %s: %s", d.Get("version").(string), err)
 	}
 
 	// set the cluster id
@@ -455,7 +455,7 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 	_, err = waitForKubernetesClusterCreate(client, d)
 	if err != nil {
 		d.SetId("")
-		return diag.Errorf("Error creating Kubernetes cluster: %s", err)
+		return diag.Errorf("Error creating Kubernetes cluster with version %s: %s", d.Get("version").(string), err)
 	}
 
 	if d.Get("registry_integration") == true {
@@ -614,7 +614,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 				return nil
 			}
 
-			return diag.Errorf("Unable to update cluster: %s", err)
+			return diag.Errorf("Unable to update cluster with version %s: %s", d.Get("version").(string), err)
 		}
 	}
 
@@ -644,7 +644,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 
 		_, err := client.Kubernetes.Upgrade(context.Background(), d.Id(), opts)
 		if err != nil {
-			return diag.Errorf("Unable to upgrade cluster version: %s", err)
+			return diag.Errorf("Unable to upgrade cluster to version %s: %s", d.Get("version").(string), err)
 		}
 	}
 


### PR DESCRIPTION
Issue: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1356

Tested with the following:
```terraform
terraform {
  required_providers {
    digitalocean = {
      source  = "digitalocean/digitalocean"
      version = ">= 2.67.0"
    }
  }
}

provider "digitalocean" {
  token = var.do_token
}

variable "do_token" {
  description = "DigitalOcean API token"
  type        = string
}

resource "digitalocean_kubernetes_cluster" "test" {
  name    = "test-invalid-version"
  region  = "sfo3" 
  version = "1.999.999-invalid-slug"  # This will cause the error

  node_pool {
    name       = "default"
    size       = "s-1vcpu-2gb"
    node_count = 1
  }
}
```
Before the change, the error looks like:
```
│ Error: Error creating Kubernetes cluster: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 (request "b0a344fc-e393-4484-aeb2-842c099b54e8") failed to test requested version slug "1.999.999-invalid-slug" for VersionFeatureDockerVpcBugFixed feature: invalid version slug
```
With this change, the error contains
```
│ Error: Error creating Kubernetes cluster with version 1.999.999-invalid-slug: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 (request "3f036119-d3df-4a12-871f-4174c9752788") failed to test requested version slug "1.999.999-invalid-slug" for VersionFeatureDockerVpcBugFixed feature: invalid version slug
```