### PR TITLE
reverting 404 change

### DIFF
--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -893,17 +893,9 @@ func dropletStateRefreshFunc(
 		}
 
 		// Retrieve the droplet properties
-		droplet, resp, err := client.Droplets.Get(context.Background(), id)
+		droplet, _, err := client.Droplets.Get(context.Background(), id)
 		if err != nil {
-			// Handle 404 as a retryable "not found" condition rather than a fatal error.
-			// This is important for reserved/contracted hypervisors where capacity may be
-			// temporarily unavailable after a destroy, causing async placement failures.
-			// Returning nil triggers NotFoundChecks retry logic in StateChangeConf.
-			// See: https://github.com/digitalocean/terraform-provider-digitalocean/issues/1486
-			if resp != nil && resp.StatusCode == 404 {
-				log.Printf("[DEBUG] Droplet (%d) not found (404), will retry", id)
-				return nil, "", nil
-			}
+
 			return nil, "", fmt.Errorf("Error retrieving droplet: %s", err)
 		}
 


### PR DESCRIPTION
Reverting the change #1493 for 404 check, keeping the increased notfoundcheck from 60 to 120 for reserved/contracted hypervisors where