### PR TITLE
Fix: droplet public_networking attribute forces replacement of all existing droplets

### DIFF
--- a/digitalocean/droplet/resource_droplet.go
+++ b/digitalocean/droplet/resource_droplet.go
@@ -215,7 +215,7 @@ func ResourceDigitalOceanDroplet() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Enables public networking for the Droplet. By default, this is always enabled on new droplets, but by explicitly setting it to false, you can create a droplet with public networking entirely disabled.",
 			},
 
@@ -345,9 +345,10 @@ func resourceDigitalOceanDropletCreate(ctx context.Context, d *schema.ResourceDa
 		opts.PrivateNetworking = attr.(bool)
 	}
 
-	pubNet := d.Get("public_networking").(bool)
-	if !pubNet {
-		opts.PublicNetworking = godo.PtrTo(false)
+	if attr, ok := d.GetOkExists("public_networking"); ok {
+		if !attr.(bool) {
+			opts.PublicNetworking = godo.PtrTo(false)
+		}
 	}
 
 	if attr, ok := d.GetOk("user_data"); ok {
@@ -475,9 +476,11 @@ func setDropletAttributes(d *schema.ResourceData, droplet *godo.Droplet) error {
 	d.Set("created_at", droplet.Created)
 	d.Set("vpc_uuid", droplet.VPCUUID)
 
-	d.Set("ipv4_address", FindIPv4AddrByType(droplet, "public"))
+	publicIPv4 := FindIPv4AddrByType(droplet, "public")
+	d.Set("ipv4_address", publicIPv4)
 	d.Set("ipv4_address_private", FindIPv4AddrByType(droplet, "private"))
 	d.Set("ipv6_address", strings.ToLower(FindIPv6AddrByType(droplet, "public")))
+	d.Set("public_networking", publicIPv4 != "")
 
 	if features := droplet.Features; features != nil {
 		d.Set("backups", slices.Contains(features, "backups"))


### PR DESCRIPTION


### Summary
PR #1515 introduced the public_networking attribute on digitalocean_droplet with ForceNew: true and Default: true. This causes terraform plan to propose destroying and recreating every existing droplet on provider upgrade, even when the user's config hasn't changed. For users with lifecycle { prevent_destroy = true }, this blocks all deployments with:

Error: Instance cannot be destroyed
Resource digitalocean_droplet.TAG has lifecycle.prevent_destroy
set, but the plan calls for this resource to be destroyed.
For users without prevent_destroy, Terraform silently destroys and recreates droplets, causing data loss, IP changes, and downtime.

###  Root Cause
Three interacting issues:

Default: true with ForceNew: true — For existing droplets whose state predates #1515, there is no public_networking value in state. Terraform injects the schema default (true), sees a diff (empty -> true), and ForceNew triggers a destroy+recreate cycle.

setDropletAttributes never sets public_networking — The Read function does not populate public_networking from the API response, so the value is never written to state. Even terraform refresh cannot correct the state.

d.Get in Create cannot distinguish "not set" from "set to false" — The create function uses d.Get("public_networking").(bool), which returns the zero value false when the attribute is absent. With Default: true this worked by accident, but any fix that removes the default must also fix the create path.

###  Fix
Three targeted changes in resource_droplet.go:

1. Schema: Default: true -> Computed: true
    Type:     schema.TypeBool,
    Optional: true,
    ForceNew: true,
    Default:  true,
    Computed: true,
},
Computed: true tells Terraform to derive the value from the API (via the provider's Read function) instead of injecting a hardcoded default. This eliminates the spurious diff on existing droplets.

2. Read: populate public_networking from the API
d.Set("ipv4_address", FindIPv4AddrByType(droplet, "public"))
publicIPv4 := FindIPv4AddrByType(droplet, "public")
d.Set("ipv4_address", publicIPv4)
d.Set("ipv4_address_private", FindIPv4AddrByType(droplet, "private"))
d.Set("ipv6_address", strings.ToLower(FindIPv6AddrByType(droplet, "public")))
d.Set("public_networking", publicIPv4 != "")
The value is derived from whether the droplet has a public IPv4 address. This ensures state is always correct after Read, Refresh, and Import.

3. Create: d.Get -> d.GetOkExists
pubNet := d.Get("public_networking").(bool)
if !pubNet {
    opts.PublicNetworking = godo.PtrTo(false)
if attr, ok := d.GetOkExists("public_networking"); ok {
    if !attr.(bool) {
        opts.PublicNetworking = godo.PtrTo(false)
    }
}
GetOkExists distinguishes between "user didn't set it" (ok=false, don't send anything, API defaults to public) and "user explicitly set it to false" (ok=true, send PublicNetworking: false). This follows the same pattern used for droplet_agent in this file.

### Test Plan

- [x] Existing unit tests pass (go test ./digitalocean/droplet/ )
- [x] Acceptance test: TestAccDigitalOceanDroplet_withPublicNetworkingSetTrue
- [x] Acceptance test:TestAccDigitalOceanDroplet_withPublicNetworkingSetFalse
- [x] Acceptance test:TestAccDigitalOceanDroplet_withPublicNetworkingNotSet
- [x] Manual verification: existing droplet state (pre-fix) produces no diff after upgrade