### PR TITLE
Fix droplet deletion timeout caused by incorrect 404 handling

### DIFF
--- a/digitalocean/kubernetes/resource_kubernetes_node_pool.go
+++ b/digitalocean/kubernetes/resource_kubernetes_node_pool.go
@@ -340,7 +340,7 @@ func waitForKubernetesNodePoolDelete(client *godo.Client, d *schema.ResourceData
 		if err != nil {
 			ticker.Stop()
 
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
 


### PR DESCRIPTION
## Summary

- Fixes regression from PR #1493 where droplet deletion times out due to incorrect 404 handling
- Adds context-aware 404 handling via new `dropletOperation` type to distinguish CREATE/DELETE/UPDATE operations
- Fixes potential nil pointer dereference in `waitForKubernetesNodePoolDelete`

## Problem

PR #1493 changed `dropletStateRefreshFunc` to return `(nil, "", nil)` on 404, which triggers the `NotFoundChecks` retry logic in `StateChangeConf`. During DELETE operations, this causes polling to continue until timeout instead of recognizing that the resource was successfully deleted.

**Before fix:**
```
[DEBUG] Droplet (546448744) not found (404), will retry  ← repeated 6+ times
[WARN] WaitForState timeout after 1m0s
[ERROR] Error deleting droplet: timeout while waiting for state to become 'archive'
```

**After fix:**
```
[DEBUG] Droplet (546455965) not found (404), deletion successful  ← single message
Destroy complete! Resources: 1 destroyed.
```

## Solution

HTTP 404 has different meanings depending on the operation context:
- **CREATE**: 404 triggers retry (for reserved hypervisors per #1486)
- **DELETE**: 404 returns "Not Found" state to signal successful deletion
- **UPDATE**: 404 returns an error (resource unexpectedly disappeared)

The fix introduces a `dropletOperation` type to track the operation context and handle 404 appropriately in each case.

## Test plan

- [x] Reproduced the bug with current main branch (droplet deletion timed out)
- [x] Verified fix works (droplet deletion completes immediately after 404)
- [x] Build passes (`make build`)
- [x] Lint passes (`make lint`)
- [x] Acceptance tests pass:
  - `TestAccDigitalOceanDroplet_Basic` ✅
  - `TestAccDigitalOceanKubernetesCluster_Basic` ✅
  - `TestAccDigitalOceanKubernetesNodePool_Basic` ✅

## Related issues

- Regression from #1493
- Preserves fix for #1486 (reserved hypervisor retry on CREATE)