### PR TITLE
Add Database Logsink Resources

### DIFF
--- a/digitalocean/database/import_database_logsink_test.go
+++ b/digitalocean/database/import_database_logsink_test.go
@@ -1,0 +1,113 @@
+package database_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_ImportBasic(t *testing.T) {
+	resourceName := "digitalocean_database_logsink_rsyslog.test"
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigBasic, clusterName, logsinkName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Import requires cluster_id,logsink_id format
+				ImportStateIdFunc: testAccDatabaseLogsinkImportID(resourceName),
+			},
+			// Test importing non-existent resource provides expected error
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", "non-existent-logsink-id"),
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
+			},
+			// Test invalid ID format
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "invalid-id-format",
+				ExpectError:       regexp.MustCompile("must use the format 'cluster_id,logsink_id' for import"),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_ImportBasic(t *testing.T) {
+	resourceName := "digitalocean_database_logsink_opensearch.test"
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigBasic, clusterName, logsinkName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Import requires cluster_id,logsink_id format
+				ImportStateIdFunc: testAccDatabaseLogsinkImportID(resourceName),
+			},
+			// Test importing non-existent resource provides expected error
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", "non-existent-logsink-id"),
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
+			},
+			// Test invalid ID format
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "invalid-id-format",
+				ExpectError:       regexp.MustCompile("must use the format 'cluster_id,logsink_id' for import"),
+			},
+		},
+	})
+}
+
+func testAccDatabaseLogsinkImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		logsinkID := rs.Primary.Attributes["logsink_id"]
+
+		if clusterID == "" {
+			return "", fmt.Errorf("cluster_id not found in resource state")
+		}
+
+		if logsinkID == "" {
+			return "", fmt.Errorf("logsink_id not found in resource state")
+		}
+
+		return fmt.Sprintf("%s,%s", clusterID, logsinkID), nil
+	}
+}

--- a/digitalocean/database/resource_database_logsink_opensearch.go
+++ b/digitalocean/database/resource_database_logsink_opensearch.go
@@ -1,0 +1,321 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceDigitalOceanDatabaseLogsinkOpensearch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDigitalOceanDatabaseLogsinkOpensearchCreate,
+		ReadContext:   resourceDigitalOceanDatabaseLogsinkOpensearchRead,
+		UpdateContext: resourceDigitalOceanDatabaseLogsinkOpensearchUpdate,
+		DeleteContext: resourceDigitalOceanDatabaseLogsinkOpensearchDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDigitalOceanDatabaseLogsinkOpensearchImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Description:  "UUID of the source database cluster that will forward logs",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Description:  "Display name for the logsink",
+			},
+			"endpoint": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateHTTPSEndpoint,
+				Description:  "HTTPS URL to OpenSearch (https://host:port)",
+			},
+			"index_prefix": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateIndexPrefix,
+				Description:  "Prefix for OpenSearch indices",
+			},
+			"index_days_max": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validateIndexDaysMax,
+				Description:  "Maximum number of days to retain indices (>= 1)",
+			},
+			"ca_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "CA certificate for TLS verification (PEM format)",
+			},
+			"timeout_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validateLogsinkTimeout,
+				Description:  "Request timeout for log deliveries in seconds (>= 1)",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Composite ID of the logsink resource",
+			},
+			"logsink_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The API sink_id returned by DigitalOcean",
+			},
+		},
+
+		CustomizeDiff: customdiff.All(
+			customdiff.ForceNewIfChange("name", func(_ context.Context, old, new, meta interface{}) bool {
+				// Force recreation if name changes
+				return old.(string) != new.(string)
+			}),
+		),
+	}
+}
+
+func resourceDigitalOceanDatabaseLogsinkOpensearchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	req := &godo.DatabaseCreateLogsinkRequest{
+		Name:   d.Get("name").(string),
+		Type:   "opensearch",
+		Config: expandLogsinkConfigOpensearch(d),
+	}
+
+	log.Printf("[DEBUG] Database logsink opensearch create configuration: %#v", req)
+	logsink, _, err := client.Databases.CreateLogsink(ctx, clusterID, req)
+	if err != nil {
+		return diag.Errorf("Error creating database logsink opensearch: %s", err)
+	}
+
+	d.SetId(createLogsinkID(clusterID, logsink.ID))
+	log.Printf("[INFO] Database logsink opensearch ID: %s", logsink.ID)
+
+	// Post-create read for consistency
+	return resourceDigitalOceanDatabaseLogsinkOpensearchRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanDatabaseLogsinkOpensearchRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+
+	if clusterID == "" || logsinkID == "" {
+		return diag.Errorf("Invalid logsink ID format: %s", d.Id())
+	}
+
+	logsink, resp, err := client.Databases.GetLogsink(ctx, clusterID, logsinkID)
+	if err != nil {
+		// If the logsink is somehow already destroyed, mark as successfully gone
+		if resp != nil && resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error retrieving database logsink opensearch: %s", err)
+	}
+
+	if logsink == nil {
+		return diag.Errorf("Error retrieving database logsink opensearch: logsink is nil")
+	}
+
+	d.Set("cluster_id", clusterID)
+	d.Set("name", logsink.Name)
+	d.Set("logsink_id", logsink.ID)
+
+	if err := flattenLogsinkConfigOpensearch(d, logsink.Config); err != nil {
+		return diag.Errorf("Error setting logsink resource data: %s", err)
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseLogsinkOpensearchUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+
+	if clusterID == "" || logsinkID == "" {
+		return diag.Errorf("Invalid logsink ID format: %s", d.Id())
+	}
+
+	req := &godo.DatabaseUpdateLogsinkRequest{
+		Config: expandLogsinkConfigOpensearch(d),
+	}
+
+	log.Printf("[DEBUG] Database logsink opensearch update configuration: %#v", req)
+	_, err := client.Databases.UpdateLogsink(ctx, clusterID, logsinkID, req)
+	if err != nil {
+		return diag.Errorf("Error updating database logsink opensearch: %s", err)
+	}
+
+	// Re-read the resource to refresh state
+	return resourceDigitalOceanDatabaseLogsinkOpensearchRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanDatabaseLogsinkOpensearchDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+
+	if clusterID == "" || logsinkID == "" {
+		return diag.Errorf("Invalid logsink ID format: %s", d.Id())
+	}
+
+	log.Printf("[INFO] Deleting database logsink opensearch: %s", d.Id())
+	_, err := client.Databases.DeleteLogsink(ctx, clusterID, logsinkID)
+	if err != nil {
+		// Treat 404 as success (already removed)
+		if godoErr, ok := err.(*godo.ErrorResponse); ok && godoErr.Response.StatusCode == 404 {
+			log.Printf("[INFO] Database logsink opensearch %s was already deleted", d.Id())
+		} else {
+			return diag.Errorf("Error deleting database logsink opensearch: %s", err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceDigitalOceanDatabaseLogsinkOpensearchImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Validate the import ID format
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+	if clusterID == "" || logsinkID == "" {
+		return nil, fmt.Errorf("must use the format 'cluster_id,logsink_id' for import (e.g. 'deadbeef-dead-4aa5-beef-deadbeef347d,01234567-89ab-cdef-0123-456789abcdef')")
+	}
+
+	// The Read function will handle populating all fields from the API
+	return []*schema.ResourceData{d}, nil
+}
+
+// expandLogsinkConfigOpensearch converts Terraform schema data to godo.DatabaseLogsinkConfig for opensearch
+func expandLogsinkConfigOpensearch(d *schema.ResourceData) *godo.DatabaseLogsinkConfig {
+	config := &godo.DatabaseLogsinkConfig{}
+
+	if v, ok := d.GetOk("endpoint"); ok {
+		config.URL = v.(string)
+	}
+	if v, ok := d.GetOk("index_prefix"); ok {
+		config.IndexPrefix = v.(string)
+	}
+	if v, ok := d.GetOk("index_days_max"); ok {
+		config.IndexDaysMax = v.(int)
+	}
+	if v, ok := d.GetOk("ca_cert"); ok {
+		config.CA = strings.TrimSpace(v.(string))
+	}
+	if v, ok := d.GetOk("timeout_seconds"); ok {
+		config.Timeout = float32(v.(int))
+	}
+
+	return config
+}
+
+// flattenLogsinkConfigOpensearch converts godo.DatabaseLogsinkConfig to Terraform schema data for opensearch
+func flattenLogsinkConfigOpensearch(d *schema.ResourceData, config *godo.DatabaseLogsinkConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.URL != "" {
+		d.Set("endpoint", config.URL)
+	}
+	if config.IndexPrefix != "" {
+		d.Set("index_prefix", config.IndexPrefix)
+	}
+	if config.IndexDaysMax != 0 {
+		d.Set("index_days_max", config.IndexDaysMax)
+	}
+	if config.CA != "" {
+		d.Set("ca_cert", strings.TrimSpace(config.CA))
+	}
+	d.Set("timeout_seconds", int(config.Timeout))
+
+	return nil
+}
+
+// validateHTTPSEndpoint validates that URL uses HTTPS scheme
+func validateHTTPSEndpoint(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be a string", key))
+		return
+	}
+
+	if strings.TrimSpace(v) == "" {
+		errs = append(errs, fmt.Errorf("%q cannot be empty", key))
+		return
+	}
+
+	u, err := url.Parse(v)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("%q must be a valid URL: %s", key, err))
+		return
+	}
+
+	if u.Scheme != "https" {
+		errs = append(errs, fmt.Errorf("%q must use HTTPS scheme", key))
+	}
+
+	return
+}
+
+// validateIndexPrefix validates index_prefix is not empty
+func validateIndexPrefix(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be a string", key))
+		return
+	}
+
+	if strings.TrimSpace(v) == "" {
+		errs = append(errs, fmt.Errorf("%q cannot be empty", key))
+	}
+
+	return
+}
+
+// validateIndexDaysMax validates index_days_max is >= 1
+func validateIndexDaysMax(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(int)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be an integer", key))
+		return
+	}
+
+	if v < 1 {
+		errs = append(errs, fmt.Errorf("%q must be >= 1", key))
+	}
+
+	return
+}
+
+// validateLogsinkTimeout validates timeout is >= 1 second
+func validateLogsinkTimeout(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(int)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be an integer", key))
+		return
+	}
+
+	if v < 1 {
+		errs = append(errs, fmt.Errorf("%q must be >= 1", key))
+	}
+
+	return
+}

--- a/digitalocean/database/resource_database_logsink_opensearch_test.go
+++ b/digitalocean/database/resource_database_logsink_opensearch_test.go
@@ -1,0 +1,273 @@
+package database_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Database Engine Support Matrix for Logsinks:
+// - PostgreSQL, MySQL, Kafka, Valkey: support rsyslog, opensearch logsinks
+// - MongoDB: supports ONLY datadog logsinks (not opensearch or rsyslog)
+//
+// These tests cover opensearch logsink functionality for supported engines only.
+
+// TestAccDigitalOceanDatabaseLogsinkOpensearch_Basic tests creating a basic opensearch logsink
+// with required fields (endpoint, index_prefix, index_days_max). Expected: successful creation.
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_Basic(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigBasic, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_opensearch.test", &logsink),
+					testAccCheckDigitalOceanDatabaseLogsinkAttributes(&logsink, logsinkName, "opensearch"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "name", logsinkName),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "endpoint", "https://opensearch.example.com:9200"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "index_prefix", "db-logs"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "index_days_max", "7"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "timeout_seconds", "10"),
+					resource.TestCheckResourceAttrSet("digitalocean_database_logsink_opensearch.test", "cluster_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_database_logsink_opensearch.test", "logsink_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_database_logsink_opensearch.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkOpensearch_Update tests updating an opensearch logsink
+// configuration (index_prefix, index_days_max, timeout_seconds). Expected: successful update.
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_Update(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigBasic, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_opensearch.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "index_prefix", "db-logs"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "index_days_max", "7"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigUpdated, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_opensearch.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "index_prefix", "updated-logs"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "index_days_max", "14"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "timeout_seconds", "30"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkOpensearch_WithCA tests creating an opensearch logsink
+// with CA certificate for TLS verification. Expected: successful creation with certificate.
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_WithCA(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigWithCA, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_opensearch.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_opensearch.test", "ca_cert", "-----BEGIN CERTIFICATE-----\nMIIDCTCCAfGgAwIBAgIUdh0W7W79ns0Gc+6ZylC6JpCrF50wDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDkxODE3NTMzNloXDTI2MDkx\nODE3NTMzNlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAsBxZyNgjCWqsDE6h5sfMZo1JfD3WFzGZN2XdPwaPDPH9\nGI6UokJbhdJXPhFPyKmXis8vRC7Dos434lCp6RuYEHYk27wBam2pZSAi/P+Be5EU\nbdJdRjikPtu31JVsbZ2ookIc9zfBxPbXd5F4wNlcUFRATv2LC2SFQ91l5fmuiThU\nXx8+0Prls1Jzuz3Ll/oLM+1vxQEZFWvZCcq4HPFyf0p5Y37alxyVGSQxOqnQW3Wu\nhxNVdMKbfhx50B9Kh62LZ4+Pcv06/ftReeIV7+lO+8/FQs1BsjbLlpsIsuXgueR5\nahfOMQ/3/Wu5sb7jN3o6DINjpBmGW8zItWnIiTm8CQIDAQABo1MwUTAdBgNVHQ4E\nFgQUmY7HILyhR4RiRKFkyDyT/7fXLRMwHwYDVR0jBBgwFoAUmY7HILyhR4RiRKFk\nyDyT/7fXLRMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAP/wy\neDjrbAMgeuTUB0DisfkUZo2RKY/hJ9+9lH9VjTQ1foomWr7J8HUJHh7Co1n8Tnjd\n0dAl1agRY0o3VZrASj3gyYWFumbe6BBjhIynzZK3rsP9BzFvl8+xNUS9jkWiFhYU\n5x9f3YzMxXQsRf6sRSfS7/IIF8SCeOZTCJIVMB8l+8XbxsoYpTKz9sG+Opg7LD2K\nFbWGBKiSbxB6SKjax0Fk0MHO07ehjOqlxqns/a78w2AsBNKc2SDv73eXv24dRzJS\nlJu7YXccTSWs2/Y+wDxTMyp3DlJ9kzkgTveXhmKJdhKW8L8a+K1hzNGBrczJeHnm\nCwPzEPg7ca5lXYLDEA==\n-----END CERTIFICATE-----"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkOpensearch_InvalidIndexDaysMax tests validation for invalid index_days_max.
+// Uses value 0 which is below minimum (must be >= 1). Expected: validation error.
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_InvalidIndexDaysMax(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigInvalidIndexDays, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("must be >= 1"),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkOpensearch_EmptyIndexPrefix tests validation for empty index_prefix.
+// Uses empty string for index_prefix which is not allowed. Expected: validation error.
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_EmptyIndexPrefix(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigEmptyIndexPrefix, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile(`"index_prefix" cannot be empty`),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkOpensearch_MalformedEndpoint tests validation for malformed endpoint URLs.
+// Uses invalid URL format that fails scheme validation. Expected: validation error.
+func TestAccDigitalOceanDatabaseLogsinkOpensearch_MalformedEndpoint(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigMalformedEndpoint, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("must use HTTPS scheme"),
+			},
+		},
+	})
+}
+
+const testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigBasic = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_opensearch" "test" {
+  cluster_id      = digitalocean_database_cluster.test.id
+  name            = "%s"
+  endpoint        = "https://opensearch.example.com:9200"
+  index_prefix    = "db-logs"
+  index_days_max  = 7
+  timeout_seconds = 10
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigUpdated = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_opensearch" "test" {
+  cluster_id      = digitalocean_database_cluster.test.id
+  name            = "%s"
+  endpoint        = "https://opensearch.example.com:9200"
+  index_prefix    = "updated-logs"
+  index_days_max  = 14
+  timeout_seconds = 30
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigWithCA = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_opensearch" "test" {
+  cluster_id      = digitalocean_database_cluster.test.id
+  name            = "%s"
+  endpoint        = "https://opensearch.example.com:9200"
+  index_prefix    = "db-logs"
+  index_days_max  = 7
+  timeout_seconds = 10
+  ca_cert         = "-----BEGIN CERTIFICATE-----\nMIIDCTCCAfGgAwIBAgIUdh0W7W79ns0Gc+6ZylC6JpCrF50wDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDkxODE3NTMzNloXDTI2MDkx\nODE3NTMzNlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAsBxZyNgjCWqsDE6h5sfMZo1JfD3WFzGZN2XdPwaPDPH9\nGI6UokJbhdJXPhFPyKmXis8vRC7Dos434lCp6RuYEHYk27wBam2pZSAi/P+Be5EU\nbdJdRjikPtu31JVsbZ2ookIc9zfBxPbXd5F4wNlcUFRATv2LC2SFQ91l5fmuiThU\nXx8+0Prls1Jzuz3Ll/oLM+1vxQEZFWvZCcq4HPFyf0p5Y37alxyVGSQxOqnQW3Wu\nhxNVdMKbfhx50B9Kh62LZ4+Pcv06/ftReeIV7+lO+8/FQs1BsjbLlpsIsuXgueR5\nahfOMQ/3/Wu5sb7jN3o6DINjpBmGW8zItWnIiTm8CQIDAQABo1MwUTAdBgNVHQ4E\nFgQUmY7HILyhR4RiRKFkyDyT/7fXLRMwHwYDVR0jBBgwFoAUmY7HILyhR4RiRKFk\nyDyT/7fXLRMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAP/wy\neDjrbAMgeuTUB0DisfkUZo2RKY/hJ9+9lH9VjTQ1foomWr7J8HUJHh7Co1n8Tnjd\n0dAl1agRY0o3VZrASj3gyYWFumbe6BBjhIynzZK3rsP9BzFvl8+xNUS9jkWiFhYU\n5x9f3YzMxXQsRf6sRSfS7/IIF8SCeOZTCJIVMB8l+8XbxsoYpTKz9sG+Opg7LD2K\nFbWGBKiSbxB6SKjax0Fk0MHO07ehjOqlxqns/a78w2AsBNKc2SDv73eXv24dRzJS\nlJu7YXccTSWs2/Y+wDxTMyp3DlJ9kzkgTveXhmKJdhKW8L8a+K1hzNGBrczJeHnm\nCwPzEPg7ca5lXYLDEA==\n-----END CERTIFICATE-----"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigInvalidIndexDays = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_opensearch" "test" {
+  cluster_id     = digitalocean_database_cluster.test.id
+  name           = "%s"
+  endpoint       = "https://opensearch.example.com:9200"
+  index_prefix   = "db-logs"
+  index_days_max = 0
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigEmptyIndexPrefix = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_opensearch" "test" {
+  cluster_id     = digitalocean_database_cluster.test.id
+  name           = "%s"
+  endpoint       = "https://opensearch.example.com:9200"
+  index_prefix   = ""
+  index_days_max = 7
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkOpensearchConfigMalformedEndpoint = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_opensearch" "test" {
+  cluster_id     = digitalocean_database_cluster.test.id
+  name           = "%s"
+  endpoint       = "not-a-valid-url"
+  index_prefix   = "db-logs"
+  index_days_max = 7
+}`

--- a/digitalocean/database/resource_database_logsink_rsyslog.go
+++ b/digitalocean/database/resource_database_logsink_rsyslog.go
@@ -1,0 +1,376 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceDigitalOceanDatabaseLogsinkRsyslog() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDigitalOceanDatabaseLogsinkRsyslogCreate,
+		ReadContext:   resourceDigitalOceanDatabaseLogsinkRsyslogRead,
+		UpdateContext: resourceDigitalOceanDatabaseLogsinkRsyslogUpdate,
+		DeleteContext: resourceDigitalOceanDatabaseLogsinkRsyslogDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDigitalOceanDatabaseLogsinkRsyslogImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Description:  "UUID of the source database cluster that will forward logs",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Description:  "Display name for the logsink",
+			},
+			"server": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Description:  "Hostname or IP address of the rsyslog server",
+			},
+			"port": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validateLogsinkPort,
+				Description:  "Port number for the rsyslog server (1-65535)",
+			},
+			"tls": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable TLS encryption for rsyslog connection",
+			},
+			"format": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "rfc5424",
+				ValidateFunc: validateRsyslogFormat,
+				Description:  "Log format: rfc5424, rfc3164, or custom",
+			},
+			"logline": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Custom logline template (required when format is 'custom')",
+			},
+			"structured_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Structured data for rsyslog",
+			},
+			"ca_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "CA certificate for TLS verification (PEM format)",
+			},
+			"client_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Client certificate for mTLS (PEM format)",
+			},
+			"client_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Client private key for mTLS (PEM format)",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Composite ID of the logsink resource",
+			},
+			"logsink_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The API sink_id returned by DigitalOcean",
+			},
+		},
+
+		CustomizeDiff: customdiff.All(
+			customdiff.ForceNewIfChange("name", func(_ context.Context, old, new, meta interface{}) bool {
+				// Force recreation if name changes
+				return old.(string) != new.(string)
+			}),
+			func(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return validateLogsinkCustomDiff(diff, "rsyslog")
+			},
+		),
+	}
+}
+
+func resourceDigitalOceanDatabaseLogsinkRsyslogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	req := &godo.DatabaseCreateLogsinkRequest{
+		Name:   d.Get("name").(string),
+		Type:   "rsyslog",
+		Config: expandLogsinkConfigRsyslog(d),
+	}
+
+	log.Printf("[DEBUG] Database logsink rsyslog create configuration: %#v", req)
+	logsink, _, err := client.Databases.CreateLogsink(ctx, clusterID, req)
+	if err != nil {
+		return diag.Errorf("Error creating database logsink rsyslog: %s", err)
+	}
+
+	log.Printf("[DEBUG] API Response logsink: %#v", logsink)
+	log.Printf("[DEBUG] Logsink ID: '%s'", logsink.ID)
+	log.Printf("[DEBUG] Logsink Name: '%s'", logsink.Name)
+	log.Printf("[DEBUG] Logsink Type: '%s'", logsink.Type)
+
+	d.SetId(createLogsinkID(clusterID, logsink.ID))
+	log.Printf("[INFO] Database logsink rsyslog ID: %s", logsink.ID)
+
+	// Post-create read for consistency
+	return resourceDigitalOceanDatabaseLogsinkRsyslogRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanDatabaseLogsinkRsyslogRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+
+	if clusterID == "" || logsinkID == "" {
+		return diag.Errorf("Invalid logsink ID format: %s", d.Id())
+	}
+
+	logsink, resp, err := client.Databases.GetLogsink(ctx, clusterID, logsinkID)
+	if err != nil {
+		// If the logsink is somehow already destroyed, mark as successfully gone
+		if resp != nil && resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error retrieving database logsink rsyslog: %s", err)
+	}
+
+	if logsink == nil {
+		return diag.Errorf("Error retrieving database logsink rsyslog: logsink is nil")
+	}
+
+	d.Set("cluster_id", clusterID)
+	d.Set("name", logsink.Name)
+	d.Set("logsink_id", logsink.ID)
+
+	if err := flattenLogsinkConfigRsyslog(d, logsink.Config); err != nil {
+		return diag.Errorf("Error setting logsink resource data: %s", err)
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseLogsinkRsyslogUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+
+	if clusterID == "" || logsinkID == "" {
+		return diag.Errorf("Invalid logsink ID format: %s", d.Id())
+	}
+
+	req := &godo.DatabaseUpdateLogsinkRequest{
+		Config: expandLogsinkConfigRsyslog(d),
+	}
+
+	log.Printf("[DEBUG] Database logsink rsyslog update configuration: %#v", req)
+	_, err := client.Databases.UpdateLogsink(ctx, clusterID, logsinkID, req)
+	if err != nil {
+		return diag.Errorf("Error updating database logsink rsyslog: %s", err)
+	}
+
+	// Re-read the resource to refresh state
+	return resourceDigitalOceanDatabaseLogsinkRsyslogRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanDatabaseLogsinkRsyslogDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+
+	if clusterID == "" || logsinkID == "" {
+		return diag.Errorf("Invalid logsink ID format: %s", d.Id())
+	}
+
+	log.Printf("[INFO] Deleting database logsink rsyslog: %s", d.Id())
+	_, err := client.Databases.DeleteLogsink(ctx, clusterID, logsinkID)
+	if err != nil {
+		// Treat 404 as success (already removed)
+		if godoErr, ok := err.(*godo.ErrorResponse); ok && godoErr.Response.StatusCode == 404 {
+			log.Printf("[INFO] Database logsink rsyslog %s was already deleted", d.Id())
+		} else {
+			return diag.Errorf("Error deleting database logsink rsyslog: %s", err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceDigitalOceanDatabaseLogsinkRsyslogImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Validate the import ID format
+	clusterID, logsinkID := splitLogsinkID(d.Id())
+	if clusterID == "" || logsinkID == "" {
+		return nil, fmt.Errorf("must use the format 'cluster_id,logsink_id' for import (e.g. 'deadbeef-dead-4aa5-beef-deadbeef347d,01234567-89ab-cdef-0123-456789abcdef')")
+	}
+
+	// The Read function will handle populating all fields from the API
+	return []*schema.ResourceData{d}, nil
+}
+
+// createLogsinkID creates a composite ID for logsink resources
+// Format: <cluster_id>,<logsink_id>
+func createLogsinkID(clusterID string, logsinkID string) string {
+	return fmt.Sprintf("%s,%s", clusterID, logsinkID)
+}
+
+// splitLogsinkID splits a composite logsink ID into cluster ID and logsink ID
+func splitLogsinkID(id string) (string, string) {
+	parts := strings.SplitN(id, ",", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+// expandLogsinkConfigRsyslog converts Terraform schema data to godo.DatabaseLogsinkConfig for rsyslog
+func expandLogsinkConfigRsyslog(d *schema.ResourceData) *godo.DatabaseLogsinkConfig {
+	config := &godo.DatabaseLogsinkConfig{}
+
+	config.Server = d.Get("server").(string)
+	config.Port = d.Get("port").(int)
+	config.TLS = d.Get("tls").(bool)
+	config.Format = d.Get("format").(string)
+	if v, ok := d.GetOk("logline"); ok {
+		config.Logline = v.(string)
+	}
+	if v, ok := d.GetOk("structured_data"); ok {
+		config.SD = v.(string)
+	}
+	if v, ok := d.GetOk("ca_cert"); ok {
+		config.CA = strings.TrimSpace(v.(string))
+	}
+	if v, ok := d.GetOk("client_cert"); ok {
+		config.Cert = strings.TrimSpace(v.(string))
+	}
+	if v, ok := d.GetOk("client_key"); ok {
+		config.Key = strings.TrimSpace(v.(string))
+	}
+
+	return config
+}
+
+// flattenLogsinkConfigRsyslog converts godo.DatabaseLogsinkConfig to Terraform schema data for rsyslog
+func flattenLogsinkConfigRsyslog(d *schema.ResourceData, config *godo.DatabaseLogsinkConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Server != "" {
+		d.Set("server", config.Server)
+	}
+	if config.Port != 0 {
+		d.Set("port", config.Port)
+	}
+	d.Set("tls", config.TLS)
+	if config.Format != "" {
+		d.Set("format", config.Format)
+	}
+	if config.Logline != "" {
+		d.Set("logline", config.Logline)
+	}
+	if config.SD != "" {
+		d.Set("structured_data", config.SD)
+	}
+	if config.CA != "" {
+		d.Set("ca_cert", strings.TrimSpace(config.CA))
+	}
+	if config.Cert != "" {
+		d.Set("client_cert", strings.TrimSpace(config.Cert))
+	}
+	if config.Key != "" {
+		d.Set("client_key", strings.TrimSpace(config.Key))
+	}
+
+	return nil
+}
+
+// validateLogsinkPort validates port is in range 1-65535
+func validateLogsinkPort(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(int)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be an integer", key))
+		return
+	}
+
+	if v < 1 || v > 65535 {
+		errs = append(errs, fmt.Errorf("%q must be between 1 and 65535", key))
+	}
+
+	return
+}
+
+// validateRsyslogFormat validates format is one of the allowed values
+func validateRsyslogFormat(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be a string", key))
+		return
+	}
+
+	validFormats := []string{"rfc5424", "rfc3164", "custom"}
+	for _, format := range validFormats {
+		if v == format {
+			return
+		}
+	}
+
+	errs = append(errs, fmt.Errorf("%q must be one of: %s", key, strings.Join(validFormats, ", ")))
+	return
+}
+
+// validateLogsinkCustomDiff validates cross-field dependencies for rsyslog logsink resources
+func validateLogsinkCustomDiff(diff *schema.ResourceDiff, sinkType string) error {
+	if sinkType != "rsyslog" {
+		return nil
+	}
+
+	// If format is custom, require logline
+	format := diff.Get("format").(string)
+	logline := diff.Get("logline").(string)
+
+	if format == "custom" && strings.TrimSpace(logline) == "" {
+		return fmt.Errorf("logline is required when format is 'custom'")
+	}
+
+	// If any TLS cert fields are set, require tls = true
+	tls := diff.Get("tls").(bool)
+	caCert := diff.Get("ca_cert").(string)
+	clientCert := diff.Get("client_cert").(string)
+	clientKey := diff.Get("client_key").(string)
+
+	if !tls && (caCert != "" || clientCert != "" || clientKey != "") {
+		return fmt.Errorf("tls must be true when ca_cert, client_cert, or client_key is set")
+	}
+
+	// If client_cert or client_key is set, require both
+	if (clientCert != "" || clientKey != "") && (clientCert == "" || clientKey == "") {
+		return fmt.Errorf("both client_cert and client_key must be set for mTLS")
+	}
+
+	return nil
+}

--- a/digitalocean/database/resource_database_logsink_rsyslog_test.go
+++ b/digitalocean/database/resource_database_logsink_rsyslog_test.go
@@ -1,0 +1,465 @@
+package database_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Database Engine Support Matrix for Logsinks:
+// - PostgreSQL, MySQL, Kafka, Valkey: support rsyslog, opensearch logsinks
+// - MongoDB: supports ONLY datadog logsinks (not opensearch or rsyslog)
+//
+// These tests cover rsyslog logsink functionality for supported engines only.
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_Basic tests creating a basic rsyslog logsink
+// with default settings (TLS disabled, RFC5424 format). Expected: successful creation.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_Basic(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigBasic, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_rsyslog.test", &logsink),
+					testAccCheckDigitalOceanDatabaseLogsinkAttributes(&logsink, logsinkName, "rsyslog"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "name", logsinkName),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "server", "192.168.1.100"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "port", "514"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "format", "rfc5424"),
+					resource.TestCheckResourceAttrSet("digitalocean_database_logsink_rsyslog.test", "cluster_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_database_logsink_rsyslog.test", "logsink_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_database_logsink_rsyslog.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_Update tests updating an rsyslog logsink
+// configuration (port, TLS enabled, format change, structured data). Expected: successful update.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_Update(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigBasic, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_rsyslog.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "port", "514"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "format", "rfc5424"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigUpdated, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_rsyslog.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "port", "1514"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "tls", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "format", "rfc3164"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "structured_data", "[example@41058 iut=\"3\"]"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_CustomFormat tests creating an rsyslog logsink
+// with custom format and logline template. Expected: successful creation with custom logline.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_CustomFormat(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigCustom, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_rsyslog.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "format", "custom"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "logline", "%timestamp% %HOSTNAME% %app-name% %procid% %msgid% %msg%"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_TLS tests creating an rsyslog logsink
+// with TLS enabled and CA certificate. Expected: successful creation with TLS configuration.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_TLS(t *testing.T) {
+	var logsink godo.DatabaseLogsink
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigTLS, clusterName, logsinkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseLogsinkExists("digitalocean_database_logsink_rsyslog.test", &logsink),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "tls", "true"),
+					resource.TestCheckResourceAttr("digitalocean_database_logsink_rsyslog.test", "ca_cert", "-----BEGIN CERTIFICATE-----\nMIIDCTCCAfGgAwIBAgIUdh0W7W79ns0Gc+6ZylC6JpCrF50wDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDkxODE3NTMzNloXDTI2MDkx\nODE3NTMzNlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAsBxZyNgjCWqsDE6h5sfMZo1JfD3WFzGZN2XdPwaPDPH9\nGI6UokJbhdJXPhFPyKmXis8vRC7Dos434lCp6RuYEHYk27wBam2pZSAi/P+Be5EU\nbdJdRjikPtu31JVsbZ2ookIc9zfBxPbXd5F4wNlcUFRATv2LC2SFQ91l5fmuiThU\nXx8+0Prls1Jzuz3Ll/oLM+1vxQEZFWvZCcq4HPFyf0p5Y37alxyVGSQxOqnQW3Wu\nhxNVdMKbfhx50B9Kh62LZ4+Pcv06/ftReeIV7+lO+8/FQs1BsjbLlpsIsuXgueR5\nahfOMQ/3/Wu5sb7jN3o6DINjpBmGW8zItWnIiTm8CQIDAQABo1MwUTAdBgNVHQ4E\nFgQUmY7HILyhR4RiRKFkyDyT/7fXLRMwHwYDVR0jBBgwFoAUmY7HILyhR4RiRKFk\nyDyT/7fXLRMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAP/wy\neDjrbAMgeuTUB0DisfkUZo2RKY/hJ9+9lH9VjTQ1foomWr7J8HUJHh7Co1n8Tnjd\n0dAl1agRY0o3VZrASj3gyYWFumbe6BBjhIynzZK3rsP9BzFvl8+xNUS9jkWiFhYU\n5x9f3YzMxXQsRf6sRSfS7/IIF8SCeOZTCJIVMB8l+8XbxsoYpTKz9sG+Opg7LD2K\nFbWGBKiSbxB6SKjax0Fk0MHO07ehjOqlxqns/a78w2AsBNKc2SDv73eXv24dRzJS\nlJu7YXccTSWs2/Y+wDxTMyp3DlJ9kzkgTveXhmKJdhKW8L8a+K1hzNGBrczJeHnm\nCwPzEPg7ca5lXYLDEA==\n-----END CERTIFICATE-----"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_MongoDB_ShouldFail tests that creating an rsyslog logsink
+// with a MongoDB cluster fails due to engine incompatibility. Expected: validation error.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_MongoDB_ShouldFail(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigMongoDB, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("log sink not supported"),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_InvalidPort tests validation for invalid port values.
+// Uses port 0 which is outside the valid range (1-65535). Expected: validation error.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_InvalidPort(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigInvalidPort, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("must be between 1 and 65535"),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_CustomFormatRequiresLogline tests validation for custom format.
+// Uses format "custom" without providing logline field. Expected: validation error requiring logline.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_CustomFormatRequiresLogline(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigCustomNoLogline, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("logline is required when format is 'custom'"),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_InvalidFormat tests validation for invalid format values.
+// Uses "invalid_format" which is not in allowed values (rfc5424, rfc3164, custom). Expected: validation error.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_InvalidFormat(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigInvalidFormat, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("must be one of: rfc5424, rfc3164, custom"),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanDatabaseLogsinkRsyslog_CertWithoutTLS tests validation for certificate fields without TLS.
+// Provides ca_cert but leaves TLS disabled (default false). Expected: validation error requiring TLS.
+func TestAccDigitalOceanDatabaseLogsinkRsyslog_CertWithoutTLS(t *testing.T) {
+	clusterName := acceptance.RandomTestName()
+	logsinkName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseLogsinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigCertWithoutTLS, clusterName, logsinkName),
+				ExpectError: regexp.MustCompile("tls must be true when ca_cert, client_cert, or client_key is set"),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanDatabaseLogsinkExists(resource string, logsink *godo.DatabaseLogsink) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+		// Parse composite ID
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		logsinkID := rs.Primary.Attributes["logsink_id"]
+
+		foundLogsink, _, err := client.Databases.GetLogsink(context.Background(), clusterID, logsinkID)
+		if err != nil {
+			return err
+		}
+
+		if foundLogsink.ID != logsinkID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*logsink = *foundLogsink
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDatabaseLogsinkAttributes(logsink *godo.DatabaseLogsink, name, sinkType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if logsink.Name != name {
+			return fmt.Errorf("Bad name: %s", logsink.Name)
+		}
+
+		if logsink.Type != sinkType {
+			return fmt.Errorf("Bad sink type: %s", logsink.Type)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDatabaseLogsinkDestroy(s *terraform.State) error {
+	client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_database_logsink_rsyslog" && rs.Type != "digitalocean_database_logsink_opensearch" {
+			continue
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		logsinkID := rs.Primary.Attributes["logsink_id"]
+
+		_, _, err := client.Databases.GetLogsink(context.Background(), clusterID, logsinkID)
+		if err == nil {
+			return fmt.Errorf("DatabaseLogsink still exists")
+		}
+	}
+
+	return nil
+}
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigBasic = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  tls        = false
+  format     = "rfc5424"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigUpdated = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id      = digitalocean_database_cluster.test.id
+  name            = "%s"
+  server          = "192.168.1.100"
+  port            = 1514
+  tls             = true
+  format          = "rfc3164"
+  structured_data = "[example@41058 iut=\"3\"]"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigCustom = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  tls        = false
+  format     = "custom"
+  logline    = "%%timestamp%% %%HOSTNAME%% %%app-name%% %%procid%% %%msgid%% %%msg%%"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigTLS = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  tls        = true
+  ca_cert    = "-----BEGIN CERTIFICATE-----\nMIIDCTCCAfGgAwIBAgIUdh0W7W79ns0Gc+6ZylC6JpCrF50wDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDkxODE3NTMzNloXDTI2MDkx\nODE3NTMzNlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAsBxZyNgjCWqsDE6h5sfMZo1JfD3WFzGZN2XdPwaPDPH9\nGI6UokJbhdJXPhFPyKmXis8vRC7Dos434lCp6RuYEHYk27wBam2pZSAi/P+Be5EU\nbdJdRjikPtu31JVsbZ2ookIc9zfBxPbXd5F4wNlcUFRATv2LC2SFQ91l5fmuiThU\nXx8+0Prls1Jzuz3Ll/oLM+1vxQEZFWvZCcq4HPFyf0p5Y37alxyVGSQxOqnQW3Wu\nhxNVdMKbfhx50B9Kh62LZ4+Pcv06/ftReeIV7+lO+8/FQs1BsjbLlpsIsuXgueR5\nahfOMQ/3/Wu5sb7jN3o6DINjpBmGW8zItWnIiTm8CQIDAQABo1MwUTAdBgNVHQ4E\nFgQUmY7HILyhR4RiRKFkyDyT/7fXLRMwHwYDVR0jBBgwFoAUmY7HILyhR4RiRKFk\nyDyT/7fXLRMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAP/wy\neDjrbAMgeuTUB0DisfkUZo2RKY/hJ9+9lH9VjTQ1foomWr7J8HUJHh7Co1n8Tnjd\n0dAl1agRY0o3VZrASj3gyYWFumbe6BBjhIynzZK3rsP9BzFvl8+xNUS9jkWiFhYU\n5x9f3YzMxXQsRf6sRSfS7/IIF8SCeOZTCJIVMB8l+8XbxsoYpTKz9sG+Opg7LD2K\nFbWGBKiSbxB6SKjax0Fk0MHO07ehjOqlxqns/a78w2AsBNKc2SDv73eXv24dRzJS\nlJu7YXccTSWs2/Y+wDxTMyp3DlJ9kzkgTveXhmKJdhKW8L8a+K1hzNGBrczJeHnm\nCwPzEPg7ca5lXYLDEA==\n-----END CERTIFICATE-----"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigMongoDB = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "mongodb"
+  version    = "7"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  format     = "rfc5424"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigInvalidPort = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 0
+  tls        = false
+  format     = "rfc5424"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigCustomNoLogline = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  tls        = false
+  format     = "custom"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigInvalidFormat = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  tls        = false
+  format     = "invalid_format"
+}`
+
+const testAccCheckDigitalOceanDatabaseLogsinkRsyslogConfigCertWithoutTLS = `
+resource "digitalocean_database_cluster" "test" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+
+resource "digitalocean_database_logsink_rsyslog" "test" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "%s"
+  server     = "192.168.1.100"
+  port       = 514
+  format     = "rfc5424"
+  ca_cert    = "-----BEGIN CERTIFICATE-----\nMIIDCTCCAfGgAwIBAgIUdh0W7W79ns0Gc+6ZylC6JpCrF50wDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDkxODE3NTMzNloXDTI2MDkx\nODE3NTMzNlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAsBxZyNgjCWqsDE6h5sfMZo1JfD3WFzGZN2XdPwaPDPH9\nGI6UokJbhdJXPhFPyKmXis8vRC7Dos434lCp6RuYEHYk27wBam2pZSAi/P+Be5EU\nbdJdRjikPtu31JVsbZ2ookIc9zfBxPbXd5F4wNlcUFRATv2LC2SFQ91l5fmuiThU\nXx8+0Prls1Jzuz3Ll/oLM+1vxQEZFWvZCcq4HPFyf0p5Y37alxyVGSQxOqnQW3Wu\nhxNVdMKbfhx50B9Kh62LZ4+Pcv06/ftReeIV7+lO+8/FQs1BsjbLlpsIsuXgueR5\nahfOMQ/3/Wu5sb7jN3o6DINjpBmGW8zItWnIiTm8CQIDAQABo1MwUTAdBgNVHQ4E\nFgQUmY7HILyhR4RiRKFkyDyT/7fXLRMwHwYDVR0jBBgwFoAUmY7HILyhR4RiRKFk\nyDyT/7fXLRMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAP/wy\neDjrbAMgeuTUB0DisfkUZo2RKY/hJ9+9lH9VjTQ1foomWr7J8HUJHh7Co1n8Tnjd\n0dAl1agRY0o3VZrASj3gyYWFumbe6BBjhIynzZK3rsP9BzFvl8+xNUS9jkWiFhYU\n5x9f3YzMxXQsRf6sRSfS7/IIF8SCeOZTCJIVMB8l+8XbxsoYpTKz9sG+Opg7LD2K\nFbWGBKiSbxB6SKjax0Fk0MHO07ehjOqlxqns/a78w2AsBNKc2SDv73eXv24dRzJS\nlJu7YXccTSWs2/Y+wDxTMyp3DlJ9kzkgTveXhmKJdhKW8L8a+K1hzNGBrczJeHnm\nCwPzEPg7ca5lXYLDEA==\n-----END CERTIFICATE-----"
+}`

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -197,6 +197,8 @@ func Provider() *schema.Provider {
 			"digitalocean_database_kafka_topic":                  database.ResourceDigitalOceanDatabaseKafkaTopic(),
 			"digitalocean_database_kafka_schema_registry":        database.ResourceDigitalOceanDatabaseKafkaSchemaRegistry(),
 			"digitalocean_database_online_migration":             database.ResourceDigitalOceanDatabaseOnlineMigration(),
+			"digitalocean_database_logsink_rsyslog":              database.ResourceDigitalOceanDatabaseLogsinkRsyslog(),
+			"digitalocean_database_logsink_opensearch":           database.ResourceDigitalOceanDatabaseLogsinkOpensearch(),
 			"digitalocean_domain":                                domain.ResourceDigitalOceanDomain(),
 			"digitalocean_droplet":                               droplet.ResourceDigitalOceanDroplet(),
 			"digitalocean_droplet_autoscale":                     dropletautoscale.ResourceDigitalOceanDropletAutoscale(),

--- a/docs/resources/database_logsink_opensearch.md
+++ b/docs/resources/database_logsink_opensearch.md
@@ -1,0 +1,129 @@
+---
+page_title: "DigitalOcean: digitalocean_database_logsink_opensearch"
+subcategory: "Databases"
+---
+
+# digitalocean\_database\_logsink\_opensearch
+
+Provides a DigitalOcean database logsink resource allowing you to forward logs from a managed database cluster to an external OpenSearch cluster or Elasticsearch endpoint.
+
+This resource is compatible with both OpenSearch and Elasticsearch endpoints due to API compatibility. You can use this resource to connect to either service.
+
+This resource supports the following DigitalOcean managed database engines:
+
+* PostgreSQL
+* MySQL
+* Kafka
+* Valkey
+
+**Note**: MongoDB databases use a different log forwarding mechanism and require Datadog logsinks (not currently available in this provider).
+
+## Example Usage
+
+### Basic OpenSearch configuration
+
+```hcl
+resource "digitalocean_database_logsink_opensearch" "example" {
+  cluster_id     = digitalocean_database_cluster.postgres-example.id
+  name           = "opensearch-logs"
+  endpoint       = "https://opensearch.example.com:9200"
+  index_prefix   = "db-logs"
+  index_days_max = 7
+}
+
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+### OpenSearch with authentication and CA certificate
+
+```hcl
+resource "digitalocean_database_logsink_opensearch" "example-secure" {
+  cluster_id      = digitalocean_database_cluster.postgres-example.id
+  name            = "opensearch-secure"
+  endpoint        = "https://user:password@opensearch.example.com:9200"
+  index_prefix    = "secure-logs"
+  index_days_max  = 14
+  ca_cert         = file("/path/to/ca.pem")
+  timeout_seconds = 30
+}
+```
+
+### Elasticsearch endpoint configuration
+
+```hcl
+resource "digitalocean_database_logsink_opensearch" "elasticsearch" {
+  cluster_id     = digitalocean_database_cluster.postgres-example.id
+  name           = "elasticsearch-logs"
+  endpoint       = "https://elasticsearch.example.com:9243"
+  index_prefix   = "es-logs"
+  index_days_max = 30
+}
+```
+
+### MySQL to OpenSearch configuration
+
+```hcl
+resource "digitalocean_database_logsink_opensearch" "mysql" {
+  cluster_id     = digitalocean_database_cluster.mysql-example.id
+  name           = "mysql-logs"
+  endpoint       = "https://opensearch.example.com:9200"
+  index_prefix   = "mysql-logs"
+  index_days_max = 7
+}
+
+resource "digitalocean_database_cluster" "mysql-example" {
+  name       = "example-mysql-cluster"
+  engine     = "mysql"
+  version    = "8"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required) UUID of the source database cluster that will forward logs.
+* `name` - (Required) Display name for the logsink. **Note**: This is immutable; changing it will force recreation of the resource.
+* `endpoint` - (Required) HTTPS URL to the OpenSearch or Elasticsearch cluster (e.g., `https://host:port`). **Note**: Only HTTPS URLs are supported.
+* `index_prefix` - (Required) Prefix for the indices where logs will be stored.
+* `index_days_max` - (Optional) Maximum number of days to retain indices. Must be 1 or greater.
+* `ca_cert` - (Optional) CA certificate for TLS verification in PEM format. Can be specified using `file()` function. This field is marked as sensitive.
+* `timeout_seconds` - (Optional) Request timeout for log deliveries in seconds. Must be 1 or greater.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The composite ID of the logsink in the format `cluster_id,logsink_id`.
+* `logsink_id` - The unique identifier for the logsink as returned by the DigitalOcean API.
+
+## Import
+
+Database logsink OpenSearch resources can be imported using the composite ID format `cluster_id,logsink_id`. For example:
+
+```
+terraform import digitalocean_database_logsink_opensearch.example 245bcfd0-7f31-4ce6-a2bc-475a116cca97,f38db7c8-1f31-4ce6-a2bc-475a116cca97
+```
+
+**Note**: The cluster ID and logsink ID must be separated by a comma.
+
+## Important Notes
+
+### Elasticsearch Compatibility
+This resource works with both OpenSearch and Elasticsearch endpoints due to their API compatibility. Use the same resource type regardless of whether you're connecting to OpenSearch or Elasticsearch.
+
+### Managed OpenSearch with Trusted Sources
+When forwarding logs to a DigitalOcean Managed OpenSearch cluster with trusted sources enabled, you must manually allow-list the IP addresses of your database cluster nodes.
+
+### Authentication
+Include authentication credentials directly in the endpoint URL using the format `https://username:password@host:port`. Alternatively, configure authentication on your OpenSearch/Elasticsearch cluster to accept connections from your database cluster's IP addresses.

--- a/docs/resources/database_logsink_rsyslog.md
+++ b/docs/resources/database_logsink_rsyslog.md
@@ -1,0 +1,117 @@
+---
+page_title: "DigitalOcean: digitalocean_database_logsink_rsyslog"
+subcategory: "Databases"
+---
+
+# digitalocean\_database\_logsink\_rsyslog
+
+Provides a DigitalOcean database logsink resource allowing you to forward logs from a managed database cluster to an external rsyslog server.
+
+This resource supports the following DigitalOcean managed database engines:
+
+* PostgreSQL
+* MySQL
+* Kafka
+* Valkey
+
+**Note**: MongoDB databases use a different log forwarding mechanism and require Datadog logsinks (not currently available in this provider).
+
+## Example Usage
+
+### Basic rsyslog configuration
+
+```hcl
+resource "digitalocean_database_logsink_rsyslog" "example" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+  name       = "rsyslog-prod"
+  server     = "192.0.2.10"
+  port       = 514
+  format     = "rfc5424"
+}
+
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+### TLS-enabled rsyslog configuration
+
+```hcl
+resource "digitalocean_database_logsink_rsyslog" "example-tls" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+  name       = "rsyslog-secure"
+  server     = "logs.example.com"
+  port       = 6514
+  tls        = true
+  format     = "rfc5424"
+  ca_cert    = file("/path/to/ca.pem")
+}
+```
+
+### mTLS (mutual TLS) configuration
+
+```hcl
+resource "digitalocean_database_logsink_rsyslog" "example-mtls" {
+  cluster_id  = digitalocean_database_cluster.postgres-example.id
+  name        = "rsyslog-mtls"
+  server      = "secure-logs.example.com"
+  port        = 6514
+  tls         = true
+  format      = "rfc5424"
+  ca_cert     = file("/path/to/ca.pem")
+  client_cert = file("/path/to/client.crt")
+  client_key  = file("/path/to/client.key")
+}
+```
+
+### Custom format configuration
+
+```hcl
+resource "digitalocean_database_logsink_rsyslog" "example-custom" {
+  cluster_id      = digitalocean_database_cluster.postgres-example.id
+  name            = "rsyslog-custom"
+  server          = "192.0.2.10"
+  port            = 514
+  format          = "custom"
+  logline         = "<%pri%>%timestamp:::date-rfc3339% %HOSTNAME% %app-name% %msg%"
+  structured_data = "[example@41058 iut=\"3\"]"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required) UUID of the source database cluster that will forward logs.
+* `name` - (Required) Display name for the logsink. **Note**: This is immutable; changing it will force recreation of the resource.
+* `server` - (Required) Hostname or IP address of the rsyslog server.
+* `port` - (Required) Port number for the rsyslog server. Must be between 1 and 65535.
+* `tls` - (Optional) Enable TLS encryption for the rsyslog connection. Defaults to `false`. **Note**: It is highly recommended to enable TLS as log messages may contain sensitive information.
+* `format` - (Optional) Log format to use. Must be one of `rfc5424` (default), `rfc3164`, or `custom`.
+* `logline` - (Optional) Custom logline template. **Required** when `format` is set to `custom`. Supports rsyslog-style templating with the following tokens: `%HOSTNAME%`, `%app-name%`, `%msg%`, `%msgid%`, `%pri%`, `%procid%`, `%structured-data%`, `%timestamp%`, and `%timestamp:::date-rfc3339%`.
+* `structured_data` - (Optional) Content of the structured data block for RFC5424 messages.
+* `ca_cert` - (Optional) CA certificate for TLS verification in PEM format. Can be specified using `file()` function.
+* `client_cert` - (Optional) Client certificate for mutual TLS authentication in PEM format. **Note**: Requires `tls` to be `true`.
+* `client_key` - (Optional) Client private key for mutual TLS authentication in PEM format. **Note**: Requires `tls` to be `true`. This field is marked as sensitive.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The composite ID of the logsink in the format `cluster_id,logsink_id`.
+* `logsink_id` - The unique identifier for the logsink as returned by the DigitalOcean API.
+
+## Import
+
+Database logsink rsyslog resources can be imported using the composite ID format `cluster_id,logsink_id`. For example:
+
+```
+terraform import digitalocean_database_logsink_rsyslog.example 245bcfd0-7f31-4ce6-a2bc-475a116cca97,f38db7c8-1f31-4ce6-a2bc-475a116cca97
+```
+
+**Note**: The cluster ID and logsink ID must be separated by a comma.

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -1,10 +1,11 @@
 # DigitalOcean Database Example
 
-This example demonstrates how to create a PostgreSQL database cluster on DigitalOcean and access its metrics credentials. It showcases:
+This example demonstrates how to create a PostgreSQL database cluster on DigitalOcean with log forwarding configured. It showcases:
 
 1. Creating a PostgreSQL database cluster with multiple nodes on the regions default VPC
-2. Accessing the account-wide database metrics credentials
-3. Outputting the metrics endpoints and credentials
+2. Configuring an rsyslog logsink to forward database logs to an external rsyslog server
+3. Accessing the account-wide database metrics credentials
+4. Outputting the metrics endpoints, credentials, and logsink information
 
 ## Prerequisites
 
@@ -18,12 +19,18 @@ export DIGITALOCEAN_TOKEN="Your API TOKEN"
 
 The example uses variables that can be customized:
 
+### Database Configuration
 - `region`: DigitalOcean region (default: "sfo3")
 - `db_name`: Name for the database cluster (default: "test-pg")
 - `db_engine`: Database engine (default: "pg" for PostgreSQL)
 - `db_version`: Database version (default: "17")
 - `db_size`: Database size slug (default: "db-s-2vcpu-4gb")
 - `db_node_count`: Number of nodes (default: 2)
+
+### Rsyslog Logsink Configuration
+- `rsyslog_server`: Hostname or IP address of your rsyslog server (default: "logs.example.com")
+- `rsyslog_port`: Port number for the rsyslog server (default: 514)
+- `rsyslog_format`: Log format - rfc5424, rfc3164, or custom (default: "rfc5424")
 
 ## Run this example using:
 
@@ -35,4 +42,6 @@ terraform apply
 
 ## Notes
 
-The database metrics credentials are account-wide, not cluster-specific.
+- The database metrics credentials are account-wide, not cluster-specific.
+- The rsyslog logsink requires a reachable rsyslog server. Update the `rsyslog_server` variable to point to your actual rsyslog server hostname or IP address.
+- For production use, consider enabling TLS for the rsyslog connection (see the [rsyslog logsink documentation](../../docs/resources/database_logsink_rsyslog.md) for TLS configuration examples).

--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -1,3 +1,4 @@
+# Terraform configuration block specifying required versions and providers
 terraform {
   required_version = "~> 1"
   required_providers {
@@ -8,17 +9,27 @@ terraform {
   }
 }
 
+# Configure the DigitalOcean provider
+# Authentication is handled via the DIGITALOCEAN_TOKEN environment variable
 provider "digitalocean" {
   # You need to set this in your .bashrc
   # export DIGITALOCEAN_TOKEN="Your API TOKEN"
 }
 
+# Look up the default VPC for the specified region
+# Database clusters are automatically placed in a VPC for network isolation
 data "digitalocean_vpc" "default" {
   region = var.region
 }
 
+# Retrieve the account-wide database metrics credentials
+# These credentials allow you to access Prometheus metrics endpoints for monitoring
+# database cluster performance and health
 data "digitalocean_database_metrics_credentials" "test" {}
 
+# Create a managed database cluster
+# This example creates a PostgreSQL cluster with multiple nodes for high availability
+# The cluster is connected to the region's default VPC for secure networking
 resource "digitalocean_database_cluster" "test" {
   name                 = var.db_name
   engine               = var.db_engine
@@ -27,4 +38,28 @@ resource "digitalocean_database_cluster" "test" {
   region               = var.region
   node_count           = var.db_node_count
   private_network_uuid = data.digitalocean_vpc.default.id
+}
+
+# Configure log forwarding from the database cluster to an external rsyslog server.
+# This allows you to aggregate and analyze database logs in your logging infrastructure.
+#
+# IMPORTANT: This example uses a basic unencrypted rsyslog configuration for simplicity.
+# For production environments, you should ALWAYS enable TLS to protect sensitive log data
+# in transit. Database logs may contain query patterns, connection details, and other
+# sensitive operational information.
+#
+# For TLS configuration examples, see:
+# https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/database_logsink_rsyslog
+#
+# TLS example configuration:
+#   tls         = true
+#   ca_cert     = file("/path/to/ca.pem")
+#   client_cert = file("/path/to/client.crt")  # Optional, for mutual TLS
+#   client_key  = file("/path/to/client.key")  # Optional, for mutual TLS
+resource "digitalocean_database_logsink_rsyslog" "example" {
+  cluster_id = digitalocean_database_cluster.test.id
+  name       = "${var.db_name}-logs"
+  server     = var.rsyslog_server
+  port       = var.rsyslog_port
+  format     = var.rsyslog_format
 }

--- a/examples/database/variables.tf
+++ b/examples/database/variables.tf
@@ -33,3 +33,21 @@ variable "db_node_count" {
   type        = number
   default     = 2
 }
+
+variable "rsyslog_server" {
+  description = "Hostname or IP address of the rsyslog server"
+  type        = string
+  default     = "logs.example.com"
+}
+
+variable "rsyslog_port" {
+  description = "Port number for the rsyslog server"
+  type        = number
+  default     = 514
+}
+
+variable "rsyslog_format" {
+  description = "Log format to use (rfc5424, rfc3164, or custom)"
+  type        = string
+  default     = "rfc5424"
+}


### PR DESCRIPTION
## Changes

- New `digitalocean_database_logsink_rsyslog` resource for forwarding database logs to rsyslog servers
- New `digitalocean_database_logsink_opensearch` resource for forwarding database logs to OpenSearch/Elasticsearch clusters
- Full CRUD operations and import support for both resources
- Comprehensive validation (port ranges, formats, HTTPS enforcement, cross-field dependencies)
- Security features (TLS/mTLS for rsyslog, HTTPS-only for OpenSearch, sensitive field handling)
- Documentation for both resources with multiple configuration examples
- Updated database example to include rsyslog logsink configuration
- Engine compatibility: PostgreSQL, MySQL, Kafka, Valkey (MongoDB uses different mechanism)
- Update Godo to latest as bug fix in https://github.com/digitalocean/godo/pull/928 is needed

## Motivation

These resources allow users to aggregate and analyze database logs using their existing logging infrastructure. Users can forward logs to rsyslog servers (with optional TLS/mTLS) or OpenSearch/Elasticsearch clusters for centralized log management, monitoring, and analysis.

## Testing

- **Rsyslog acceptance tests:** 10/10 passing
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_Basic`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_Update`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_CustomFormat`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_TLS`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_ImportBasic`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_InvalidPort`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_InvalidFormat`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_CustomFormatRequiresLogline`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_CertWithoutTLS`
  - `TestAccDigitalOceanDatabaseLogsinkRsyslog_MongoDB_ShouldFail`

- **OpenSearch acceptance tests:** 7/7 passing
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_Basic`
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_Update`
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_WithCA`
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_ImportBasic`
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_InvalidIndexDaysMax`
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_EmptyIndexPrefix`
  - `TestAccDigitalOceanDatabaseLogsinkOpensearch_MalformedEndpoint`