### PR TITLE
Fix public_networking default causing droplet destruction

### DIFF
--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -214,8 +214,8 @@ func ResourceDigitalOceanDroplet() *schema.Resource {
 			"public_networking": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
-				Default:     true,
 				Description: "Enables public networking for the Droplet. By default, this is always enabled on new droplets, but by explicitly setting it to false, you can create a droplet with public networking entirely disabled.",
 			},
 
@@ -478,6 +478,7 @@ func setDropletAttributes(d *schema.ResourceData, droplet *godo.Droplet) error {
 	d.Set("ipv4_address", FindIPv4AddrByType(droplet, "public"))
 	d.Set("ipv4_address_private", FindIPv4AddrByType(droplet, "private"))
 	d.Set("ipv6_address", strings.ToLower(FindIPv6AddrByType(droplet, "public")))
+	d.Set("public_networking", FindIPv4AddrByType(droplet, "public") != "")
 
 	if features := droplet.Features; features != nil {
 		d.Set("backups", slices.Contains(features, "backups"))

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -825,9 +825,9 @@ func TestAccDigitalOceanDroplet_withPublicNetworkingSetFalse(t *testing.T) {
 	})
 }
 
-// TestAccDigitalOceanDroplet_withPublicNetworkingSetTrue tests that no error is returned
+// TestAccDigitalOceanDroplet_withPublicNetworkingNotSet tests that no error is returned
 // from the API when creating a Droplet with the "public_networking" field is explicitly not set,
-// defaulting to true.
+// and that the computed value is true (public networking is enabled by default).
 func TestAccDigitalOceanDroplet_withPublicNetworkingNotSet(t *testing.T) {
 	var droplet godo.Droplet
 	keyName := acceptance.RandomTestName()


### PR DESCRIPTION
Fixes #1524

Hardcoded default was making Terraform recreate droplets when users didn't actually change public_networking. Switched to computing the value from the actual droplet state instead. Now Terraform stays in sync with the API and only recreates if the user explicitly changes it.