### PR TITLE
APICLI-4364 - loadbalancer, certificate: wait for GLB cert binding + retry cert delete on rotation

### DIFF
--- a/digitalocean/certificate/resource_certificate.go
+++ b/digitalocean/certificate/resource_certificate.go
@@ -18,6 +18,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+const (
+	certificateDeleteDefaultTimeout = 15 * time.Minute
+	certificateDeleteInitialBackoff = 2 * time.Second
+	certificateDeleteMaxBackoff     = 30 * time.Second
+)
+
 func ResourceDigitalOceanCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDigitalOceanCertificateCreate,
@@ -28,6 +34,11 @@ func ResourceDigitalOceanCertificate() *schema.Resource {
 		},
 
 		Schema: resourceDigitalOceanCertificateV1(),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(certificateDeleteDefaultTimeout),
+		},
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
@@ -280,6 +291,15 @@ func resourceDigitalOceanCertificateRead(ctx context.Context, d *schema.Resource
 
 }
 
+func certificateDeleteBlockedByLoadBalancer(err error) bool {
+	if err == nil {
+		return false
+	}
+	// API message variants when a certificate is still attached to a load balancer.
+	return util.IsDigitalOceanError(err, http.StatusForbidden, "Make sure the certificate is not in use before deleting it") ||
+		util.IsDigitalOceanError(err, http.StatusForbidden, "being used by one or more load balancers")
+}
+
 func resourceDigitalOceanCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig).GodoClient()
 
@@ -292,20 +312,41 @@ func resourceDigitalOceanCertificateDelete(ctx context.Context, d *schema.Resour
 		return nil
 	}
 
-	timeout := 30 * time.Second
-	err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
-		_, err = client.Certificates.Delete(context.Background(), cert.ID)
-		if err != nil {
-			if util.IsDigitalOceanError(err, http.StatusForbidden, "Make sure the certificate is not in use before deleting it") {
-				log.Printf("[DEBUG] Received %s, retrying certificate deletion", err.Error())
-				time.Sleep(1 * time.Second)
-				return retry.RetryableError(err)
-			}
+	deleteTimeout := d.Timeout(schema.TimeoutDelete)
+	if deleteTimeout == 0 {
+		deleteTimeout = certificateDeleteDefaultTimeout
+	}
 
-			return retry.NonRetryableError(err)
+	waitCtx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	backoff := certificateDeleteInitialBackoff
+
+	err = retry.RetryContext(waitCtx, deleteTimeout, func() *retry.RetryError {
+		resp, delErr := client.Certificates.Delete(waitCtx, cert.ID)
+		if delErr == nil {
+			return nil
+		}
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		if certificateDeleteBlockedByLoadBalancer(delErr) {
+			log.Printf("[DEBUG] Certificate %q delete blocked (likely still referenced by a load balancer); retrying after %s: %v", d.Id(), backoff, delErr)
+			select {
+			case <-waitCtx.Done():
+				return retry.NonRetryableError(fmt.Errorf("timeout waiting to delete certificate %q after load balancers released it: %w", d.Id(), waitCtx.Err()))
+			case <-time.After(backoff):
+			}
+			if backoff < certificateDeleteMaxBackoff {
+				backoff *= 2
+				if backoff > certificateDeleteMaxBackoff {
+					backoff = certificateDeleteMaxBackoff
+				}
+			}
+			return retry.RetryableError(delErr)
 		}
 
-		return nil
+		return retry.NonRetryableError(delErr)
 	})
 	if err != nil {
 		return diag.Errorf("Error deleting Certificate: %s", err)

--- a/digitalocean/certificate/resource_certificate_unit_test.go
+++ b/digitalocean/certificate/resource_certificate_unit_test.go
@@ -1,0 +1,102 @@
+package certificate
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+// godoErr builds a *godo.ErrorResponse suitable for unit testing the error
+// classification helpers without making any network calls.
+func godoErr(status int, message string) error {
+	return &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: status},
+		Message:  message,
+	}
+}
+
+func TestCertificateDeleteBlockedByLoadBalancer(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		blocked bool
+	}{
+		{
+			name:    "nil error is not blocked",
+			err:     nil,
+			blocked: false,
+		},
+		{
+			name:    "plain Go error is not blocked",
+			err:     errors.New("network unreachable"),
+			blocked: false,
+		},
+		{
+			name:    "403 with primary in-use message is blocked",
+			err:     godoErr(http.StatusForbidden, "Make sure the certificate is not in use before deleting it"),
+			blocked: true,
+		},
+		{
+			name:    "403 with alternate in-use message is blocked",
+			err:     godoErr(http.StatusForbidden, "Certificate is being used by one or more load balancers"),
+			blocked: true,
+		},
+		{
+			name:    "match is case-insensitive",
+			err:     godoErr(http.StatusForbidden, "MAKE SURE THE CERTIFICATE IS NOT IN USE BEFORE DELETING IT"),
+			blocked: true,
+		},
+		{
+			name:    "403 with unrelated message is not blocked",
+			err:     godoErr(http.StatusForbidden, "rate limit exceeded"),
+			blocked: false,
+		},
+		{
+			name:    "404 with matching message is not blocked",
+			err:     godoErr(http.StatusNotFound, "Make sure the certificate is not in use before deleting it"),
+			blocked: false,
+		},
+		{
+			name:    "500 is not blocked even with matching message",
+			err:     godoErr(http.StatusInternalServerError, "being used by one or more load balancers"),
+			blocked: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := certificateDeleteBlockedByLoadBalancer(tc.err); got != tc.blocked {
+				t.Fatalf("certificateDeleteBlockedByLoadBalancer(%v) = %v, want %v", tc.err, got, tc.blocked)
+			}
+		})
+	}
+}
+
+// TestResourceDigitalOceanCertificateTimeouts asserts that the resource ships
+// with the explicit create/delete timeouts the GLB rotation fix relies on.
+// If a future change drops or shortens these defaults the rotation runbook
+// stops working, so we guard them here.
+func TestResourceDigitalOceanCertificateTimeouts(t *testing.T) {
+	r := ResourceDigitalOceanCertificate()
+	if r.Timeouts == nil {
+		t.Fatal("expected ResourceTimeout to be configured on digitalocean_certificate")
+	}
+
+	if r.Timeouts.Create == nil || *r.Timeouts.Create != 10*time.Minute {
+		t.Fatalf("expected default Create timeout of 10m, got %v", r.Timeouts.Create)
+	}
+	if r.Timeouts.Delete == nil || *r.Timeouts.Delete != certificateDeleteDefaultTimeout {
+		t.Fatalf("expected default Delete timeout of %v, got %v", certificateDeleteDefaultTimeout, r.Timeouts.Delete)
+	}
+
+	if certificateDeleteInitialBackoff >= certificateDeleteMaxBackoff {
+		t.Fatalf("initial backoff %v must be smaller than max backoff %v", certificateDeleteInitialBackoff, certificateDeleteMaxBackoff)
+	}
+
+	if _, ok := r.Schema["name"]; !ok {
+		t.Fatal("expected 'name' attribute on certificate schema")
+	}
+}

--- a/digitalocean/loadbalancer/loadbalancer.go
+++ b/digitalocean/loadbalancer/loadbalancer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/certificate"
@@ -383,4 +384,95 @@ func flattenLoadBalancerIds(list []string) *schema.Set {
 		flatSet.Add(v)
 	}
 	return flatSet
+}
+
+// glbCertificateBindingWaitTimeout is how long we poll the API after creating or
+// updating a GLOBAL load balancer until each custom domain's certificate_name
+// matches config. This narrows the race where a replaced certificate is deleted
+// while the control plane still reports it attached to the load balancer.
+const glbCertificateBindingWaitTimeout = 15 * time.Minute
+
+// glbDesiredDomainCertificates returns domain name -> certificate_name for
+// non-managed GLB domains that specify a custom certificate.
+func glbDesiredDomainCertificates(d *schema.ResourceData) map[string]string {
+	desired := make(map[string]string)
+	v, ok := d.GetOk("domains")
+	if !ok {
+		return desired
+	}
+	for _, raw := range v.(*schema.Set).List() {
+		m := raw.(map[string]interface{})
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		if managed, _ := m["is_managed"].(bool); managed {
+			continue
+		}
+		certName, ok := m["certificate_name"].(string)
+		if !ok || certName == "" {
+			continue
+		}
+		desired[name] = certName
+	}
+	return desired
+}
+
+func waitForGLBDomainCertificateBindings(ctx context.Context, client *godo.Client, lbID string, desired map[string]string) error {
+	if len(desired) == 0 {
+		return nil
+	}
+	conf := &retry.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"ready"},
+		Refresh: func() (interface{}, string, error) {
+			lb, _, err := client.LoadBalancers.Get(ctx, lbID)
+			if err != nil {
+				return nil, "", err
+			}
+			flat, err := flattenDomains(client, lb.Domains)
+			if err != nil {
+				return nil, "", err
+			}
+			actual := make(map[string]string)
+			for _, dm := range flat {
+				name, _ := dm["name"].(string)
+				if name == "" {
+					continue
+				}
+				certName, _ := dm["certificate_name"].(string)
+				if certName != "" {
+					actual[name] = certName
+				}
+			}
+			for dom, wantCert := range desired {
+				got, ok := actual[dom]
+				if !ok || got != wantCert {
+					return lb, "pending", nil
+				}
+			}
+			return lb, "ready", nil
+		},
+		Timeout:    glbCertificateBindingWaitTimeout,
+		Delay:      3 * time.Second,
+		MinTimeout: 2 * time.Second,
+	}
+	if _, err := conf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("timed out after %v waiting for global load balancer %q domain certificate bindings to match %#v: %w", glbCertificateBindingWaitTimeout, lbID, desired, err)
+	}
+	return nil
+}
+
+// waitForGLBDomainCertificatesIfNeeded polls after GLB writes when type is GLOBAL
+// and custom domain certificates are configured.
+func waitForGLBDomainCertificatesIfNeeded(ctx context.Context, d *schema.ResourceData, client *godo.Client, lbID string) error {
+	typ, ok := d.GetOk("type")
+	if !ok || !strings.EqualFold(typ.(string), "GLOBAL") {
+		return nil
+	}
+	desired := glbDesiredDomainCertificates(d)
+	if len(desired) == 0 {
+		return nil
+	}
+	return waitForGLBDomainCertificateBindings(ctx, client, lbID, desired)
 }

--- a/digitalocean/loadbalancer/loadbalancer_unit_test.go
+++ b/digitalocean/loadbalancer/loadbalancer_unit_test.go
@@ -1,0 +1,196 @@
+package loadbalancer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// newLBResourceData materializes a *schema.ResourceData for the
+// digitalocean_loadbalancer resource and sets the provided attributes.
+// It is the most ergonomic way to exercise helpers that read from the
+// resource without standing up a full provider.
+func newLBResourceData(t *testing.T, attrs map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+	r := ResourceDigitalOceanLoadbalancer()
+	d := r.TestResourceData()
+	for k, v := range attrs {
+		if err := d.Set(k, v); err != nil {
+			t.Fatalf("d.Set(%q): %v", k, err)
+		}
+	}
+	return d
+}
+
+func TestGLBDesiredDomainCertificates(t *testing.T) {
+	cases := []struct {
+		name    string
+		domains []interface{}
+		want    map[string]string
+	}{
+		{
+			name:    "no domains returns empty map",
+			domains: nil,
+			want:    map[string]string{},
+		},
+		{
+			name: "single custom domain with certificate is included",
+			domains: []interface{}{
+				map[string]interface{}{
+					"name":             "example.com",
+					"certificate_name": "cert-new",
+					"is_managed":       false,
+				},
+			},
+			want: map[string]string{"example.com": "cert-new"},
+		},
+		{
+			name: "managed domain is excluded",
+			domains: []interface{}{
+				map[string]interface{}{
+					"name":             "managed.example.com",
+					"certificate_name": "any-cert",
+					"is_managed":       true,
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "domain without certificate_name is excluded",
+			domains: []interface{}{
+				map[string]interface{}{
+					"name":       "no-cert.example.com",
+					"is_managed": false,
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "domain with empty name is excluded",
+			domains: []interface{}{
+				map[string]interface{}{
+					"name":             "",
+					"certificate_name": "cert-new",
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "mixed set keeps only eligible domains",
+			domains: []interface{}{
+				map[string]interface{}{
+					"name":             "a.example.com",
+					"certificate_name": "cert-a",
+				},
+				map[string]interface{}{
+					"name":             "b.example.com",
+					"certificate_name": "cert-b",
+				},
+				map[string]interface{}{
+					"name":             "managed.example.com",
+					"certificate_name": "ignored",
+					"is_managed":       true,
+				},
+				map[string]interface{}{
+					"name": "no-cert.example.com",
+				},
+			},
+			want: map[string]string{
+				"a.example.com": "cert-a",
+				"b.example.com": "cert-b",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			attrs := map[string]interface{}{}
+			if tc.domains != nil {
+				attrs["domains"] = tc.domains
+			}
+			d := newLBResourceData(t, attrs)
+
+			got := glbDesiredDomainCertificates(d)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("glbDesiredDomainCertificates() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWaitForGLBDomainCertificatesIfNeeded_NoOpPaths covers the cheap paths
+// that must short-circuit before any API call is made. We deliberately pass a
+// nil godo client; if any of these branches were to dereference the client
+// the test would panic, surfacing the regression.
+func TestWaitForGLBDomainCertificatesIfNeeded_NoOpPaths(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs map[string]interface{}
+	}{
+		{
+			name: "regional load balancer skips GLB polling",
+			attrs: map[string]interface{}{
+				"type": "REGIONAL",
+				"domains": []interface{}{
+					map[string]interface{}{
+						"name":             "example.com",
+						"certificate_name": "cert-new",
+					},
+				},
+			},
+		},
+		{
+			name: "global load balancer with no custom domains skips polling",
+			attrs: map[string]interface{}{
+				"type": "GLOBAL",
+			},
+		},
+		{
+			name: "global load balancer with only managed domains skips polling",
+			attrs: map[string]interface{}{
+				"type": "GLOBAL",
+				"domains": []interface{}{
+					map[string]interface{}{
+						"name":       "managed.example.com",
+						"is_managed": true,
+					},
+				},
+			},
+		},
+		{
+			name: "global load balancer with domain but no certificate_name skips polling",
+			attrs: map[string]interface{}{
+				"type": "GLOBAL",
+				"domains": []interface{}{
+					map[string]interface{}{
+						"name": "no-cert.example.com",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newLBResourceData(t, tc.attrs)
+			// nil client is safe only because each case must short-circuit.
+			if err := waitForGLBDomainCertificatesIfNeeded(context.Background(), d, nil, "ignored-lb-id"); err != nil {
+				t.Fatalf("expected nil error on no-op path, got %v", err)
+			}
+		})
+	}
+}
+
+// TestWaitForGLBDomainCertificateBindings_EmptyDesired makes sure the
+// underlying poller exits immediately when there is nothing to wait for,
+// without touching the godo client.
+func TestWaitForGLBDomainCertificateBindings_EmptyDesired(t *testing.T) {
+	if err := waitForGLBDomainCertificateBindings(context.Background(), nil, "ignored-lb-id", nil); err != nil {
+		t.Fatalf("expected nil error for empty desired set, got %v", err)
+	}
+	if err := waitForGLBDomainCertificateBindings(context.Background(), nil, "ignored-lb-id", map[string]string{}); err != nil {
+		t.Fatalf("expected nil error for empty desired map, got %v", err)
+	}
+}

--- a/digitalocean/loadbalancer/resource_loadbalancer.go
+++ b/digitalocean/loadbalancer/resource_loadbalancer.go
@@ -742,6 +742,10 @@ func resourceDigitalOceanLoadbalancerCreate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("Error waiting for Load Balancer (%s) to become active: %s", d.Get("name"), err)
 	}
 
+	if err := waitForGLBDomainCertificatesIfNeeded(ctx, d, client, loadbalancer.ID); err != nil {
+		return diag.Errorf("Error waiting for Global Load Balancer domain certificate bindings: %s", err)
+	}
+
 	return resourceDigitalOceanLoadbalancerRead(ctx, d, meta)
 }
 
@@ -846,6 +850,12 @@ func resourceDigitalOceanLoadbalancerUpdate(ctx context.Context, d *schema.Resou
 	_, _, err = client.LoadBalancers.Update(context.Background(), d.Id(), lbOpts)
 	if err != nil {
 		return diag.Errorf("Error updating Load Balancer: %s", err)
+	}
+
+	if d.HasChange("domains") {
+		if err := waitForGLBDomainCertificatesIfNeeded(ctx, d, client, d.Id()); err != nil {
+			return diag.Errorf("Error waiting for Global Load Balancer domain certificate bindings after update: %s", err)
+		}
 	}
 
 	return resourceDigitalOceanLoadbalancerRead(ctx, d, meta)

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -84,6 +84,12 @@ certificate. Only valid when type is `custom`.
 which the certificate will be issued. The domains must be managed using
 DigitalOcean's DNS. Only valid when type is `lets_encrypt`.
 
+## Timeouts
+
+`timeouts` block allows you to configure [operation timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `10 minutes`) Used when waiting for the certificate to reach the `verified` state.
+* `delete` - (Default `15 minutes`) Used when deleting a certificate that may still be referenced by a load balancer. The provider retries delete while the API reports the certificate is in use, so a longer timeout reduces failures during certificate rotation on Global Load Balancers.
 
 ## Attributes Reference
 

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -164,6 +164,8 @@ the backend service. Default value is `false`.
 * `certificate_id` - (Optional) **Deprecated** The certificate ID to be used for TLS handshaking.
 * `certificate_name` - (Optional) The certificate name to be used for TLS handshaking.
 
+After create and after update when `domains` changes, the provider polls the load balancer (for up to 15 minutes) until each non-managed domain’s `certificate_name` reported by the API matches the configuration. That reduces race conditions when replacing `digitalocean_certificate` resources that use `create_before_destroy`.
+
 `glb_settings` supports the following:
 
 * `target_protocol` - (Required) The protocol used for traffic from the Load Balancer to the backend Droplets. The possible values are: `http` and `https`.

--- a/examples/loadbalancer/glb_certificate_rotation_two_phase/README.md
+++ b/examples/loadbalancer/glb_certificate_rotation_two_phase/README.md
@@ -36,4 +36,4 @@ Or use the value from `terraform output attach_this_certificate_name_to_glb_doma
 
 ## If you start from a single certificate resource
 
-Use `terraform state mv` to split one resource into `old` / `new` addresses, or add a second resource and import — pair with support on the first migration if needed. See `docs/design/glb-certificate-terraform-rotation.md` section **Immediate safe process**.
+Use `terraform state mv` to split one resource into `old` / `new` addresses, or add a second resource and import — pair with support on the first migration if needed.

--- a/examples/loadbalancer/glb_certificate_rotation_two_phase/README.md
+++ b/examples/loadbalancer/glb_certificate_rotation_two_phase/README.md
@@ -1,0 +1,39 @@
+# Global Load Balancer: two-phase custom certificate rotation
+
+This example shows the **safe immediate process** for rotating a **custom** TLS certificate on a **Global** load balancer when a single `terraform apply` can hit API errors deleting the old certificate while it is still referenced.
+
+It is a **structural template** only: you must supply real PEM material and merge the `domains` change into your **existing** Global Load Balancer configuration.
+
+## Prerequisites
+
+- A working **`digitalocean_loadbalancer`** with `type = "GLOBAL"` and `domains` using a custom certificate today.
+- A **new** certificate `name` that does not collide with any existing certificate name in the account.
+
+## Phase 1 — switch GLB to new cert (keep old cert in Terraform)
+
+1. Copy `main.tf` and fill variables (or use `.tfvars`).
+2. Ensure **both** `digitalocean_certificate.old` and `digitalocean_certificate.new` exist in configuration.
+3. In your **existing** `digitalocean_loadbalancer` (GLOBAL), set `domains` to use the new cert, for example:
+
+```hcl
+  domains {
+    name               = "your.hostname.example"
+    is_managed         = false
+    certificate_name = digitalocean_certificate.new.name
+  }
+```
+
+Or use the value from `terraform output attach_this_certificate_name_to_glb_domains` if wiring across modules.
+
+4. Run `terraform plan` — you should see **create** (new cert) and **update** (GLB), **no destroy** of the old cert.
+5. Run `terraform apply`.
+
+## Phase 2 — delete old cert only
+
+1. Remove the `digitalocean_certificate.old` resource block (and any references) from your configuration.
+2. Run `terraform plan` — you should see **destroy** for the old cert only.
+3. Run `terraform apply`.
+
+## If you start from a single certificate resource
+
+Use `terraform state mv` to split one resource into `old` / `new` addresses, or add a second resource and import — pair with support on the first migration if needed. See `docs/design/glb-certificate-terraform-rotation.md` section **Immediate safe process**.

--- a/examples/loadbalancer/glb_certificate_rotation_two_phase/main.tf
+++ b/examples/loadbalancer/glb_certificate_rotation_two_phase/main.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = ">= 2.50.0"
+      version = ">= 2.86.0"
     }
   }
 }

--- a/examples/loadbalancer/glb_certificate_rotation_two_phase/main.tf
+++ b/examples/loadbalancer/glb_certificate_rotation_two_phase/main.tf
@@ -1,0 +1,90 @@
+# Two-phase GLB custom certificate rotation — certificate resources only.
+#
+# Phase 1: add digitalocean_certificate.new; keep digitalocean_certificate.old;
+#   in your EXISTING digitalocean_loadbalancer, set:
+#     domains { ... certificate_name = digitalocean_certificate.new.name }
+#   then terraform apply (no destroy of old cert).
+#
+# Phase 2: remove the digitalocean_certificate.old block from this file (and
+#   its variables); terraform apply again to delete the old cert only.
+
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = ">= 2.50.0"
+    }
+  }
+}
+
+variable "do_token" {
+  type        = string
+  sensitive   = true
+  description = "DigitalOcean API token (or use DIGITALOCEAN_TOKEN and omit)."
+}
+
+variable "old_cert_name" {
+  type        = string
+  description = "Existing certificate name (Phase 1 only)."
+}
+
+variable "new_cert_name" {
+  type        = string
+  description = "New unique certificate name for rotation."
+}
+
+variable "old_private_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "old_leaf_certificate" {
+  type      = string
+  sensitive = true
+}
+
+variable "old_certificate_chain" {
+  type      = string
+  sensitive = true
+}
+
+variable "new_private_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "new_leaf_certificate" {
+  type      = string
+  sensitive = true
+}
+
+variable "new_certificate_chain" {
+  type      = string
+  sensitive = true
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+# Phase 2: remove this entire resource and its variables.
+resource "digitalocean_certificate" "old" {
+  name              = var.old_cert_name
+  type              = "custom"
+  private_key       = var.old_private_key
+  leaf_certificate  = var.old_leaf_certificate
+  certificate_chain = var.old_certificate_chain
+}
+
+resource "digitalocean_certificate" "new" {
+  name              = var.new_cert_name
+  type              = "custom"
+  private_key       = var.new_private_key
+  leaf_certificate  = var.new_leaf_certificate
+  certificate_chain = var.new_certificate_chain
+}
+
+output "attach_this_certificate_name_to_glb_domains" {
+  description = "Set domains.certificate_name in your Global LB to this value for Phase 1."
+  value       = digitalocean_certificate.new.name
+}


### PR DESCRIPTION
https://do-internal.atlassian.net/browse/APICLI-3455
Terraform apply was failing on Global Load Balancer custom-certificate rotation: Terraform tried to delete the old certificate before the LB control plane had finished swapping the binding to the new one, so the delete returned 403 "certificate in use" and the apply aborted.
* digitalocean_loadbalancer: after Create (and after Update when domains change) poll LoadBalancers.Get until each custom GLB domain reports the configured certificate_name. Short-circuits for REGIONAL load balancers, managed domains, and domains without a certificate_name so non-GLB paths are unaffected.
* digitalocean_certificate: add explicit Create (10m) and Delete (15m) timeouts and a retry loop with exponential backoff (2s -> 30s) that retries only the "certificate in use" 403 from the API; all other errors fail fast. Honors the user-supplied timeouts block and propagates ctx so terraform apply cancellation is respected. Adds unit tests for the error classifier, timeout defaults, the desired-binding extractor, and the no-op short-circuit paths. Acceptance test for the end-to-end rotation will be added in a follow-up so it does not run on every CI build.
Docs updated for both resources.