### PR TITLE
DOKS: per-cluster SSO config

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -225,24 +225,26 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 
 			"sso": {
 				Type:     schema.TypeList,
+				Computed: true,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Required: true,
+							Computed: true,
 						},
 						"required": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"issuer_url": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 						"client_id": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -271,10 +273,6 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				Computed: true,
 			},
 
-			"kube_config_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"kube_config": kubernetesConfigSchema(),
 
 			"auto_upgrade": {

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -230,13 +230,19 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
+							Required: true,
 						},
 						"required": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
+						},
+						"issuer_url": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"client_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -265,6 +271,10 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"kube_config_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"kube_config": kubernetesConfigSchema(),
 
 			"auto_upgrade": {

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -639,16 +639,18 @@ func flattenCAConfigOpts(opts *godo.KubernetesClusterAutoscalerConfiguration) []
 	return result
 }
 
-func expandSSOOpts(d *schema.ResourceData) *godo.KubernetesClusterSSO {
+func expandSSOOpts(sso []interface{}) *godo.KubernetesClusterSSO {
 	ssoConfig := &godo.KubernetesClusterSSO{}
-	if _, isSet := d.GetOk("sso"); !isSet {
+	if len(sso) == 0 || sso[0] == nil {
 		return ssoConfig
 	}
 
-	ssoConfig.Enabled = d.Get("sso.0.enabled").(bool)
-	ssoConfig.Required = d.Get("sso.0.required").(bool)
-	ssoConfig.IssuerURL = d.Get("sso.0.issuer_url").(string)
-	ssoConfig.ClientID = d.Get("sso.0.client_id").(string)
+	ssoMap := sso[0].(map[string]interface{})
+
+	ssoConfig.Enabled = ssoMap["enabled"].(bool)
+	ssoConfig.Required = ssoMap["required"].(bool)
+	ssoConfig.IssuerURL = ssoMap["issuer_url"].(string)
+	ssoConfig.ClientID = ssoMap["client_id"].(string)
 
 	return ssoConfig
 }

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -640,10 +640,11 @@ func flattenCAConfigOpts(opts *godo.KubernetesClusterAutoscalerConfiguration) []
 }
 
 func expandSSOOpts(sso []interface{}) *godo.KubernetesClusterSSO {
-	ssoConfig := &godo.KubernetesClusterSSO{}
 	if len(sso) == 0 || sso[0] == nil {
-		return ssoConfig
+		return nil
 	}
+
+	ssoConfig := &godo.KubernetesClusterSSO{}
 
 	ssoMap := sso[0].(map[string]interface{})
 

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -639,19 +639,16 @@ func flattenCAConfigOpts(opts *godo.KubernetesClusterAutoscalerConfiguration) []
 	return result
 }
 
-func expandSSOOptsIfSet(d *schema.ResourceData) *godo.KubernetesClusterSSO {
-	if _, isSet := d.GetOk("sso"); !isSet {
-		return nil
-	}
-
+func expandSSOOpts(d *schema.ResourceData) *godo.KubernetesClusterSSO {
 	ssoConfig := &godo.KubernetesClusterSSO{}
+	if _, isSet := d.GetOk("sso"); !isSet {
+		return ssoConfig
+	}
 
-	if v, isSet := d.GetOkExists("sso.0.enabled"); isSet {
-		ssoConfig.Enabled = v.(bool)
-	}
-	if v, isSet := d.GetOkExists("sso.0.required"); isSet {
-		ssoConfig.Required = v.(bool)
-	}
+	ssoConfig.Enabled = d.Get("sso.0.enabled").(bool)
+	ssoConfig.Required = d.Get("sso.0.required").(bool)
+	ssoConfig.IssuerURL = d.Get("sso.0.issuer_url").(string)
+	ssoConfig.ClientID = d.Get("sso.0.client_id").(string)
 
 	return ssoConfig
 }
@@ -665,6 +662,8 @@ func flattenSSOOpts(opts *godo.KubernetesClusterSSO) []map[string]interface{} {
 	item := make(map[string]interface{})
 	item["enabled"] = opts.Enabled
 	item["required"] = opts.Required
+	item["issuer_url"] = opts.IssuerURL
+	item["client_id"] = opts.ClientID
 	result = append(result, item)
 
 	return result

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -196,6 +196,8 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			"sso": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -456,7 +458,7 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 		HA:           d.Get("ha").(bool),
 		Tags:         tag.ExpandTags(d.Get("tags").(*schema.Set).List()),
 		NodePools:    poolCreateRequests,
-		SSO:          expandSSOOpts(d),
+		SSO:          expandSSOOpts(d.Get("sso").([]interface{})),
 	}
 
 	if maint, ok := d.GetOk("maintenance_policy"); ok {
@@ -681,7 +683,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 			NvidiaGpuDevicePlugin:             expandNvidiaGpuDevicePluginOpts(d.Get(nvidiaGpuDevicePluginField).([]interface{})),
 			RdmaSharedDevicePlugin:            expandRdmaSharedDevicePluginOpts(d.Get(rdmaSharedDevicePluginField).([]interface{})),
 			ClusterAutoscalerConfiguration:    expandCAConfigOptsForUpdate(d.GetChange("cluster_autoscaler_configuration")),
-			SSO:                               expandSSOOpts(d),
+			SSO:                               expandSSOOpts(d.Get("sso").([]interface{})),
 		}
 
 		if maint, ok := d.GetOk("maintenance_policy"); ok {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -200,13 +200,19 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
+							Required: true,
 						},
 						"required": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
+						},
+						"issuer_url": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"client_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -450,7 +456,7 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 		HA:           d.Get("ha").(bool),
 		Tags:         tag.ExpandTags(d.Get("tags").(*schema.Set).List()),
 		NodePools:    poolCreateRequests,
-		SSO:          expandSSOOptsIfSet(d),
+		SSO:          expandSSOOpts(d),
 	}
 
 	if maint, ok := d.GetOk("maintenance_policy"); ok {
@@ -675,7 +681,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 			NvidiaGpuDevicePlugin:             expandNvidiaGpuDevicePluginOpts(d.Get(nvidiaGpuDevicePluginField).([]interface{})),
 			RdmaSharedDevicePlugin:            expandRdmaSharedDevicePluginOpts(d.Get(rdmaSharedDevicePluginField).([]interface{})),
 			ClusterAutoscalerConfiguration:    expandCAConfigOptsForUpdate(d.GetChange("cluster_autoscaler_configuration")),
-			SSO:                               expandSSOOptsIfSet(d),
+			SSO:                               expandSSOOpts(d),
 		}
 
 		if maint, ok := d.GetOk("maintenance_policy"); ok {


### PR DESCRIPTION
A few related changes for DOKS SSO. The project is not available to the public yet, so, breaking changes in the sso-specific flags are okay.

1. DOKS now expects per-cluster SSO configuration (i.e. each cluster gets an SSO client ID and issuer url). Adding the corresponding fields to the schema
2. There's no more reason to differentiate between "enabled" and "required" values not being set by the customer vs being set to "false". This makes it much less awkward to handle for terraform: no more `GetOkExists`

