### PR TITLE
apps: Add secure origin header to Terraform

### DIFF
--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -1266,6 +1266,31 @@ func TestAccDigitalOceanApp_VPC(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanApp_SecureHeader(t *testing.T) {
+	var app godo.App
+	appName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_withSecureHeader, appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.name", appName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.secure_header.0.key", "X-Secret-Header"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.ingress.0.secure_header.0.value", "secret"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanApp_Maintenance(t *testing.T) {
 	var app godo.App
 	appName := acceptance.RandomTestName()
@@ -2200,6 +2225,42 @@ resource "digitalocean_app" "foobar" {
 
     vpc {
       id = "%s"
+    }
+  }
+}`
+
+var testAccCheckDigitalOceanAppConfig_withSecureHeader = `
+resource "digitalocean_app" "foobar" {
+  spec {
+    name   = "%s"
+    region = "nyc"
+
+    service {
+      name = "go-service"
+      git {
+        repo_clone_url = "https://github.com/digitalocean/sample-golang.git"
+        branch         = "main"
+      }
+      instance_size_slug = "basic-xxs"
+      instance_count     = 1
+    }
+
+    ingress {
+      secure_header {
+        key   = "X-Secret-Header"
+        value = "secret"
+      }
+
+      rule {
+        component {
+          name = "go-service"
+        }
+        match {
+          path {
+            prefix = "/"
+          }
+        }
+      }
     }
   }
 }`

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/digitalocean/terraform-provider-digitalocean
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.173.0
+	github.com/digitalocean/godo v1.174.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.173.0 h1:tgzevGhlz9VFjk2y3NmeItUT4vIVVCRFETlG/1GlEQI=
-github.com/digitalocean/godo v1.173.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.174.0 h1:9nVX8WqAPd7ZN9Yn63HeLRAI8m2vi9QeotcDvYmB+ns=
+github.com/digitalocean/godo v1.174.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.174.0] - 2026-02-09
+
+- #946 - @blesswinsamuel - apps: Update app spec to support InactivitySleep configuration
+- #949 - @lprasanth-nadiminti - Add DOSettings with ServiceCnames support for database clusters
+- #945 - @v-amanjain-afk - switch performance tier of nfs share
+- #947 - @ZachEddy - apps: Add secure header app spec field to godo
+
 ## [1.173.0] - 2026-01-22
 
 - #942 - @anup-deka - Fix data type

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -319,7 +319,8 @@ type AppIngressSpec struct {
 	LoadBalancer     AppIngressSpecLoadBalancer `json:"load_balancer,omitempty"`
 	LoadBalancerSize int64                      `json:"load_balancer_size,omitempty"`
 	// Rules for configuring HTTP ingress for component routes, CORS, rewrites, and redirects.
-	Rules []*AppIngressSpecRule `json:"rules,omitempty"`
+	Rules        []*AppIngressSpecRule `json:"rules,omitempty"`
+	SecureHeader *AppSecureHeaderSpec  `json:"secure_header,omitempty"`
 }
 
 // AppIngressSpecLoadBalancer the model 'AppIngressSpecLoadBalancer'
@@ -374,6 +375,13 @@ type AppIngressSpecRuleStringMatch struct {
 	// Prefix-based match. For example, `/api` will match `/api`, `/api/`, and any nested paths such as `/api/v1/endpoint`.
 	Prefix string `json:"prefix,omitempty"`
 	Exact  string `json:"exact,omitempty"`
+}
+
+type AppSecureHeaderSpec struct {
+	// The name of the header to set.
+	Key string `json:"key,omitempty"`
+	// The value of the header to set.
+	Value string `json:"value,omitempty"`
 }
 
 // AppInstance struct for AppInstance
@@ -565,9 +573,11 @@ type AppServiceSpec struct {
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
-	LogDestinations     []*AppLogDestinationSpec   `json:"log_destinations,omitempty"`
-	Termination         *AppServiceSpecTermination `json:"termination,omitempty"`
-	LivenessHealthCheck *HealthCheckSpec           `json:"liveness_health_check,omitempty"`
+	LogDestinations []*AppLogDestinationSpec   `json:"log_destinations,omitempty"`
+	Termination     *AppServiceSpecTermination `json:"termination,omitempty"`
+	// A configuration for putting the service to sleep after it has been inactive. Note: this is in Private Preview.
+	InactivitySleep     *AppServiceSpecInactivitySleep `json:"inactivity_sleep,omitempty"`
+	LivenessHealthCheck *HealthCheckSpec               `json:"liveness_health_check,omitempty"`
 }
 
 // AppServiceSpecHealthCheck struct for AppServiceSpecHealthCheck
@@ -588,6 +598,13 @@ type AppServiceSpecHealthCheck struct {
 	HTTPPath string `json:"http_path,omitempty"`
 	// The port on which the health check will be performed. If not set, the health check will be performed on the component's http_port.
 	Port int64 `json:"port,omitempty"`
+}
+
+// AppServiceSpecInactivitySleep struct for AppServiceSpecInactivitySleep
+type AppServiceSpecInactivitySleep struct {
+	// The number of seconds to wait before putting the service to sleep after it has been inactive. Minimum 600, Maximum 86400.
+	AfterSeconds int32                       `json:"after_seconds,omitempty"`
+	LoadingPage  *InactivitySleepLoadingPage `json:"loading_page,omitempty"`
 }
 
 // AppServiceSpecTermination struct for AppServiceSpecTermination
@@ -1319,6 +1336,14 @@ const (
 	ImageSourceSpecRegistryType_DockerHub   ImageSourceSpecRegistryType = "DOCKER_HUB"
 	ImageSourceSpecRegistryType_Ghcr        ImageSourceSpecRegistryType = "GHCR"
 )
+
+// InactivitySleepLoadingPage struct for InactivitySleepLoadingPage
+type InactivitySleepLoadingPage struct {
+	// Whether to show a loading page while the service is waking up from sleep. Defaults to false. If this is enabled and there is a request header `Accept` containing `text/html`, then the app will show a loading page with a 503 status code until the service is woken up.
+	Enabled bool `json:"enabled,omitempty"`
+	// A custom loading page to display when the service is woken up from sleep. If not provided, a default loading page will be shown.
+	CustomURL string `json:"custom_url,omitempty"`
+}
 
 // AppInstanceSize struct for AppInstanceSize
 type AppInstanceSize struct {

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1869,6 +1869,14 @@ func (a *AppServiceSpec) GetImage() *ImageSourceSpec {
 	return a.Image
 }
 
+// GetInactivitySleep returns the InactivitySleep field.
+func (a *AppServiceSpec) GetInactivitySleep() *AppServiceSpecInactivitySleep {
+	if a == nil {
+		return nil
+	}
+	return a.InactivitySleep
+}
+
 // GetInstanceCount returns the InstanceCount field.
 func (a *AppServiceSpec) GetInstanceCount() int64 {
 	if a == nil {
@@ -2019,6 +2027,22 @@ func (a *AppServiceSpecHealthCheck) GetTimeoutSeconds() int32 {
 		return 0
 	}
 	return a.TimeoutSeconds
+}
+
+// GetAfterSeconds returns the AfterSeconds field.
+func (a *AppServiceSpecInactivitySleep) GetAfterSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.AfterSeconds
+}
+
+// GetLoadingPage returns the LoadingPage field.
+func (a *AppServiceSpecInactivitySleep) GetLoadingPage() *InactivitySleepLoadingPage {
+	if a == nil {
+		return nil
+	}
+	return a.LoadingPage
 }
 
 // GetDrainSeconds returns the DrainSeconds field.
@@ -4063,6 +4087,22 @@ func (i *ImageSourceSpec) GetTag() string {
 
 // GetEnabled returns the Enabled field.
 func (i *ImageSourceSpecDeployOnPush) GetEnabled() bool {
+	if i == nil {
+		return false
+	}
+	return i.Enabled
+}
+
+// GetCustomURL returns the CustomURL field.
+func (i *InactivitySleepLoadingPage) GetCustomURL() string {
+	if i == nil {
+		return ""
+	}
+	return i.CustomURL
+}
+
+// GetEnabled returns the Enabled field.
+func (i *InactivitySleepLoadingPage) GetEnabled() bool {
 	if i == nil {
 		return false
 	}

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -237,6 +237,7 @@ type Database struct {
 	ProjectID                string                     `json:"project_id,omitempty"`
 	StorageSizeMib           uint64                     `json:"storage_size_mib,omitempty"`
 	MetricsEndpoints         []*ServiceAddress          `json:"metrics_endpoints,omitempty"`
+	DOSettings               *DOSettings                `json:"do_settings,omitempty"`
 }
 
 // DatabaseCA represents a database ca.
@@ -261,6 +262,11 @@ type DatabaseConnection struct {
 type ServiceAddress struct {
 	Host string `json:"host"`
 	Port int    `json:"port"`
+}
+
+// DOSettings contains DigitalOcean-specific settings for a database cluster.
+type DOSettings struct {
+	ServiceCnames []string `json:"service_cnames,omitempty"`
 }
 
 // DatabaseUser represents a user in the database
@@ -347,6 +353,7 @@ type DatabaseCreateRequest struct {
 	ProjectID          string                        `json:"project_id"`
 	StorageSizeMib     uint64                        `json:"storage_size_mib,omitempty"`
 	Rules              []*DatabaseCreateFirewallRule `json:"rules"`
+	DOSettings         *DOSettings                   `json:"do_settings,omitempty"`
 }
 
 // DatabaseResizeRequest can be used to initiate a database resize operation.
@@ -470,6 +477,7 @@ type DatabaseReplica struct {
 	Tags               []string            `json:"tags,omitempty"`
 	StorageSizeMib     uint64              `json:"storage_size_mib,omitempty"`
 	Size               string              `json:"size"`
+	DOSettings         *DOSettings         `json:"do_settings,omitempty"`
 }
 
 // DatabasePool represents a database connection pool
@@ -527,12 +535,13 @@ type DatabaseCreateDBRequest struct {
 
 // DatabaseCreateReplicaRequest is used to create a new read-only replica
 type DatabaseCreateReplicaRequest struct {
-	Name               string   `json:"name"`
-	Region             string   `json:"region"`
-	Size               string   `json:"size"`
-	PrivateNetworkUUID string   `json:"private_network_uuid"`
-	Tags               []string `json:"tags,omitempty"`
-	StorageSizeMib     uint64   `json:"storage_size_mib,omitempty"`
+	Name               string      `json:"name"`
+	Region             string      `json:"region"`
+	Size               string      `json:"size"`
+	PrivateNetworkUUID string      `json:"private_network_uuid"`
+	Tags               []string    `json:"tags,omitempty"`
+	StorageSizeMib     uint64      `json:"storage_size_mib,omitempty"`
+	DOSettings         *DOSettings `json:"do_settings,omitempty"`
 }
 
 // DatabaseUpdateFirewallRulesRequest is used to set the firewall rules for a database

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.173.0"
+	libraryVersion = "1.174.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/nfs.go
+++ b/vendor/github.com/digitalocean/godo/nfs.go
@@ -99,10 +99,11 @@ type NfsSnapshot struct {
 
 // NfsCreateRequest represents a request to create an NFS share.
 type NfsCreateRequest struct {
-	Name    string   `json:"name"`
-	SizeGib int      `json:"size_gib"`
-	Region  string   `json:"region"`
-	VpcIDs  []string `json:"vpc_ids,omitempty"`
+	Name            string   `json:"name"`
+	SizeGib         int      `json:"size_gib"`
+	Region          string   `json:"region"`
+	VpcIDs          []string `json:"vpc_ids,omitempty"`
+	PerformanceTier string   `json:"performance_tier,omitempty"`
 }
 
 // nfsRoot represents a response from the DigitalOcean API

--- a/vendor/github.com/digitalocean/godo/nfs_actions.go
+++ b/vendor/github.com/digitalocean/godo/nfs_actions.go
@@ -14,6 +14,7 @@ type NfsActionsService interface {
 	Snapshot(ctx context.Context, nfsShareId string, nfsSnapshotName string, region string) (*NfsAction, *Response, error)
 	Attach(ctx context.Context, nfsShareId string, vpcID string, region string) (*NfsAction, *Response, error)
 	Detach(ctx context.Context, nfsShareId string, vpcID string, region string) (*NfsAction, *Response, error)
+	SwitchPerformanceTier(ctx context.Context, nfsShareId string, tier string) (*NfsAction, *Response, error)
 }
 
 // NfsActionsServiceOp handles communication with the NFS action related
@@ -69,6 +70,11 @@ type NfsDetachParams struct {
 	VpcID string `json:"vpc_id"`
 }
 
+// NfsSwitchPerformanceTierParams represents parameters to switch the performance tier of an NFS share.
+type NfsSwitchPerformanceTierParams struct {
+	PerformanceTier string `json:"performance_tier"`
+}
+
 // Resize an NFS share
 func (s *NfsActionsServiceOp) Resize(ctx context.Context, nfsShareId string, size uint64, region string) (*NfsAction, *Response, error) {
 	request := &NfsActionRequest{
@@ -117,6 +123,17 @@ func (s *NfsActionsServiceOp) Detach(ctx context.Context, nfsShareId, vpcID, reg
 	return s.doAction(ctx, nfsShareId, request)
 }
 
+// Switch performance tier of an NFS share
+func (s *NfsActionsServiceOp) SwitchPerformanceTier(ctx context.Context, nfsShareId string, tier string) (*NfsAction, *Response, error) {
+	request := &NfsActionRequest{
+		Type: "switch_performance_tier",
+		Params: &NfsSwitchPerformanceTierParams{
+			PerformanceTier: tier,
+		},
+	}
+
+	return s.doAction(ctx, nfsShareId, request)
+}
 func (s *NfsActionsServiceOp) doAction(ctx context.Context, nfsShareId string, request *NfsActionRequest) (*NfsAction, *Response, error) {
 	if request == nil {
 		return nil, nil, NewArgError("request", "request can't be nil")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.173.0
+# github.com/digitalocean/godo v1.174.0
 ## explicit; go 1.23.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Adds app spec support for secure origin header in Terraform.

Related:

- digitalocean/godo#946
- digitalocean/doctl#1804