### PR TITLE
droplet: honour public_networking = false (was silently dropped by GetOk)

### DIFF
--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -345,9 +345,12 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 		opts.PrivateNetworking = attr.(bool)
 	}
 
-	if attr, ok := d.GetOk("public_networking"); ok {
-		b := attr.(bool)
-		opts.PublicNetworking = &b
+	// GetOkExists (rather than GetOk) so that an explicit `false` is
+	// forwarded to the API. GetOk treats the zero value (false) as
+	// "unset" and would silently drop the override, leaving the droplet
+	// with a public NIC. Mirrors the droplet_agent pattern below.
+	if attr, ok := d.GetOkExists("public_networking"); ok {
+		opts.PublicNetworking = godo.PtrTo(attr.(bool))
 	}
 
 	if attr, ok := d.GetOk("user_data"); ok {

--- a/digitalocean/droplet/resource_droplet_test.go
+++ b/digitalocean/droplet/resource_droplet_test.go
@@ -819,6 +819,16 @@ func TestAccDigitalOceanDroplet_withPublicNetworkingSetFalse(t *testing.T) {
 						"digitalocean_droplet.foobar", "public_networking", "false"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "image", "rancheros"),
+					// Verify against the live API object that the droplet was
+					// actually created with no public NIC — guards against a
+					// regression where the attribute is correct in state but
+					// the API override is silently dropped.
+					func(s *terraform.State) error {
+						if ip, _ := droplet.PublicIPv4(); ip != "" {
+							return fmt.Errorf("expected no public IPv4, got %q", ip)
+						}
+						return nil
+					},
 				),
 			},
 		},


### PR DESCRIPTION
## Summary

Setting `public_networking = false` on `digitalocean_droplet` is silently ignored — the droplet is still created with a public NIC.

Repro:
```hcl
resource "digitalocean_droplet" "private" {
  name              = "private-pg"
  region            = "lon1"
  size              = "s-1vcpu-1gb"
  image             = "debian-13-x64"
  vpc_uuid          = digitalocean_vpc.example.id
  public_networking = false
}
```
After apply (provider v2.82+), the droplet has both `eth0` (public IPv4) and `eth1` (VPC private IPv4). DigitalOcean's own metadata endpoint confirms the public interface is present.

## Root cause

`resourceDigitalOceanDropletCreate` reads the attribute with `GetOk`:

```go
if attr, ok := d.GetOk("public_networking"); ok {
    b := attr.(bool)
    opts.PublicNetworking = &b
}
```

`schema.ResourceData.GetOk` returns `ok=false` for the zero value of the type — for `TypeBool` that is `false`. So an explicit `public_networking = false` never reaches `godo.DropletCreateRequest.PublicNetworking`, and the API applies its default (public networking on).

## Fix

Switch to `GetOkExists`, which distinguishes "not set" from "set to the zero value". This mirrors the existing handling of `droplet_agent` three lines below in the same file — same `*bool` godo field, same `bool-that-must-support-false` semantic:

```go
if attr, ok := d.GetOkExists("droplet_agent"); ok {
    opts.WithDropletAgent = godo.PtrTo(attr.(bool))
}
```

`GetOkExists` is marked deprecated in terraform-plugin-sdk v2 but is still the documented escape hatch for this exact case, and is already used in this repo. An alternative would be `d.GetRawConfig().GetAttr("public_networking")` with a null check — happy to switch if the maintainers prefer that style.

## Test

The existing acceptance test `TestAccDigitalOceanDroplet_withPublicNetworkingSetFalse` only asserts state attributes, which is why it missed the regression. Added an extra check against the live `godo.Droplet` object: `droplet.PublicIPv4()` must be empty. That closes the loop against the actual API behaviour and would have caught the bug when it was introduced.

## Out of scope

`digitalocean_droplet_autoscale` has a similar gap: `expandTemplate` declares `public_networking` in the schema but never assigns it to `godo.DropletAutoscaleResourceTemplate.PublicNetworking`. Happy to include that in this PR or file a separate one — it's a distinct fix site and requires a nested-attribute lookup, so I kept this PR focused on `digitalocean_droplet`.

Related: #1515 (added the attribute), #1524 / #1526 (addressed a separate drift/recreation bug).