### PR TITLE
Show an error message if invalid 'id' field given when importing DNS records

### DIFF
--- a/digitalocean/domain/resource_record.go
+++ b/digitalocean/domain/resource_record.go
@@ -249,9 +249,10 @@ func resourceDigitalOceanRecordImport(d *schema.ResourceData, meta interface{}) 
 
 		d.SetId(s[1])
 		d.Set("domain", s[0])
+		return []*schema.ResourceData{d}, nil
 	}
 
-	return []*schema.ResourceData{d}, nil
+	return nil, fmt.Errorf("invalid import block 'id = \"%s\"', required format is 'id = \"<domain>,<record_id>\"'", d.Id())
 }
 
 func resourceDigitalOceanRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
Having been tripped up by the 'Domain is invalid because it is empty' error in issue #1492, this PR adds a more meaningful message!

Now, given the following DomainRecord import block: 
```hcl
import {
  to = digitalocean_record.my_domain-record
  id = "123456789"
}
```
Terraform plan will give a more appropriate error message:
```
╷
│ Error: invalid import block 'id = "123456789"', required format is 'id = "<domain>,<record_id>"'
│ 
│ 
╵
```
Since I was changing `resourceDigitalOceanRecordImport` while implementing #1539 , I thought I would add this separately, I hope it is helpful!

Cheers,
Paul.