### PR TITLE
APP Platform: Fix Intermittent 524 error

### DIFF
--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -7,12 +7,62 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	apppkg "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/app"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+// Unit tests for deployment_per_page schema.
+func TestDeploymentPerPageSchemaExists(t *testing.T) {
+	r := apppkg.ResourceDigitalOceanApp()
+
+	s, ok := r.Schema["deployment_per_page"]
+	if !ok {
+		t.Fatalf("expected schema to contain 'deployment_per_page'")
+	}
+
+	if s.Type != 2 { // schema.TypeInt == 2
+		t.Fatalf("deployment_per_page should be TypeInt, got %v", s.Type)
+	}
+
+	if !s.Optional {
+		t.Fatalf("deployment_per_page should be Optional")
+	}
+
+	if s.Default == nil {
+		t.Fatalf("deployment_per_page should have a default")
+	}
+
+	def, ok := s.Default.(int)
+	if !ok || def != 20 {
+		t.Fatalf("deployment_per_page default expected 20, got %#v", s.Default)
+	}
+}
+
+func TestDeploymentPerPageDefaultValueInResourceData(t *testing.T) {
+	r := apppkg.ResourceDigitalOceanApp()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{})
+	got, ok := d.Get("deployment_per_page").(int)
+	if !ok {
+		t.Fatalf("deployment_per_page value missing or wrong type")
+	}
+	if got != 20 {
+		t.Fatalf("expected default deployment_per_page 20, got %d", got)
+	}
+}
+
+func TestDeploymentPerPageCustomValueInResourceData(t *testing.T) {
+	r := apppkg.ResourceDigitalOceanApp()
+	input := map[string]interface{}{"deployment_per_page": 5}
+	d := schema.TestResourceDataRaw(t, r.Schema, input)
+	got := d.Get("deployment_per_page").(int)
+	if got != 5 {
+		t.Fatalf("expected deployment_per_page 5, got %d", got)
+	}
+}
 
 func TestAccDigitalOceanApp_Image(t *testing.T) {
 	var app godo.App

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -677,6 +677,7 @@ In addition to the above attributes, the following are exported:
 - `urn` - The uniform resource identifier for the app.
 - `updated_at` - The date and time of when the app was last updated.
 - `created_at` - The date and time of when the app was created.
+- `deployment_per_page` - (Optional) Controls how many deployments are requested per API page when listing deployments during create/update waits. Defaults to `20`. Reduce this value (for example `5`) if you experience API timeouts when listing deployments.
 
 ## Import
 


### PR DESCRIPTION
Accounts with tens of thousands of deployments can produce very large API responses. Large single responses sometimes hit Intermittent 524 error. Reducing per-request payload size avoids those timeouts.

- Made App Platform ListDeployments page-size configurable to avoid intermittent 524 timeouts when listing very large deployment histories.
- Adds an optional resource attribute `deployment_per_page` (int, default 20) to `digitalocean_app` and wires it into `waitForAppDeployment` so ListDeployments uses `&godo.ListOptions{PerPage: perPage}`.
- Includes unit tests for schema presence, default, and custom values.

What changed

- Schema: added `deployment_per_page` (TypeInt, Optional, Default: 20).
- Create/Update: read `deployment_per_page` and pass to `waitForAppDeployment`.
- `waitForAppDeployment`: uses `&godo.ListOptions{PerPage: perPage}` when calling `client.Apps.ListDeployments`.
- Docs: updated resource docs to document `deployment_per_page`.
- Tests: added unit tests verifying schema, default value, and override behavior.

Usage

- Default behavior unchanged (deployment_per_page = 20).
- To reduce response size (recommended if you observe 524 error), set in your resource:

```
resource "digitalocean_app" "example" {
  deployment_per_page = 5
  spec {
    ...
  }
}
```