### PR TITLE
Document ipv6 attribute in loadbalancer resource

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -178,6 +178,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `id` - The ID of the Load Balancer
 * `ip`- The ip of the Load Balancer
+* `ipv6` - The IPv6 address of the Load Balancer
 * `urn` - The uniform resource name for the Load Balancer
 
 ## Import


### PR DESCRIPTION
## Summary
  The `ipv6` computed attribute was missing from the loadbalancer resource documentation, despite being implemented in the code since the addition of DUALSTACK network_stack support.

  ## Changes
  - Added `ipv6` attribute to the Attributes Reference section in `docs/resources/loadbalancer.md`

  ## Context
  The `ipv6` attribute is available on both the `digitalocean_loadbalancer` resource and data source when a load balancer is configured with `network_stack = "DUALSTACK"`. This attribute returns the IPv6 address assigned to the load balancer, similar to how the `ip` attribute returns the IPv4 address.

  The implementation exists in `digitalocean/loadbalancer/datasource_loadbalancer.go` (lines 70-73, 439-441) and the resource implementation, but was not documented in the Attributes Reference section.
