### PR TITLE
HA default true for 1.36.0 and later

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -2792,13 +2792,13 @@ func expandAppIngressMatch(config []interface{}) *godo.AppIngressSpecRuleMatch {
 	path := match["path"].([]interface{})
 	if len(path) > 0 {
 		ruleMatch.Path = &godo.AppIngressSpecRuleStringMatch{
-			Prefix: path[0].(map[string]interface{})["prefix"].(string),
+			Prefix: godo.PtrTo(path[0].(map[string]interface{})["prefix"].(string)),
 		}
 	}
 	authority := match["authority"].([]interface{})
 	if len(authority) > 0 {
 		ruleMatch.Authority = &godo.AppIngressSpecRuleStringMatch{
-			Exact: authority[0].(map[string]interface{})["exact"].(string),
+			Exact: godo.PtrTo(authority[0].(map[string]interface{})["exact"].(string)),
 		}
 	}
 
@@ -2936,14 +2936,14 @@ func flattenAppIngressRuleMatch(match *godo.AppIngressSpecRuleMatch) []map[strin
 		if match.Path != nil {
 			r["path"] = []map[string]interface{}{
 				{
-					"prefix": match.Path.Prefix,
+					"prefix": match.Path.GetPrefix(),
 				},
 			}
 		}
 		if match.Authority != nil {
 			r["authority"] = []map[string]interface{}{
 				{
-					"exact": match.Authority.Exact,
+					"exact": match.Authority.GetExact(),
 				},
 			}
 		}

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -72,6 +72,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name         = "%s"
   region       = "lon1"
   version      = data.digitalocean_kubernetes_versions.test.latest_version
+  ha           = false
   tags         = ["foo", "bar"]
   auto_upgrade = true
 
@@ -156,6 +157,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {

--- a/digitalocean/kubernetes/datasource_kubernetes_versions_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_versions_test.go
@@ -81,6 +81,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.foobar.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"

--- a/digitalocean/kubernetes/import_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/import_kubernetes_cluster_test.go
@@ -160,6 +160,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"

--- a/digitalocean/kubernetes/import_kubernetes_node_pool_test.go
+++ b/digitalocean/kubernetes/import_kubernetes_node_pool_test.go
@@ -19,6 +19,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -70,7 +70,7 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"ha": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 
 			"registry_integration": {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -32,6 +32,15 @@ const (
 	rdmaSharedDevicePluginField            = "rdma_shared_device_plugin"
 )
 
+// ExpandHAFromConfig returns the HA value for the create request. When ha is not
+// specified in config, returns nil so the API applies its version-dependent default.
+func ExpandHAFromConfig(value interface{}, ok bool) *bool {
+	if !ok {
+		return nil
+	}
+	return godo.PtrTo(value.(bool))
+}
+
 func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDigitalOceanKubernetesClusterCreate,
@@ -70,7 +79,7 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"ha": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				// Default is version-dependent: true for DOKS >= 1.36, false otherwise (set in CustomizeDiff)
 			},
 
 			"registry_integration": {
@@ -427,10 +436,11 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 		RegionSlug:   d.Get("region").(string),
 		VersionSlug:  d.Get("version").(string),
 		SurgeUpgrade: d.Get("surge_upgrade").(bool),
-		HA:           d.Get("ha").(bool),
 		Tags:         tag.ExpandTags(d.Get("tags").(*schema.Set).List()),
 		NodePools:    poolCreateRequests,
 	}
+	ha, haOk := d.GetOk("ha")
+	opts.HA = ExpandHAFromConfig(ha, haOk)
 
 	if maint, ok := d.GetOk("maintenance_policy"); ok {
 		maintPolicy, err := expandMaintPolicyOpts(maint.([]interface{}))

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -81,7 +81,10 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"ha": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				// Default is version-dependent: true for DOKS >= 1.36, false otherwise (set in CustomizeDiff)
+				Computed: true,
+				// When omitted from config, create sends nil HA so the API applies its version-dependent
+				// default; read stores the actual value. Computed avoids perpetual diff (config zero false
+				// vs state true on newer DOKS). Explicit ha = true/false is still honored (GetOkExists).
 			},
 
 			"registry_integration": {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -34,7 +34,8 @@ const (
 )
 
 // ExpandHAFromConfig returns the HA value for the create request. When ha is not
-// specified in config, returns nil so the API applies its version-dependent default.
+// specified in config (ok from GetOkExists is false), returns nil so the API applies
+// its version-dependent default. When ok is true, value may be false (explicit HA off).
 func ExpandHAFromConfig(value interface{}, ok bool) *bool {
 	if !ok {
 		return nil
@@ -468,7 +469,8 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 		NodePools:    poolCreateRequests,
 		SSO:          expandSSOOpts(d.Get("sso").([]interface{})),
 	}
-	ha, haOk := d.GetOk("ha")
+	// GetOkExists: optional bool without Default — GetOk would treat ha = false as unset.
+	ha, haOk := d.GetOkExists("ha")
 	opts.HA = ExpandHAFromConfig(ha, haOk)
 
 	if maint, ok := d.GetOk("maintenance_policy"); ok {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -112,6 +112,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   region        = "lon1"
   version       = data.digitalocean_kubernetes_versions.test.latest_version
   surge_upgrade = true
+  ha            = false
   tags          = ["foo", "bar", "one"]
 
   node_pool {
@@ -218,7 +219,8 @@ resource "digitalocean_container_registry" "foobar" {
 resource "digitalocean_kubernetes_cluster" "foobar" {
   name                 = "%s"
   region               = "nyc3"
-  registry_integration = true
+  ha                   = false
+  registry_integration  = true
   version              = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {
@@ -249,6 +251,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "nyc3"
+  ha      = false
   version = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {
@@ -272,6 +275,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 resource "digitalocean_kubernetes_cluster" "foobar" {
   name                 = "%s"
   region               = "nyc3"
+  ha                   = false
   version              = data.digitalocean_kubernetes_versions.test.latest_version
   registry_integration = true
 
@@ -591,6 +595,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name         = "%s"
   region       = "lon1"
   version      = data.digitalocean_kubernetes_versions.test.latest_version
+  ha           = false
   auto_upgrade = true
 
   node_pool {
@@ -630,6 +635,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -660,6 +666,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -691,6 +698,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -732,6 +740,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -760,6 +769,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -791,6 +801,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -1025,6 +1036,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   region        = "nyc1"
   version       = data.digitalocean_kubernetes_versions.test.latest_version
   surge_upgrade = true
+  ha            = false
   tags          = ["foo", "bar", "one"]
 
   node_pool {
@@ -1058,6 +1070,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   region        = "lon1"
   version       = data.digitalocean_kubernetes_versions.test.latest_version
   surge_upgrade = true
+  ha            = false
   tags          = ["foo", "bar", "one"]
 
 %s
@@ -1088,6 +1101,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   region        = "lon1"
   version       = data.digitalocean_kubernetes_versions.test.latest_version
   surge_upgrade = true
+  ha            = false
   tags          = ["foo", "bar", "one"]
 
 %s
@@ -1118,6 +1132,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   region        = "lon1"
   version       = data.digitalocean_kubernetes_versions.test.latest_version
   surge_upgrade = true
+  ha            = false
   tags          = ["foo", "bar", "one"]
 
 %s
@@ -1148,6 +1163,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   region        = "lon1"
   version       = data.digitalocean_kubernetes_versions.test.latest_version
   surge_upgrade = true
+  ha            = false
   tags          = ["foo", "bar"]
 
   node_pool {
@@ -1171,6 +1187,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {
@@ -1216,6 +1233,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -1247,6 +1265,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name                             = "%s"
   region                           = "nyc1"
   version                          = data.digitalocean_kubernetes_versions.test.latest_version
+  ha                               = false
   destroy_all_associated_resources = true
 
   node_pool {
@@ -1265,6 +1284,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name           = "%s"
   region         = "nyc1"
   version        = data.digitalocean_kubernetes_versions.test.latest_version
+  ha             = false
   cluster_subnet = "192.168.0.0/20"
   service_subnet = "192.168.16.0/22"
   node_pool {
@@ -1302,6 +1322,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "nyc1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   routing_agent {
     enabled = true
   }
@@ -1321,6 +1342,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "nyc1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   amd_gpu_device_plugin {
     enabled = true
   }
@@ -1340,6 +1362,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "nyc1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   amd_gpu_device_metrics_exporter_plugin {
     enabled = true
   }
@@ -1359,6 +1382,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "nyc1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   nvidia_gpu_device_plugin {
     enabled = true
   }
@@ -1378,6 +1402,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "nyc1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   rdma_shared_device_plugin {
     enabled = true
   }
@@ -1419,6 +1444,32 @@ func testAccCheckDigitalOceanKubernetesClusterExists(n string, cluster *godo.Kub
 		return nil
 	}
 }
+
+func Test_expandHAFromConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		ok    bool
+		want  *bool
+	}{
+		{"ha not provided", nil, false, nil},
+		{"ha true", true, true, ptrTo(true)},
+		{"ha false", false, true, ptrTo(false)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kubernetes.ExpandHAFromConfig(tt.value, tt.ok)
+			if (got == nil) != (tt.want == nil) {
+				t.Errorf("expandHAFromConfig() got nil=%v, want nil=%v", got == nil, tt.want == nil)
+			}
+			if got != nil && tt.want != nil && *got != *tt.want {
+				t.Errorf("expandHAFromConfig() = %v, want %v", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func ptrTo(b bool) *bool { return &b }
 
 func Test_filterTags(t *testing.T) {
 	tests := []struct {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -220,7 +220,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name                 = "%s"
   region               = "nyc3"
   ha                   = false
-  registry_integration  = true
+  registry_integration = true
   version              = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {

--- a/digitalocean/kubernetes/resource_kubernetes_node_pool_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_node_pool_test.go
@@ -22,6 +22,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {
@@ -102,6 +103,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {
@@ -230,6 +232,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -269,6 +272,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -307,6 +311,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -346,6 +351,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -396,6 +402,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -432,6 +439,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -471,6 +479,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
 
   node_pool {
     name       = "default"
@@ -512,6 +521,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {
@@ -540,6 +550,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {
@@ -576,6 +587,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {
@@ -617,6 +629,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   name    = "%s"
   region  = "lon1"
   version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
   tags    = ["foo", "bar"]
 
   node_pool {

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -156,7 +156,7 @@ The following arguments are supported:
 * `vpc_uuid` - (Optional) The ID of the VPC where the Kubernetes cluster will be located.
 * `auto_upgrade` - (Optional) A boolean value indicating whether the cluster will be automatically upgraded to new patch releases during its maintenance window.
 * `surge_upgrade` - (Optional) Enable/disable surge upgrades for a cluster. Default: true
-* `ha` - (Optional) Enable/disable the high availability control plane for a cluster. Once enabled for a cluster, high availability cannot be disabled. Default: false
+* `ha` - (Optional) Enable/disable the high availability control plane for a cluster. Once enabled for a cluster, high availability cannot be disabled. Default: true (for 1.36.0 and later)
 * `registry_integration` - (optional) Enables or disables the DigitalOcean container registry integration for the cluster. This requires that a container registry has first been created for the account. Default: false
 * `node_pool` - (Required) A block representing the cluster's default node pool. Additional node pools may be added to the cluster using the `digitalocean_kubernetes_node_pool` resource. The following arguments may be specified:
   - `name` - (Required) A name for the node pool.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.1
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.188.0
+	github.com/digitalocean/godo v1.190.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.188.0 h1:QDxgjWnJYRf3JStAY9KM0xUqPC1YfXkPQWUMRRzraCk=
-github.com/digitalocean/godo v1.188.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.190.0 h1:Gfqu0tSZm1n1gxkfbpNgLP43LNg3FQ21lFPAZVG0zXo=
+github.com/digitalocean/godo v1.190.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.190.0] - 2026-05-14
+
+- #1001 - ensure that kubernetes GetKubeConfigWithExpiry fetches a token-based kubeconfig
+- #1004 - Add custom models API and tests
+- #970 - Make HA flag optional in Kubernetes cluster create request for version-based API defaults
+
+## [1.189.0] - 2026-05-04
+
+**BREAKING CHANGE:** `AppIngressSpecRuleStringMatch.Prefix` and `.Exact` changed from `string` to `*string` to fix empty-string matching. Consumers that directly read or assign these fields will need to update their code. Use `godo.PtrTo("value")` for assignment and the `GetPrefix()`/`GetExact()` accessors for reading.
+
+- #994 - @aupadhyay-shark - App Ingress authority routing only supports exact matching #937
+
 ## [1.188.0] - 2026-04-27
 
 - #1000 - @m3co-code - add new fields to k8s node pool template for auto-scaler

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -389,8 +389,8 @@ type AppIngressSpecRuleRoutingRedirect struct {
 // AppIngressSpecRuleStringMatch The string match configuration.
 type AppIngressSpecRuleStringMatch struct {
 	// Prefix-based match. For example, `/api` will match `/api`, `/api/`, and any nested paths such as `/api/v1/endpoint`.
-	Prefix string `json:"prefix,omitempty"`
-	Exact  string `json:"exact,omitempty"`
+	Prefix *string `json:"prefix,omitempty"`
+	Exact  *string `json:"exact,omitempty"`
 }
 
 type AppSecureHeaderSpec struct {

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1079,18 +1079,18 @@ func (a *AppIngressSpecRuleRoutingRedirect) GetUri() string {
 
 // GetExact returns the Exact field.
 func (a *AppIngressSpecRuleStringMatch) GetExact() string {
-	if a == nil {
+	if a == nil || a.Exact == nil {
 		return ""
 	}
-	return a.Exact
+	return *a.Exact
 }
 
 // GetPrefix returns the Prefix field.
 func (a *AppIngressSpecRuleStringMatch) GetPrefix() string {
-	if a == nil {
+	if a == nil || a.Prefix == nil {
 		return ""
 	}
-	return a.Prefix
+	return *a.Prefix
 }
 
 // GetComponentName returns the ComponentName field.

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.188.0"
+	libraryVersion = "1.190.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/gradientai.go
+++ b/vendor/github.com/digitalocean/godo/gradientai.go
@@ -30,6 +30,51 @@ const (
 	OpenAIAPIKeysPath            = "/v2/gen-ai/openai/keys"
 	UpdateFunctionRoutePath      = functionRouteBasePath + "/%s"
 	DeleteFunctionRoutePath      = functionRouteBasePath + "/%s"
+	customModelsBasePath         = "/v2/gen-ai/custom_models"
+	customModelImportPath        = customModelsBasePath + "/import"
+	customModelByIDPath          = customModelsBasePath + "/%s"
+	customModelMetadataPath      = customModelsBasePath + "/%s/metadata"
+)
+
+// CustomModelStatus represents the status of a custom model.
+type CustomModelStatus string
+
+const (
+	CustomModelStatusUnspecified CustomModelStatus = "STATUS_UNSPECIFIED"
+	CustomModelStatusImporting   CustomModelStatus = "STATUS_IMPORTING"
+	CustomModelStatusReady       CustomModelStatus = "STATUS_READY"
+	CustomModelStatusFailed      CustomModelStatus = "STATUS_FAILED"
+	CustomModelStatusDeleted     CustomModelStatus = "STATUS_DELETED"
+)
+
+// CustomModelSourceType represents the source from which a custom model was imported.
+type CustomModelSourceType string
+
+const (
+	CustomModelSourceTypeUnspecified  CustomModelSourceType = "SOURCE_TYPE_UNSPECIFIED"
+	CustomModelSourceTypeHuggingFace  CustomModelSourceType = "SOURCE_TYPE_HUGGINGFACE"
+	CustomModelSourceTypeSpacesBucket CustomModelSourceType = "SOURCE_TYPE_SPACES_BUCKET"
+	CustomModelSourceTypeSDKUpload    CustomModelSourceType = "SOURCE_TYPE_SDK_UPLOAD"
+	CustomModelSourceTypeFineTuning   CustomModelSourceType = "SOURCE_TYPE_FINE_TUNING"
+)
+
+// CustomModelSourceRefAccessType represents the access level required for a custom model source repository.
+type CustomModelSourceRefAccessType string
+
+const (
+	CustomModelSourceRefAccessTypeUnspecified CustomModelSourceRefAccessType = "ACCESS_TYPE_UNSPECIFIED"
+	CustomModelSourceRefAccessTypePublic      CustomModelSourceRefAccessType = "ACCESS_TYPE_PUBLIC"
+	CustomModelSourceRefAccessTypePrivate     CustomModelSourceRefAccessType = "ACCESS_TYPE_PRIVATE"
+	CustomModelSourceRefAccessTypeGated       CustomModelSourceRefAccessType = "ACCESS_TYPE_GATED"
+)
+
+// DeleteCustomModelStatus represents the status of a delete custom model operation.
+type DeleteCustomModelStatus string
+
+const (
+	DeleteCustomModelStatusUnspecified DeleteCustomModelStatus = "DELETE_CUSTOM_MODEL_STATUS_UNSPECIFIED"
+	DeleteCustomModelStatusSuccess     DeleteCustomModelStatus = "DELETE_CUSTOM_MODEL_STATUS_SUCCESS"
+	DeleteCustomModelStatusFail        DeleteCustomModelStatus = "DELETE_CUSTOM_MODEL_STATUS_FAIL"
 )
 
 // GradientAIService is an interface for interfacing with the Gradient AI Agent endpoints
@@ -85,6 +130,10 @@ type GradientAIService interface {
 	SearchModels(context.Context, string) ([]string, *Response, error)
 	GetModelByUUID(context.Context, string) (*Model, *Response, error)
 	ListDatacenterRegions(context.Context, *bool, *bool) ([]*DatacenterRegions, *Response, error)
+	ListCustomModels(ctx context.Context, opt *CustomModelListOptions) (*CustomModelListResponse, *Response, error)
+	ImportCustomModel(ctx context.Context, importRequest *CustomModelImportRequest) (*CustomModelImportResponse, *Response, error)
+	DeleteCustomModel(ctx context.Context, uuid string) (*CustomModelDeleteResponse, *Response, error)
+	UpdateCustomModelMetadata(ctx context.Context, uuid string, updateRequest *CustomModelMetadataUpdateRequest) (*CustomModel, *Response, error)
 }
 
 var _ GradientAIService = &GradientAIServiceOp{}
@@ -1894,6 +1943,231 @@ func (g *GradientAIServiceOp) ListDatacenterRegions(ctx context.Context, servesI
 		return nil, resp, err
 	}
 	return root.DatacenterRegions, resp, nil
+}
+
+// CustomModel represents a user-imported model (from HuggingFace, Spaces, etc.).
+type CustomModel struct {
+	Uuid                 string                         `json:"uuid,omitempty"`
+	Name                 string                         `json:"name,omitempty"`
+	Description          string                         `json:"description,omitempty"`
+	Status               CustomModelStatus              `json:"status,omitempty"`
+	Architecture         string                         `json:"architecture,omitempty"`
+	SourceType           CustomModelSourceType          `json:"source_type,omitempty"`
+	SourceRef            *CustomModelSourceRef          `json:"source_ref,omitempty"`
+	TotalSizeBytes       string                         `json:"total_size_bytes,omitempty"`
+	FileCount            int                            `json:"file_count,omitempty"`
+	License              string                         `json:"license,omitempty"`
+	Tags                 *CustomModelTags               `json:"tags,omitempty"`
+	CreatedAt            *Timestamp                     `json:"created_at,omitempty"`
+	UpdatedAt            *Timestamp                     `json:"updated_at,omitempty"`
+	ActiveDeployments    []*CustomModelActiveDeployment `json:"active_deployments,omitempty"`
+	ContextLength        int                            `json:"context_length,omitempty"`
+	CostEstimatePerMonth int                            `json:"cost_estimate_per_month,omitempty"`
+	InputModalities      []string                       `json:"input_modalities,omitempty"`
+	OutputModalities     []string                       `json:"output_modalities,omitempty"`
+	Parameters           string                         `json:"parameters,omitempty"`
+	TeamId               string                         `json:"team_id,omitempty"`
+	ConfigJson           map[string]any                 `json:"config_json,omitempty"`
+	StorageRegion        string                         `json:"storage_region,omitempty"`
+}
+
+// CustomModelSourceRef references the original source of a custom model.
+type CustomModelSourceRef struct {
+	RepoId     string                         `json:"repo_id,omitempty"`
+	CommitSha  string                         `json:"commit_sha,omitempty"`
+	AccessType CustomModelSourceRefAccessType `json:"access_type,omitempty"`
+	Bucket     string                         `json:"bucket,omitempty"`
+	Region     string                         `json:"region,omitempty"`
+	Prefix     string                         `json:"prefix,omitempty"`
+	HfToken    string                         `json:"hf_token,omitempty"`
+}
+
+// CustomModelTags contains user-defined tags for organizing custom models.
+type CustomModelTags struct {
+	Tags []string `json:"tags,omitempty"`
+}
+
+// CustomModelActiveDeployment represents an active dedicated inference deployment using a custom model.
+type CustomModelActiveDeployment struct {
+	Id         string                                `json:"id,omitempty"`
+	Name       string                                `json:"name,omitempty"`
+	RegionSlug string                                `json:"region_slug,omitempty"`
+	State      string                                `json:"state,omitempty"`
+	Endpoints  *CustomModelActiveDeploymentEndpoints `json:"endpoints,omitempty"`
+	CreatedAt  string                                `json:"created_at,omitempty"`
+	UpdatedAt  string                                `json:"updated_at,omitempty"`
+}
+
+// CustomModelActiveDeploymentEndpoints contains the endpoint URLs for a custom-model deployment.
+type CustomModelActiveDeploymentEndpoints struct {
+	PublicEndpointFqdn  string `json:"public_endpoint_fqdn,omitempty"`
+	PrivateEndpointFqdn string `json:"private_endpoint_fqdn,omitempty"`
+}
+
+// CustomModelImportJob tracks the progress of a custom model import.
+type CustomModelImportJob struct {
+	Uuid         string     `json:"uuid,omitempty"`
+	Status       string     `json:"status,omitempty"`
+	FilesTotal   int        `json:"files_total,omitempty"`
+	FilesDone    int        `json:"files_done,omitempty"`
+	BytesTotal   string     `json:"bytes_total,omitempty"`
+	BytesDone    string     `json:"bytes_done,omitempty"`
+	ErrorMessage string     `json:"error_message,omitempty"`
+	ErrorStep    string     `json:"error_step,omitempty"`
+	StartedAt    *Timestamp `json:"started_at,omitempty"`
+	CompletedAt  *Timestamp `json:"completed_at,omitempty"`
+	CreatedAt    *Timestamp `json:"created_at,omitempty"`
+}
+
+// CustomModelImportValidationStep describes a single validation step performed during a custom model import.
+type CustomModelImportValidationStep struct {
+	Name   string `json:"name,omitempty"`
+	Passed bool   `json:"passed,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// CustomModelListOptions specifies optional parameters for listing custom models.
+type CustomModelListOptions struct {
+	Status CustomModelStatus `url:"status,omitempty"`
+	ListOptions
+}
+
+// CustomModelImportRequest is the request body for importing a custom model.
+type CustomModelImportRequest struct {
+	Name                     string                `json:"name"`
+	SourceType               CustomModelSourceType `json:"source_type"`
+	SourceRef                *CustomModelSourceRef `json:"source_ref,omitempty"`
+	Description              string                `json:"description,omitempty"`
+	PreferredGpuRegion       string                `json:"preferred_gpu_region,omitempty"`
+	AcceptTermsAndConditions bool                  `json:"accept_terms_and_conditions,omitempty"`
+	Tags                     *CustomModelTags      `json:"tags,omitempty"`
+}
+
+// CustomModelMetadataUpdateRequest is the request body for updating custom model metadata.
+type CustomModelMetadataUpdateRequest struct {
+	Name        string           `json:"name,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Tags        *CustomModelTags `json:"tags,omitempty"`
+}
+
+// CustomModelListResponse is the response returned by ListCustomModels.
+type CustomModelListResponse struct {
+	Models       []*CustomModel `json:"models,omitempty"`
+	Links        *Links         `json:"links,omitempty"`
+	Meta         *Meta          `json:"meta,omitempty"`
+	MaxThreshold int            `json:"max_threshold,omitempty"`
+}
+
+// CustomModelImportResponse is the response returned by ImportCustomModel.
+type CustomModelImportResponse struct {
+	Model           *CustomModel                       `json:"model,omitempty"`
+	ImportJob       *CustomModelImportJob              `json:"import_job,omitempty"`
+	ValidationSteps []*CustomModelImportValidationStep `json:"validation_steps,omitempty"`
+	Error           string                             `json:"error,omitempty"`
+}
+
+// CustomModelDeleteResponse is the response returned by DeleteCustomModel.
+type CustomModelDeleteResponse struct {
+	Status DeleteCustomModelStatus `json:"status,omitempty"`
+	Error  string                  `json:"error,omitempty"`
+}
+
+type customModelRoot struct {
+	Model *CustomModel `json:"model"`
+}
+
+// ListCustomModels returns the list of custom models for the team.
+func (s *GradientAIServiceOp) ListCustomModels(ctx context.Context, opt *CustomModelListOptions) (*CustomModelListResponse, *Response, error) {
+	path, err := addOptions(customModelsBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CustomModelListResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+	return root, resp, nil
+}
+
+// ImportCustomModel imports a new custom model from a supported source (HuggingFace, Spaces, etc.).
+func (s *GradientAIServiceOp) ImportCustomModel(ctx context.Context, importRequest *CustomModelImportRequest) (*CustomModelImportResponse, *Response, error) {
+	if importRequest == nil {
+		return nil, nil, fmt.Errorf("import request is required")
+	}
+	if importRequest.Name == "" {
+		return nil, nil, fmt.Errorf("Name is required")
+	}
+	if importRequest.SourceType == "" {
+		return nil, nil, fmt.Errorf("SourceType is required")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, customModelImportPath, importRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CustomModelImportResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// DeleteCustomModel deletes the custom model with the given UUID.
+func (s *GradientAIServiceOp) DeleteCustomModel(ctx context.Context, uuid string) (*CustomModelDeleteResponse, *Response, error) {
+	if uuid == "" {
+		return nil, nil, fmt.Errorf("uuid is required")
+	}
+	path := fmt.Sprintf(customModelByIDPath, uuid)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CustomModelDeleteResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// UpdateCustomModelMetadata updates the metadata (description, tags, name) of an existing custom model.
+func (s *GradientAIServiceOp) UpdateCustomModelMetadata(ctx context.Context, uuid string, updateRequest *CustomModelMetadataUpdateRequest) (*CustomModel, *Response, error) {
+	if uuid == "" {
+		return nil, nil, fmt.Errorf("uuid is required")
+	}
+	if updateRequest == nil {
+		return nil, nil, fmt.Errorf("update request is required")
+	}
+	path := fmt.Sprintf(customModelMetadataPath, uuid)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(customModelRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Model, resp, nil
 }
 
 func (a Agent) String() string {

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -76,7 +76,8 @@ type KubernetesClusterCreateRequest struct {
 	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
 	ServiceSubnet string   `json:"service_subnet,omitempty"`
 
-	// Create cluster with highly available control plane. When nil, API applies version-dependent default (true for 1.36+).
+	// HA enables a highly available control plane. When omitted, the API applies
+	// version-based defaults: false for versions < 1.36, true for versions >= 1.36.
 	HA *bool `json:"ha,omitempty"`
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
@@ -807,7 +808,7 @@ func (svc *KubernetesServiceOp) GetKubeConfig(ctx context.Context, clusterID str
 		return nil, nil, err
 	}
 	q := req.URL.Query()
-	if get.Type != "" {
+	if get != nil && get.Type != "" {
 		q.Add("type", get.Type)
 	}
 	req.URL.RawQuery = q.Encode()
@@ -832,6 +833,7 @@ func (svc *KubernetesServiceOp) GetKubeConfigWithExpiry(ctx context.Context, clu
 	}
 	q := req.URL.Query()
 	q.Add("expiry_seconds", fmt.Sprintf("%d", expirySeconds))
+	q.Add("type", "token")
 	req.URL.RawQuery = q.Encode()
 	configBytes := bytes.NewBuffer(nil)
 	resp, err := svc.client.Do(ctx, req, configBytes)
@@ -852,7 +854,7 @@ func (svc *KubernetesServiceOp) GetCredentials(ctx context.Context, clusterID st
 		return nil, nil, err
 	}
 	q := req.URL.Query()
-	if get.ExpirySeconds != nil {
+	if get != nil && get.ExpirySeconds != nil {
 		q.Add("expiry_seconds", strconv.Itoa(*get.ExpirySeconds))
 	}
 	req.URL.RawQuery = q.Encode()

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -76,8 +76,8 @@ type KubernetesClusterCreateRequest struct {
 	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
 	ServiceSubnet string   `json:"service_subnet,omitempty"`
 
-	// Create cluster with highly available control plane
-	HA bool `json:"ha"`
+	// Create cluster with highly available control plane. When nil, API applies version-dependent default (true for 1.36+).
+	HA *bool `json:"ha,omitempty"`
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.188.0
+# github.com/digitalocean/godo v1.190.0
 ## explicit; go 1.23.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
Updates the `ha` schema default to nil for Kubernetes clusters. So that API based default can apply, if user doesn't provide it explicitly in the config

API based defaults:
Kubernetes ≥ 1.36.0: HA control plane enabled when ha is omitted
Kubernetes < 1.36.0: HA control plane disabled when ha is omitted

e2e Validations: https://docs.google.com/document/d/1MNy8df0iekNwVp5xsGZ1HuaXoWVerDViTVdnBRJeraE/edit?tab=t.yc0jg93jcl8l