### PR TITLE
digitalocean_app: support liveness_health_check on services and workers

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -841,6 +841,14 @@ func appSpecWorkerSchema() *schema.Resource {
 			Optional:    true,
 			Description: "The amount of instances that this component should be scaled to.",
 		},
+		"liveness_health_check": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: appSpecHealthCheckSchema(),
+			},
+		},
 		"autoscaling": {
 			Type:     schema.TypeList,
 			Optional: true,
@@ -2020,6 +2028,42 @@ func flattenAppHealthCheck(check *godo.AppServiceSpecHealthCheck) []interface{} 
 	return result
 }
 
+func expandAppLivenessHealthCheck(config []interface{}) *godo.HealthCheckSpec {
+	healthCheckConfig := config[0].(map[string]interface{})
+
+	healthCheck := &godo.HealthCheckSpec{
+		HTTPPath:            healthCheckConfig["http_path"].(string),
+		InitialDelaySeconds: int32(healthCheckConfig["initial_delay_seconds"].(int)),
+		PeriodSeconds:       int32(healthCheckConfig["period_seconds"].(int)),
+		TimeoutSeconds:      int32(healthCheckConfig["timeout_seconds"].(int)),
+		SuccessThreshold:    int32(healthCheckConfig["success_threshold"].(int)),
+		FailureThreshold:    int32(healthCheckConfig["failure_threshold"].(int)),
+		Port:                int64(healthCheckConfig["port"].(int)),
+	}
+
+	return healthCheck
+}
+
+func flattenAppLivenessHealthCheck(check *godo.HealthCheckSpec) []interface{} {
+	result := make([]interface{}, 0)
+
+	if check != nil {
+
+		r := make(map[string]interface{})
+		r["http_path"] = check.HTTPPath
+		r["initial_delay_seconds"] = check.InitialDelaySeconds
+		r["period_seconds"] = check.PeriodSeconds
+		r["timeout_seconds"] = check.TimeoutSeconds
+		r["success_threshold"] = check.SuccessThreshold
+		r["failure_threshold"] = check.FailureThreshold
+		r["port"] = check.Port
+
+		result = append(result, r)
+	}
+
+	return result
+}
+
 func expandAppInternalPorts(config []interface{}) []int64 {
 	appInternalPorts := make([]int64, len(config))
 
@@ -2336,6 +2380,11 @@ func expandAppSpecWorkers(config []interface{}) []*godo.AppWorkerSpec {
 			s.Image = expandAppImageSourceSpec(image)
 		}
 
+		livenessHealthChecks := worker["liveness_health_check"].([]interface{})
+		if len(livenessHealthChecks) > 0 {
+			s.LivenessHealthCheck = expandAppLivenessHealthCheck(livenessHealthChecks)
+		}
+
 		alerts := worker["alert"].([]interface{})
 		if len(alerts) > 0 {
 			s.Alerts = expandAppAlerts(alerts)
@@ -2382,6 +2431,7 @@ func flattenAppSpecWorkers(workers []*godo.AppWorkerSpec) []map[string]interface
 		r["instance_count"] = int(w.InstanceCount)
 		r["source_dir"] = w.SourceDir
 		r["environment_slug"] = w.EnvironmentSlug
+		r["liveness_health_check"] = flattenAppLivenessHealthCheck(w.LivenessHealthCheck)
 		r["alert"] = flattenAppAlerts(w.Alerts)
 		r["log_destination"] = flattenAppLogDestinations(w.LogDestinations)
 		r["autoscaling"] = flattenAppAutoscaling(w.Autoscaling)

--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -710,6 +710,14 @@ func appSpecServicesSchema() *schema.Resource {
 				Schema: appSpecHealthCheckSchema(),
 			},
 		},
+		"liveness_health_check": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: appSpecHealthCheckSchema(),
+			},
+		},
 		"image": {
 			Type:     schema.TypeList,
 			Optional: true,
@@ -2169,6 +2177,11 @@ func expandAppSpecServices(config []interface{}) []*godo.AppServiceSpec {
 			s.HealthCheck = expandAppHealthCheck(checks)
 		}
 
+		livenessHealthChecks := service["liveness_health_check"].([]interface{})
+		if len(livenessHealthChecks) > 0 {
+			s.LivenessHealthCheck = expandAppLivenessHealthCheck(livenessHealthChecks)
+		}
+
 		internalPorts := service["internal_ports"].(*schema.Set).List()
 		if len(internalPorts) > 0 {
 			s.InternalPorts = expandAppInternalPorts(internalPorts)
@@ -2225,6 +2238,7 @@ func flattenAppSpecServices(services []*godo.AppServiceSpec) []map[string]interf
 		r["dockerfile_path"] = s.DockerfilePath
 		r["env"] = flattenAppEnvs(s.Envs)
 		r["health_check"] = flattenAppHealthCheck(s.HealthCheck)
+		r["liveness_health_check"] = flattenAppLivenessHealthCheck(s.LivenessHealthCheck)
 		r["instance_size_slug"] = s.InstanceSizeSlug
 		r["instance_count"] = int(s.InstanceCount)
 		r["source_dir"] = s.SourceDir

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -147,6 +147,12 @@ func TestAccDigitalOceanApp_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.health_check.0.port", "1234"),
 					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.liveness_health_check.0.http_path", "/live"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.liveness_health_check.0.failure_threshold", "6"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.service.0.liveness_health_check.0.port", "1234"),
+					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.alert.0.value", "75"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.service.0.alert.0.operator", "GREATER_THAN"),
@@ -670,6 +676,12 @@ func TestAccDigitalOceanApp_Worker(t *testing.T) {
 						"digitalocean_app.foobar", "spec.0.worker.0.log_destination.0.name", "WorkerLogs"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.worker.0.log_destination.0.logtail.0.token", "test-api-token"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.worker.0.liveness_health_check.0.http_path", "/live"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.worker.0.liveness_health_check.0.failure_threshold", "6"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.worker.0.liveness_health_check.0.port", "8080"),
 				),
 			},
 			{
@@ -1364,6 +1376,12 @@ resource "digitalocean_app" "foobar" {
         port            = 1234
       }
 
+      liveness_health_check {
+        http_path         = "/live"
+        failure_threshold = 6
+        port              = 1234
+      }
+
       alert {
         value    = 75
         operator = "GREATER_THAN"
@@ -1868,6 +1886,12 @@ resource "digitalocean_app" "foobar" {
       git {
         repo_clone_url = "https://github.com/digitalocean/sample-sleeper.git"
         branch         = "main"
+      }
+
+      liveness_health_check {
+        http_path         = "/live"
+        failure_threshold = 6
+        port              = 8080
       }
 
       log_destination {

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -381,6 +381,14 @@ A `service` can contain:
   - `success_threshold` - The number of successful health checks before considered healthy.
   - `failure_threshold` - The number of failed health checks before considered unhealthy.
   - `port` - The health check will be performed on this port instead of component's HTTP port.
+- `liveness_health_check` - A liveness health check to determine if the service should be restarted. Failing to respond will result in the component being restarted.
+  - `http_path` - The route path used for the HTTP health check ping. If not set, the HTTP health check will be disabled and a TCP health check used instead.
+  - `initial_delay_seconds` - The number of seconds to wait before beginning health checks.
+  - `period_seconds` - The number of seconds to wait between health checks.
+  - `timeout_seconds` - The number of seconds after which the check times out.
+  - `success_threshold` - The number of successful health checks before considered healthy.
+  - `failure_threshold` - The number of failed health checks before considered unhealthy.
+  - `port` - The port on which the health check will be performed.
 - `cors` - (Deprecated - use `ingress`) The [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policies of the app.
 - `alert` - Describes an alert policy for the component.
   - `rule` - The type of the alert to configure. Component app alert policies can be: `CPU_UTILIZATION`, `MEM_UTILIZATION`, or `RESTART_COUNT`.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -463,6 +463,14 @@ A `worker` can contain:
 - `environment_slug` - An environment slug describing the type of this app.
 - `instance_size_slug` - The instance size to use for this component. This determines the plan (basic or professional) and the available CPU and memory. The list of available instance sizes can be [found with the API](https://docs.digitalocean.com/reference/api/digitalocean/#tag/Apps/operation/apps_list_instanceSizes) or using the [doctl CLI](https://docs.digitalocean.com/reference/doctl/) (`doctl apps tier instance-size list`). Default: `basic-xxs`
 - `instance_count` - The amount of instances that this component should be scaled to.
+- `liveness_health_check` - A liveness health check to determine if the worker should be restarted. Workers do not accept inbound traffic, so only HTTP liveness probes are supported (TCP is not).
+  - `http_path` - The route path used for the HTTP health check ping.
+  - `initial_delay_seconds` - The number of seconds to wait before beginning health checks.
+  - `period_seconds` - The number of seconds to wait between health checks.
+  - `timeout_seconds` - The number of seconds after which the check times out.
+  - `success_threshold` - The number of successful health checks before considered healthy.
+  - `failure_threshold` - The number of failed health checks before considered unhealthy.
+  - `port` - The port on which the health check will be performed.
 - `git` - A Git repo to use as the component's source. The repository must be able to be cloned without authentication. Only one of `git`, `github` or `gitlab` may be set
   - `repo_clone_url` - The clone URL of the repo.
   - `branch` - The name of the branch to use.


### PR DESCRIPTION
## Description

The App Platform [spec](https://docs.digitalocean.com/products/app-platform/reference/app-spec/) exposes a `liveness_health_check` block on both `service` and `worker` components (mapping to `godo.HealthCheckSpec`), but the provider schema previously didn't expose it on either:

- `service` only had the legacy `health_check` block (which maps to `godo.AppServiceSpecHealthCheck` — semantically a readiness check).
- `worker` had no health check at all.

This PR closes the parity gap by adding a `liveness_health_check` block to both `service` and `worker` schemas, wired against `AppServiceSpec.LivenessHealthCheck` and `AppWorkerSpec.LivenessHealthCheck` respectively. The schema reuses the existing `appSpecHealthCheckSchema()` since `HealthCheckSpec` and `AppServiceSpecHealthCheck` share the same set of fields (the spec only differs on per-field defaults).

Existing `service.health_check` behavior is unchanged.

Docs in `docs/resources/app.md` and acceptance test coverage (for both component types) are included.

Closes #1446

### Affected Resource(s)

- `digitalocean_app`

### Example usage

```hcl
resource "digitalocean_app" "example" {
  spec {
    name   = "example"
    region = "ams"

    service {
      name               = "api"
      http_port          = 8080
      instance_size_slug = "apps-d-1vcpu-0.5gb"
      instance_count     = 1

      image {
        registry_type = "DOCR"
        repository    = "my-api"
        tag           = "latest"
      }

      health_check {
        http_path = "/ready"
      }

      liveness_health_check {
        http_path             = "/live"
        initial_delay_seconds = 30
        failure_threshold     = 6
      }
    }

    worker {
      name               = "results-worker"
      instance_size_slug = "apps-d-1vcpu-0.5gb"
      instance_count     = 1

      image {
        registry_type = "DOCR"
        repository    = "my-worker"
        tag           = "latest"
      }

      liveness_health_check {
        http_path             = "/health/live"
        port                  = 8080
        initial_delay_seconds = 30
        period_seconds        = 10
        timeout_seconds       = 5
        success_threshold     = 1
        failure_threshold     = 6
      }
    }
  }
}
```

### Release Note

```release-note
`digitalocean_app`: add `liveness_health_check` block to `service` and `worker` components.
```