### PR TITLE
added support for autoscaling

### DIFF
--- a/digitalocean/database/datasource_database_cluster.go
+++ b/digitalocean/database/datasource_database_cluster.go
@@ -162,6 +162,27 @@ func DataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"storage_autoscale": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"threshold_percent": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"increment_gib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"metrics_endpoints": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -221,6 +242,18 @@ func dataSourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Re
 			d.Set("node_count", db.NumNodes)
 			d.Set("tags", tag.FlattenTags(db.Tags))
 			d.Set("storage_size_mib", strconv.FormatUint(db.StorageSizeMib, 10))
+
+			autoscale := db.StorageAutoscale
+			if autoscale == nil {
+				var autoscaleErr error
+				autoscale, _, autoscaleErr = client.Databases.GetStorageAutoscale(context.Background(), db.ID)
+				if autoscaleErr != nil {
+					return diag.Errorf("Error retrieving storage autoscale for database cluster: %s", autoscaleErr)
+				}
+			}
+			if err := d.Set("storage_autoscale", flattenStorageAutoscale(autoscale)); err != nil {
+				return diag.Errorf("[DEBUG] Error setting storage_autoscale - error: %#v", err)
+			}
 
 			if _, ok := d.GetOk("maintenance_window"); ok {
 				if err := d.Set("maintenance_window", flattenMaintWindowOpts(*db.MaintenanceWindow)); err != nil {

--- a/digitalocean/database/datasource_database_cluster_test.go
+++ b/digitalocean/database/datasource_database_cluster_test.go
@@ -59,6 +59,51 @@ func TestAccDataSourceDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceDigitalOceanDatabaseCluster_StorageAutoscale(t *testing.T) {
+	var database godo.Database
+	databaseName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanDatabaseClusterConfigStorageAutoscaleEnabled, databaseName, 80, 10),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanDatabaseClusterConfigStorageAutoscaleEnabledWithDatasource, databaseName, 80, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanDatabaseClusterExists("data.digitalocean_database_cluster.foobar", &database),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "name", databaseName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "storage_autoscale.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "storage_autoscale.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "storage_autoscale.0.threshold_percent", "80"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "storage_autoscale.0.increment_gib", "10"),
+					testAccCheckDigitalOceanDatabaseClusterStorageAutoscale("data.digitalocean_database_cluster.foobar", true, 80, 10),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanDatabaseClusterConfigStorageAutoscaleDisabledWithDatasource, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanDatabaseClusterExists("data.digitalocean_database_cluster.foobar", &database),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "name", databaseName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "storage_autoscale.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_database_cluster.foobar", "storage_autoscale.0.enabled", "false"),
+					testAccCheckDigitalOceanDatabaseClusterStorageAutoscale("data.digitalocean_database_cluster.foobar", false, 0, 0),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDataSourceDigitalOceanDatabaseClusterExists(n string, databaseCluster *godo.Database) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -138,6 +183,66 @@ resource "digitalocean_database_cluster" "foobar" {
   node_count       = 1
   tags             = ["production"]
   storage_size_mib = 10240
+}
+
+data "digitalocean_database_cluster" "foobar" {
+  name = digitalocean_database_cluster.foobar.name
+}
+`
+
+const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigStorageAutoscaleEnabled = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
+
+  storage_autoscale {
+    enabled           = true
+    threshold_percent = %d
+    increment_gib     = %d
+  }
+}
+`
+
+const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigStorageAutoscaleEnabledWithDatasource = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
+
+  storage_autoscale {
+    enabled           = true
+    threshold_percent = %d
+    increment_gib     = %d
+  }
+}
+
+data "digitalocean_database_cluster" "foobar" {
+  name = digitalocean_database_cluster.foobar.name
+}
+`
+
+const testAccCheckDataSourceDigitalOceanDatabaseClusterConfigStorageAutoscaleDisabledWithDatasource = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
+
+  storage_autoscale {
+    enabled = false
+  }
 }
 
 data "digitalocean_database_cluster" "foobar" {

--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -264,6 +264,31 @@ func ResourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"storage_autoscale": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"threshold_percent": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(15, 95),
+						},
+						"increment_gib": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(10),
+							Description:  "Storage increase step size in GiB (minimum 10 GiB, rounded to nearest 10 GiB). If not specified, system auto-calculates (25% of current size, min 50 GiB, max 1024 GiB, rounded to 10 GiB steps). Cooldown: 1 hour between autoscale operations.",
+						},
+					},
+				},
+			},
+
 			"metrics_endpoints": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -351,6 +376,10 @@ func resourceDigitalOceanDatabaseClusterCreate(ctx context.Context, d *schema.Re
 		if err == nil {
 			opts.StorageSizeMib = v
 		}
+	}
+
+	if v, ok := d.GetOk("storage_autoscale"); ok {
+		opts.StorageAutoscale = expandStorageAutoscale(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] database cluster create configuration: %#v", opts)
@@ -518,6 +547,16 @@ func resourceDigitalOceanDatabaseClusterUpdate(ctx context.Context, d *schema.Re
 		}
 	}
 
+	if d.HasChange("storage_autoscale") {
+		if v, ok := d.GetOk("storage_autoscale"); ok {
+			autoscale := expandStorageAutoscale(v.([]interface{}))
+			_, err := client.Databases.UpdateStorageAutoscale(context.Background(), d.Id(), autoscale)
+			if err != nil {
+				return diag.Errorf("Error updating storage autoscale for database cluster: %s", err)
+			}
+		}
+	}
+
 	return resourceDigitalOceanDatabaseClusterRead(ctx, d, meta)
 }
 
@@ -567,6 +606,20 @@ func resourceDigitalOceanDatabaseClusterRead(ctx context.Context, d *schema.Reso
 		}
 
 		d.Set("sql_mode", mode)
+	}
+
+	if _, ok := d.GetOk("storage_autoscale"); ok {
+		autoscale := database.StorageAutoscale
+		if autoscale == nil {
+			autoscale, _, err = client.Databases.GetStorageAutoscale(context.Background(), d.Id())
+			if err != nil {
+				return diag.Errorf("Error retrieving storage autoscale for database cluster: %s", err)
+			}
+		}
+
+		if err := d.Set("storage_autoscale", flattenStorageAutoscale(autoscale)); err != nil {
+			return diag.Errorf("[DEBUG] Error setting storage_autoscale - error: %#v", err)
+		}
 	}
 
 	// Computed values
@@ -755,6 +808,46 @@ func buildDBConnectionURI(conn *godo.DatabaseConnection, d *schema.ResourceData)
 
 func buildDBPrivateURI(conn *godo.DatabaseConnection, d *schema.ResourceData) (string, error) {
 	return buildDBConnectionURI(conn, d)
+}
+
+func expandStorageAutoscale(config []interface{}) *godo.DatabaseStorageAutoscale {
+	configMap := config[0].(map[string]interface{})
+
+	autoscale := &godo.DatabaseStorageAutoscale{
+		Enabled: configMap["enabled"].(bool),
+	}
+
+	if v, ok := configMap["threshold_percent"]; ok && v != nil {
+		threshold := v.(int)
+		autoscale.ThresholdPercent = &threshold
+	}
+
+	if v, ok := configMap["increment_gib"]; ok && v != nil {
+		increment := uint64(v.(int))
+		autoscale.IncrementGib = &increment
+	}
+
+	return autoscale
+}
+
+func flattenStorageAutoscale(autoscale *godo.DatabaseStorageAutoscale) []map[string]interface{} {
+	if autoscale == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0)
+	item := make(map[string]interface{})
+
+	item["enabled"] = autoscale.Enabled
+	if autoscale.ThresholdPercent != nil {
+		item["threshold_percent"] = *autoscale.ThresholdPercent
+	}
+	if autoscale.IncrementGib != nil {
+		item["increment_gib"] = int(*autoscale.IncrementGib)
+	}
+	result = append(result, item)
+
+	return result
 }
 
 func expandBackupRestore(config []interface{}) *godo.DatabaseBackupRestore {

--- a/digitalocean/database/resource_database_cluster_test.go
+++ b/digitalocean/database/resource_database_cluster_test.go
@@ -236,6 +236,57 @@ func TestAccDigitalOceanDatabaseCluster_WithMaintWindow(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseCluster_WithStorageAutoscale(t *testing.T) {
+	var database godo.Database
+	databaseName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithStorageAutoscale, databaseName, 80, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.#", "1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.0.threshold_percent", "80"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.0.increment_gib", "10"),
+					testAccCheckDigitalOceanDatabaseClusterStorageAutoscale("digitalocean_database_cluster.foobar", true, 80, 10),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithStorageAutoscale, databaseName, 90, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.0.threshold_percent", "90"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.0.increment_gib", "20"),
+					testAccCheckDigitalOceanDatabaseClusterStorageAutoscale("digitalocean_database_cluster.foobar", true, 90, 20),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithStorageAutoscaleDisabled, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "storage_autoscale.0.enabled", "false"),
+					testAccCheckDigitalOceanDatabaseClusterStorageAutoscale("digitalocean_database_cluster.foobar", false, 0, 0),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanDatabaseCluster_WithSQLMode(t *testing.T) {
 	var database godo.Database
 	databaseName := acceptance.RandomTestName()
@@ -706,6 +757,41 @@ func testAccCheckDigitalOceanDatabaseClusterMetricsEndpoints(resourceName string
 	}
 }
 
+func testAccCheckDigitalOceanDatabaseClusterStorageAutoscale(name string, enabled bool, thresholdPercent, incrementGib int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+		autoscale, _, err := client.Databases.GetStorageAutoscale(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error retrieving storage autoscale: %s", err)
+		}
+
+		if autoscale.Enabled != enabled {
+			return fmt.Errorf("expected storage autoscale enabled %v, got %v", enabled, autoscale.Enabled)
+		}
+
+		if !enabled {
+			return nil
+		}
+
+		if autoscale.ThresholdPercent == nil || *autoscale.ThresholdPercent != thresholdPercent {
+			return fmt.Errorf("expected threshold_percent %d, got %#v", thresholdPercent, autoscale.ThresholdPercent)
+		}
+
+		expectedIncrement := uint64(incrementGib)
+		if autoscale.IncrementGib == nil || *autoscale.IncrementGib != expectedIncrement {
+			return fmt.Errorf("expected increment_gib %d, got %#v", incrementGib, autoscale.IncrementGib)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckDigitalOceanDatabaseClusterExists(n string, database *godo.Database) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -893,6 +979,38 @@ resource "digitalocean_database_cluster" "foobar" {
   maintenance_window {
     day  = "friday"
     hour = "13:00"
+  }
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigWithStorageAutoscale = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
+
+  storage_autoscale {
+    enabled           = true
+    threshold_percent = %d
+    increment_gib     = %d
+  }
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigWithStorageAutoscaleDisabled = `
+resource "digitalocean_database_cluster" "foobar" {
+  name       = "%s"
+  engine     = "pg"
+  version    = "15"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+  tags       = ["production"]
+
+  storage_autoscale {
+    enabled = false
   }
 }`
 

--- a/docs/data-sources/database_cluster.md
+++ b/docs/data-sources/database_cluster.md
@@ -37,6 +37,8 @@ The following attributes are exported:
 * `region` - DigitalOcean region where the cluster will reside.
 * `node_count` - Number of nodes that will be included in the cluster.
 * `maintenance_window` - Defines when the automatic maintenance should be performed for the database cluster.
+* `storage_size_mib` - The disk size, in MiB, allocated to the cluster.
+* `storage_autoscale` - Storage autoscaling configuration for the database cluster.
 * `private_network_uuid` - The ID of the VPC where the database cluster is located.
 * `host` - Database cluster's hostname.
 * `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
@@ -53,6 +55,12 @@ The following attributes are exported:
 
 * `day` - The day of the week on which to apply maintenance updates.
 * `hour` - The hour in UTC at which maintenance updates will be applied in 24 hour format.
+
+`storage_autoscale` supports the following:
+
+* `enabled` - Whether storage autoscaling is enabled for the cluster.
+* `threshold_percent` - The storage utilization percentage at which autoscaling is triggered.
+* `increment_gib` - The amount of storage, in GiB, to add when autoscaling is triggered.
 
 OpenSearch clusters will have the following additional attributes with connection
 details for their dashboard:

--- a/docs/resources/database_cluster.md
+++ b/docs/resources/database_cluster.md
@@ -130,6 +130,13 @@ The following arguments are supported:
 * `sql_mode` - (Optional) A comma separated string specifying the  SQL modes for a MySQL cluster.
 * `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
 * `storage_size_mib` - (Optional) Defines the disk size, in MiB, allocated to the cluster. This can be adjusted on MySQL and PostreSQL clusters based on predefined ranges for each slug/droplet size.
+* `storage_autoscale` - (Optional) Storage autoscaling configuration for the database cluster.
+
+`storage_autoscale` supports the following:
+
+* `enabled` - (Required) Whether storage autoscaling is enabled for the cluster.
+* `threshold_percent` - (Optional) The storage utilization percentage at which autoscaling is triggered.
+* `increment_gib` - (Optional) The amount of storage, in GiB, to add when autoscaling is triggered.
 
 `maintenance_window` supports the following:
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.1
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.192.0
+	github.com/digitalocean/godo v1.193.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.192.0 h1:It3AcVa123/Eh/Ol+F9CXXBBlTsWyUIYe8yZhhFZ9Q4=
-github.com/digitalocean/godo v1.192.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.193.0 h1:CSbbUl5LufT75KPNvex3vDnBYjY2RfJWs7T3Ac7dHpA=
+github.com/digitalocean/godo v1.193.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.193.0] - 2026-05-26
+
+- #1015 - @nbhoot157 - Add VectorDBs service for vector database API support
+- #1018 - @gangasingh01 - mod: added support for get and update StorageAutoscale endpoints
+- #1016 - @ritheek-pitti-do - Added Cancel Eval and DeletePreset Endpoints
+- #1014 - @venkatranabothu - Add Delete Model Evaluation Run API support
+- #1013 - @d-honeybadger - add worker_subnet_uuid field to doks methods
+- #1012 - @sshirolkar - add pricing for non-token based models in godo 
+
 ## [1.192.0] - 2026-05-19
 
 - #1010 - @SSharma-10 - Update readme

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -49,6 +49,7 @@ const (
 	databaseKafkaSchemaRegistrySubjectPath       = databaseBasePath + "/%s/schema-registry/%s"
 	databaseKafkaSchemaRegistryConfigPath        = databaseBasePath + "/%s/schema-registry/config"
 	databaseKafkaSchemaRegistrySubjectConfigPath = databaseBasePath + "/%s/schema-registry/config/%s"
+	databaseStorageAutoscalePath                 = databaseBasePath + "/%s/autoscale"
 )
 
 // SQL Mode constants allow for MySQL-specific SQL flavor configuration.
@@ -129,6 +130,8 @@ type DatabasesService interface {
 	Resize(context.Context, string, *DatabaseResizeRequest) (*Response, error)
 	Migrate(context.Context, string, *DatabaseMigrateRequest) (*Response, error)
 	UpdateMaintenance(context.Context, string, *DatabaseUpdateMaintenanceRequest) (*Response, error)
+	GetStorageAutoscale(context.Context, string) (*DatabaseStorageAutoscale, *Response, error)
+	UpdateStorageAutoscale(context.Context, string, *DatabaseStorageAutoscale) (*Response, error)
 	InstallUpdate(context.Context, string) (*Response, error)
 	ListBackups(context.Context, string, *ListOptions) ([]DatabaseBackup, *Response, error)
 	GetUser(context.Context, string, string) (*DatabaseUser, *Response, error)
@@ -236,6 +239,7 @@ type Database struct {
 	Tags                     []string                   `json:"tags,omitempty"`
 	ProjectID                string                     `json:"project_id,omitempty"`
 	StorageSizeMib           uint64                     `json:"storage_size_mib,omitempty"`
+	StorageAutoscale         *DatabaseStorageAutoscale  `json:"storage_autoscale,omitempty"`
 	MetricsEndpoints         []*ServiceAddress          `json:"metrics_endpoints,omitempty"`
 	DOSettings               *DOSettings                `json:"do_settings,omitempty"`
 }
@@ -326,6 +330,13 @@ type DatabaseBackup struct {
 	SizeGigabytes float64   `json:"size_gigabytes,omitempty"`
 }
 
+// DatabaseStorageAutoscale represents the storage autoscaling configuration for a database cluster
+type DatabaseStorageAutoscale struct {
+	Enabled          bool    `json:"enabled"`
+	ThresholdPercent *int    `json:"threshold_percent,omitempty"`
+	IncrementGib     *uint64 `json:"increment_gib,omitempty"`
+}
+
 // DatabaseBackupRestore contains information needed to restore a backup.
 type DatabaseBackupRestore struct {
 	DatabaseName    string `json:"database_name,omitempty"`
@@ -352,6 +363,7 @@ type DatabaseCreateRequest struct {
 	BackupRestore      *DatabaseBackupRestore        `json:"backup_restore,omitempty"`
 	ProjectID          string                        `json:"project_id"`
 	StorageSizeMib     uint64                        `json:"storage_size_mib,omitempty"`
+	StorageAutoscale   *DatabaseStorageAutoscale     `json:"storage_autoscale,omitempty"`
 	Rules              []*DatabaseCreateFirewallRule `json:"rules"`
 	DOSettings         *DOSettings                   `json:"do_settings,omitempty"`
 }
@@ -950,6 +962,10 @@ type databaseReplicasRoot struct {
 	Replicas []DatabaseReplica `json:"replicas"`
 }
 
+type databaseStorageAutoscaleRoot struct {
+	StorageAutoscale *DatabaseStorageAutoscale `json:"storage"`
+}
+
 type evictionPolicyRoot struct {
 	EvictionPolicy string `json:"eviction_policy"`
 }
@@ -1205,6 +1221,38 @@ func (svc *DatabasesServiceOp) Migrate(ctx context.Context, databaseID string, m
 func (svc *DatabasesServiceOp) UpdateMaintenance(ctx context.Context, databaseID string, maintenance *DatabaseUpdateMaintenanceRequest) (*Response, error) {
 	path := fmt.Sprintf(databaseMaintenancePath, databaseID)
 	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, maintenance)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetStorageAutoscale retrieves the storage autoscaling configuration for a database cluster.
+func (svc *DatabasesServiceOp) GetStorageAutoscale(ctx context.Context, databaseID string) (*DatabaseStorageAutoscale, *Response, error) {
+	path := fmt.Sprintf(databaseStorageAutoscalePath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseStorageAutoscaleRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.StorageAutoscale, resp, nil
+}
+
+// UpdateStorageAutoscale updates the storage autoscaling configuration on a cluster
+func (svc *DatabasesServiceOp) UpdateStorageAutoscale(ctx context.Context, databaseID string, autoscale *DatabaseStorageAutoscale) (*Response, error) {
+	path := fmt.Sprintf(databaseStorageAutoscalePath, databaseID)
+	root := &databaseStorageAutoscaleRoot{
+		StorageAutoscale: autoscale,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, root)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.192.0"
+	libraryVersion = "1.193.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -97,6 +97,7 @@ type Client struct {
 	StorageActions      StorageActionsService
 	Tags                TagsService
 	UptimeChecks        UptimeChecksService
+	VectorDBs           VectorDBsService
 	VPCs                VPCsService
 	PartnerAttachment   PartnerAttachmentService
 	GradientAI          GradientAIService
@@ -339,6 +340,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.StorageActions = &StorageActionsServiceOp{client: c}
 	c.Tags = &TagsServiceOp{client: c}
 	c.UptimeChecks = &UptimeChecksServiceOp{client: c}
+	c.VectorDBs = &VectorDBsServiceOp{client: c}
 	c.VPCs = &VPCsServiceOp{client: c}
 	c.PartnerAttachment = &PartnerAttachmentServiceOp{client: c}
 	c.GradientAI = &GradientAIServiceOp{client: c}

--- a/vendor/github.com/digitalocean/godo/gradientai.go
+++ b/vendor/github.com/digitalocean/godo/gradientai.go
@@ -9,31 +9,36 @@ import (
 )
 
 const (
-	gradientBasePath             = "/v2/gen-ai/agents"
-	agentModelBasePath           = "/v2/gen-ai/models"
-	datacenterRegionsPath        = "/v2/gen-ai/regions"
-	agentRouteBasePath           = gradientBasePath + "/%s/child_agents/%s"
-	KnowledgeBasePath            = "/v2/gen-ai/knowledge_bases"
-	functionRouteBasePath        = gradientBasePath + "/%s/functions"
-	KnowledgeBaseDataSourcesPath = KnowledgeBasePath + "/%s/data_sources"
-	GetKnowledgeBaseByIDPath     = KnowledgeBasePath + "/%s"
-	UpdateKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
-	DeleteKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
-	AgentKnowledgeBasePath       = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
-	DeleteDataSourcePath         = KnowledgeBasePath + "/%s/data_sources/%s"
-	IndexingJobsPath             = "/v2/gen-ai/indexing_jobs"
-	IndexingJobByIDPath          = IndexingJobsPath + "/%s"
-	IndexingJobCancelPath        = IndexingJobsPath + "/%s/cancel"
-	IndexingJobDataSourcesPath   = IndexingJobsPath + "/%s/data_sources"
-	AnthropicAPIKeysPath         = "/v2/gen-ai/anthropic/keys"
-	AnthropicAPIKeyByIDPath      = AnthropicAPIKeysPath + "/%s"
-	OpenAIAPIKeysPath            = "/v2/gen-ai/openai/keys"
-	UpdateFunctionRoutePath      = functionRouteBasePath + "/%s"
-	DeleteFunctionRoutePath      = functionRouteBasePath + "/%s"
-	customModelsBasePath         = "/v2/gen-ai/custom_models"
-	customModelImportPath        = customModelsBasePath + "/import"
-	customModelByIDPath          = customModelsBasePath + "/%s"
-	customModelMetadataPath      = customModelsBasePath + "/%s/metadata"
+	gradientBasePath               = "/v2/gen-ai/agents"
+	agentModelBasePath             = "/v2/gen-ai/models"
+	datacenterRegionsPath          = "/v2/gen-ai/regions"
+	agentRouteBasePath             = gradientBasePath + "/%s/child_agents/%s"
+	KnowledgeBasePath              = "/v2/gen-ai/knowledge_bases"
+	functionRouteBasePath          = gradientBasePath + "/%s/functions"
+	KnowledgeBaseDataSourcesPath   = KnowledgeBasePath + "/%s/data_sources"
+	GetKnowledgeBaseByIDPath       = KnowledgeBasePath + "/%s"
+	UpdateKnowledgeBaseByIDPath    = KnowledgeBasePath + "/%s"
+	DeleteKnowledgeBaseByIDPath    = KnowledgeBasePath + "/%s"
+	AgentKnowledgeBasePath         = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
+	DeleteDataSourcePath           = KnowledgeBasePath + "/%s/data_sources/%s"
+	IndexingJobsPath               = "/v2/gen-ai/indexing_jobs"
+	IndexingJobByIDPath            = IndexingJobsPath + "/%s"
+	IndexingJobCancelPath          = IndexingJobsPath + "/%s/cancel"
+	IndexingJobDataSourcesPath     = IndexingJobsPath + "/%s/data_sources"
+	AnthropicAPIKeysPath           = "/v2/gen-ai/anthropic/keys"
+	AnthropicAPIKeyByIDPath        = AnthropicAPIKeysPath + "/%s"
+	OpenAIAPIKeysPath              = "/v2/gen-ai/openai/keys"
+	UpdateFunctionRoutePath        = functionRouteBasePath + "/%s"
+	DeleteFunctionRoutePath        = functionRouteBasePath + "/%s"
+	customModelsBasePath           = "/v2/gen-ai/custom_models"
+	customModelImportPath          = customModelsBasePath + "/import"
+	customModelByIDPath            = customModelsBasePath + "/%s"
+	customModelMetadataPath        = customModelsBasePath + "/%s/metadata"
+	modelEvaluationRunsBasePath    = "/v2/gen-ai/model_evaluation_runs"
+	modelEvaluationRunByIDPath     = modelEvaluationRunsBasePath + "/%s"
+	modelEvaluationRunCancelPath   = modelEvaluationRunsBasePath + "/%s/cancel"
+	modelEvaluationPresetsBasePath = "/v2/gen-ai/model_evaluation_presets"
+	modelEvaluationPresetByIDPath  = modelEvaluationPresetsBasePath + "/%s"
 )
 
 // CustomModelStatus represents the status of a custom model.
@@ -75,6 +80,40 @@ const (
 	DeleteCustomModelStatusUnspecified DeleteCustomModelStatus = "DELETE_CUSTOM_MODEL_STATUS_UNSPECIFIED"
 	DeleteCustomModelStatusSuccess     DeleteCustomModelStatus = "DELETE_CUSTOM_MODEL_STATUS_SUCCESS"
 	DeleteCustomModelStatusFail        DeleteCustomModelStatus = "DELETE_CUSTOM_MODEL_STATUS_FAIL"
+)
+
+// DeleteModelEvaluationRunStatus represents the status of a delete model evaluation run operation.
+type DeleteModelEvaluationRunStatus string
+
+const (
+	DeleteModelEvaluationRunStatusUnspecified DeleteModelEvaluationRunStatus = "DELETE_MODEL_EVALUATION_RUN_STATUS_UNSPECIFIED"
+	DeleteModelEvaluationRunStatusSuccess     DeleteModelEvaluationRunStatus = "DELETE_MODEL_EVALUATION_RUN_STATUS_SUCCESS"
+	DeleteModelEvaluationRunStatusFail        DeleteModelEvaluationRunStatus = "DELETE_MODEL_EVALUATION_RUN_STATUS_FAIL"
+)
+
+// ModelEvaluationRunStatus represents the lifecycle status of a model evaluation run.
+type ModelEvaluationRunStatus string
+
+const (
+	ModelEvaluationRunStatusUnspecified   ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_STATUS_UNSPECIFIED"
+	ModelEvaluationRunQueued              ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_QUEUED"
+	ModelEvaluationRunRunningDataset      ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_RUNNING_DATASET"
+	ModelEvaluationRunEvaluatingResults   ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_EVALUATING_RESULTS"
+	ModelEvaluationRunCancelling          ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_CANCELLING"
+	ModelEvaluationRunCancelled           ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_CANCELLED"
+	ModelEvaluationRunSuccessful          ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_SUCCESSFUL"
+	ModelEvaluationRunPartiallySuccessful ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_PARTIALLY_SUCCESSFUL"
+	ModelEvaluationRunFailed              ModelEvaluationRunStatus = "MODEL_EVALUATION_RUN_FAILED"
+)
+
+// CandidateModelSource indicates whether evaluation inference runs against the
+// serverless platform, a dedicated deployment, or a model router.
+type CandidateModelSource string
+
+const (
+	CandidateModelSourceServerless CandidateModelSource = "CANDIDATE_MODEL_SOURCE_SERVERLESS"
+	CandidateModelSourceDedicated  CandidateModelSource = "CANDIDATE_MODEL_SOURCE_DEDICATED"
+	CandidateModelSourceRouter     CandidateModelSource = "CANDIDATE_MODEL_SOURCE_ROUTER"
 )
 
 // GradientAIService is an interface for interfacing with the Gradient AI Agent endpoints
@@ -135,6 +174,9 @@ type GradientAIService interface {
 	ImportCustomModel(ctx context.Context, importRequest *CustomModelImportRequest) (*CustomModelImportResponse, *Response, error)
 	DeleteCustomModel(ctx context.Context, uuid string) (*CustomModelDeleteResponse, *Response, error)
 	UpdateCustomModelMetadata(ctx context.Context, uuid string, updateRequest *CustomModelMetadataUpdateRequest) (*CustomModel, *Response, error)
+	DeleteModelEvaluationRun(ctx context.Context, evalRunUUID string) (*ModelEvaluationRunDeleteResponse, *Response, error)
+	DeleteModelEvaluationPreset(ctx context.Context, evalPresetUUID string) (*ModelEvaluationPresetDeleteResponse, *Response, error)
+	CancelModelEvaluationRun(ctx context.Context, evalRunUUID string) (*ModelEvaluationRunCancelResponse, *Response, error)
 }
 
 var _ GradientAIService = &GradientAIServiceOp{}
@@ -635,10 +677,22 @@ type ModelVersion struct {
 	Patch int `json:"patch,omitempty"`
 }
 
-// ModelPricing represents the pricing per million tokens for a model
+// ModelPricing represents token- and unit-based pricing for a model.
 type ModelPricing struct {
-	InputPricePerMillion  float64 `json:"input_price_per_million,omitempty"`
-	OutputPricePerMillion float64 `json:"output_price_per_million,omitempty"`
+	InputPricePerMillion               float64 `json:"input_price_per_million,omitempty"`
+	OutputPricePerMillion              float64 `json:"output_price_per_million,omitempty"`
+	PricePerImage                      float64 `json:"price_per_image,omitempty"`
+	PricePerMegapixel                  float64 `json:"price_per_megapixel,omitempty"`
+	PricePerSecond                     float64 `json:"price_per_second,omitempty"`
+	PricePerVideo                      float64 `json:"price_per_video,omitempty"`
+	PricePerAudio                      float64 `json:"price_per_audio,omitempty"`
+	PricePerThousandCharacters         float64 `json:"price_per_thousand_characters,omitempty"`
+	TextInputPricePerMillion           float64 `json:"text_input_price_per_million,omitempty"`
+	TextOutputPricePerMillion          float64 `json:"text_output_price_per_million,omitempty"`
+	TextCacheReadInputPricePerMillion  float64 `json:"text_cache_read_input_price_per_million,omitempty"`
+	ImageInputPricePerMillion          float64 `json:"image_input_price_per_million,omitempty"`
+	ImageOutputPricePerMillion         float64 `json:"image_output_price_per_million,omitempty"`
+	ImageCacheReadInputPricePerMillion float64 `json:"image_cache_read_input_price_per_million,omitempty"`
 }
 
 // AgentCreateRequest represents the request to create a new Gradient AI Agent
@@ -2161,6 +2215,117 @@ func (s *GradientAIServiceOp) DeleteCustomModel(ctx context.Context, uuid string
 	}
 
 	root := new(CustomModelDeleteResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// ModelEvaluationRunDeleteResponse is the response returned by DeleteModelEvaluationRun.
+type ModelEvaluationRunDeleteResponse struct {
+	Status DeleteModelEvaluationRunStatus `json:"status,omitempty"`
+	Error  string                         `json:"error,omitempty"`
+}
+
+// ModelEvaluationRunSummary is a lightweight view of an evaluation run used in
+// run history listings and the cancel response.
+type ModelEvaluationRunSummary struct {
+	CandidateModelName   string                   `json:"candidate_model_name,omitempty"`
+	CandidateModelSource CandidateModelSource     `json:"candidate_model_source,omitempty"`
+	CandidateModelUuid   string                   `json:"candidate_model_uuid,omitempty"`
+	CreatedAt            *Timestamp               `json:"created_at,omitempty"`
+	DatasetName          string                   `json:"dataset_name,omitempty"`
+	DatasetUuid          string                   `json:"dataset_uuid,omitempty"`
+	EvalRunUuid          string                   `json:"eval_run_uuid,omitempty"`
+	JudgeModelName       string                   `json:"judge_model_name,omitempty"`
+	JudgeModelUuid       string                   `json:"judge_model_uuid,omitempty"`
+	Name                 string                   `json:"name,omitempty"`
+	Status               ModelEvaluationRunStatus `json:"status,omitempty"`
+}
+
+// CancelModelEvaluationRunRequest represents the request payload for cancelling
+// a model evaluation run.
+type CancelModelEvaluationRunRequest struct {
+	EvalRunUUID string `json:"eval_run_uuid"`
+}
+
+// ModelEvaluationRunCancelResponse is the response returned by CancelModelEvaluationRun.
+type ModelEvaluationRunCancelResponse struct {
+	Run *ModelEvaluationRunSummary `json:"run,omitempty"`
+}
+
+// ModelEvaluationPresetDeleteResponse is the response returned by
+// DeleteModelEvaluationPreset. The underlying API returns an empty object on
+// success; this struct exists for forward compatibility and to keep the SDK
+// signature consistent with sibling delete operations.
+type ModelEvaluationPresetDeleteResponse struct{}
+
+// DeleteModelEvaluationRun deletes the model evaluation run with the given UUID.
+// The run must be in a terminal status (successful, partially_successful, failed,
+// or cancelled). For runs still in progress, either wait for the run to finish or
+// cancel it, then retry the delete.
+func (s *GradientAIServiceOp) DeleteModelEvaluationRun(ctx context.Context, evalRunUUID string) (*ModelEvaluationRunDeleteResponse, *Response, error) {
+	if evalRunUUID == "" {
+		return nil, nil, fmt.Errorf("eval run uuid is required")
+	}
+	path := fmt.Sprintf(modelEvaluationRunByIDPath, evalRunUUID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ModelEvaluationRunDeleteResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// DeleteModelEvaluationPreset deletes the saved model evaluation preset with
+// the given UUID.
+func (s *GradientAIServiceOp) DeleteModelEvaluationPreset(ctx context.Context, evalPresetUUID string) (*ModelEvaluationPresetDeleteResponse, *Response, error) {
+	if evalPresetUUID == "" {
+		return nil, nil, fmt.Errorf("eval preset uuid is required")
+	}
+	path := fmt.Sprintf(modelEvaluationPresetByIDPath, evalPresetUUID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ModelEvaluationPresetDeleteResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// CancelModelEvaluationRun cancels an in-progress model evaluation run. The run
+// must be in a non-terminal status (queued, running_dataset, or
+// evaluating_results); already-terminal runs return an error. The returned
+// summary's status is `cancelling` while the underlying workflow is being torn
+// down and transitions to `cancelled` once cluster-side teardown completes.
+func (s *GradientAIServiceOp) CancelModelEvaluationRun(ctx context.Context, evalRunUUID string) (*ModelEvaluationRunCancelResponse, *Response, error) {
+	if evalRunUUID == "" {
+		return nil, nil, fmt.Errorf("eval run uuid is required")
+	}
+	path := fmt.Sprintf(modelEvaluationRunCancelPath, evalRunUUID)
+
+	cancelRequest := &CancelModelEvaluationRunRequest{
+		EvalRunUUID: evalRunUUID,
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, cancelRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ModelEvaluationRunCancelResponse)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -68,13 +68,14 @@ type KubernetesServiceOp struct {
 
 // KubernetesClusterCreateRequest represents a request to create a Kubernetes cluster.
 type KubernetesClusterCreateRequest struct {
-	Name          string   `json:"name,omitempty"`
-	RegionSlug    string   `json:"region,omitempty"`
-	VersionSlug   string   `json:"version,omitempty"`
-	Tags          []string `json:"tags,omitempty"`
-	VPCUUID       string   `json:"vpc_uuid,omitempty"`
-	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
-	ServiceSubnet string   `json:"service_subnet,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	RegionSlug       string   `json:"region,omitempty"`
+	VersionSlug      string   `json:"version,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	VPCUUID          string   `json:"vpc_uuid,omitempty"`
+	WorkerSubnetUUID string   `json:"worker_subnet_uuid,omitempty"`
+	ClusterSubnet    string   `json:"cluster_subnet,omitempty"`
+	ServiceSubnet    string   `json:"service_subnet,omitempty"`
 
 	// HA enables a highly available control plane. When omitted, the API applies
 	// version-based defaults: false for versions < 1.36, true for versions >= 1.36.
@@ -225,16 +226,17 @@ type KubernetesGetClusterStatusMessagesRequest struct {
 
 // KubernetesCluster represents a Kubernetes cluster.
 type KubernetesCluster struct {
-	ID            string   `json:"id,omitempty"`
-	Name          string   `json:"name,omitempty"`
-	RegionSlug    string   `json:"region,omitempty"`
-	VersionSlug   string   `json:"version,omitempty"`
-	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
-	ServiceSubnet string   `json:"service_subnet,omitempty"`
-	IPv4          string   `json:"ipv4,omitempty"`
-	Endpoint      string   `json:"endpoint,omitempty"`
-	Tags          []string `json:"tags,omitempty"`
-	VPCUUID       string   `json:"vpc_uuid,omitempty"`
+	ID               string   `json:"id,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	RegionSlug       string   `json:"region,omitempty"`
+	VersionSlug      string   `json:"version,omitempty"`
+	ClusterSubnet    string   `json:"cluster_subnet,omitempty"`
+	ServiceSubnet    string   `json:"service_subnet,omitempty"`
+	IPv4             string   `json:"ipv4,omitempty"`
+	Endpoint         string   `json:"endpoint,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	VPCUUID          string   `json:"vpc_uuid,omitempty"`
+	WorkerSubnetUUID string   `json:"worker_subnet_uuid,omitempty"`
 
 	// Cluster runs a highly available control plane
 	HA bool `json:"ha,omitempty"`

--- a/vendor/github.com/digitalocean/godo/vector_databases.go
+++ b/vendor/github.com/digitalocean/godo/vector_databases.go
@@ -1,0 +1,341 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	vectorDatabaseBasePath        = "/v2/vector-databases"
+	vectorDatabaseSinglePath      = vectorDatabaseBasePath + "/%s"
+	vectorDatabaseBackupsPath     = vectorDatabaseBasePath + "/%s/backups"
+	vectorDatabaseRestorePath     = vectorDatabaseBasePath + "/%s/backups/%s/restore"
+	vectorDatabaseCredentialsPath = vectorDatabaseBasePath + "/%s/credentials"
+	vectorDatabaseResizePath      = vectorDatabaseBasePath + "/%s/resize"
+	vectorDatabaseTagsPath        = vectorDatabaseBasePath + "/%s/tags"
+)
+
+// VectorDBsService provides access to the DigitalOcean Vector DB API.
+//
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Vector-Databases
+type VectorDBsService interface {
+	List(context.Context, *ListOptions) ([]VectorDB, *Response, error)
+	Get(context.Context, string) (*VectorDB, *Response, error)
+	Create(context.Context, *VectorDBCreateRequest) (*VectorDB, *Response, error)
+	Update(context.Context, string, *VectorDBUpdateRequest) (*VectorDB, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+	Resize(context.Context, string, *VectorDBResizeRequest) (*VectorDB, *Response, error)
+	UpdateTags(context.Context, string, *VectorDBUpdateTagsRequest) (*VectorDB, *Response, error)
+	GetCredentials(context.Context, string) (*VectorDBAdminCredentials, *Response, error)
+	ListBackups(context.Context, string) ([]VectorDBBackup, *Response, error)
+	RestoreBackup(context.Context, string, string, *VectorDBRestoreBackupRequest) (*VectorDBRestoreBackupResponse, *Response, error)
+	GetRestoreStatus(context.Context, string, string) (*VectorDBRestoreStatus, *Response, error)
+}
+
+// VectorDBsServiceOp handles communication with the Vector DB related methods
+// of the DigitalOcean API.
+type VectorDBsServiceOp struct {
+	client *Client
+}
+
+var _ VectorDBsService = &VectorDBsServiceOp{}
+
+// VectorDB represents a provisioned vector database instance.
+type VectorDB struct {
+	ID        string             `json:"id,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Region    string             `json:"region,omitempty"`
+	OwnerUUID string             `json:"owner_uuid,omitempty"`
+	Status    string             `json:"status,omitempty"`
+	Config    *VectorDBConfig    `json:"config,omitempty"`
+	CreatedAt time.Time          `json:"created_at,omitempty"`
+	UpdatedAt time.Time          `json:"updated_at,omitempty"`
+	Endpoints *VectorDBEndpoints `json:"endpoints,omitempty"`
+	Size      string             `json:"size,omitempty"`
+	Tags      []string           `json:"tags,omitempty"`
+}
+
+// VectorDBConfig holds optional, advanced cluster settings.
+type VectorDBConfig struct {
+	DefaultQuantization string `json:"default_quantization,omitempty"`
+	EnableAutoSchema    bool   `json:"enable_auto_schema,omitempty"`
+	WeaviateVersion     string `json:"weaviate_version,omitempty"`
+}
+
+// VectorDBEndpoints contains the connection endpoints for a vector database instance.
+type VectorDBEndpoints struct {
+	HTTP string `json:"http,omitempty"`
+	GRPC string `json:"grpc,omitempty"`
+}
+
+// VectorDBBackup represents a single backup of a vector database.
+type VectorDBBackup struct {
+	BackupID    string    `json:"backup_id,omitempty"`
+	Status      string    `json:"status,omitempty"`
+	StartedAt   time.Time `json:"started_at,omitempty"`
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+}
+
+// VectorDBCreateRequest represents a request to create a vector database.
+type VectorDBCreateRequest struct {
+	Name   string   `json:"name,omitempty"`
+	Region string   `json:"region,omitempty"`
+	Size   string   `json:"size,omitempty"`
+	Tags   []string `json:"tags,omitempty"`
+}
+
+// VectorDBUpdateRequest represents a request to update a vector database.
+type VectorDBUpdateRequest struct {
+	ID     string          `json:"id,omitempty"`
+	Config *VectorDBConfig `json:"config,omitempty"`
+}
+
+// VectorDBResizeRequest represents a request to resize a vector database.
+type VectorDBResizeRequest struct {
+	ID   string `json:"id,omitempty"`
+	Size string `json:"size,omitempty"`
+}
+
+// VectorDBUpdateTagsRequest represents a request to update tags on a vector database.
+type VectorDBUpdateTagsRequest struct {
+	ID   string   `json:"id,omitempty"`
+	Tags []string `json:"tags,omitempty"`
+}
+
+// VectorDBAdminCredentials represents admin credentials for a vector database.
+type VectorDBAdminCredentials struct {
+	UserID   string `json:"user_id,omitempty"`
+	APIToken string `json:"api_token,omitempty"`
+}
+
+// VectorDBRestoreBackupRequest represents a request to restore a vector database from a backup.
+type VectorDBRestoreBackupRequest struct {
+	ID       string `json:"id,omitempty"`
+	BackupID string `json:"backup_id,omitempty"`
+}
+
+// VectorDBRestoreBackupResponse represents the initial response from a restore operation.
+type VectorDBRestoreBackupResponse struct {
+	BackupID string `json:"backup_id,omitempty"`
+	Status   string `json:"status,omitempty"`
+}
+
+// VectorDBRestoreStatus represents the current status of a restore operation.
+type VectorDBRestoreStatus struct {
+	BackupID string `json:"backup_id,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+type vectorDBRoot struct {
+	VectorDB *VectorDB `json:"vector_db"`
+}
+
+type vectorDBsRoot struct {
+	VectorDBs []VectorDB `json:"vector_dbs"`
+	Total     int64      `json:"total"`
+}
+
+type vectorDBBackupsRoot struct {
+	Backups []VectorDBBackup `json:"backups"`
+}
+
+type vectorDBAdminCredentialsRoot struct {
+	UserID   string `json:"user_id"`
+	APIToken string `json:"api_token"`
+}
+
+type vectorDBRestoreBackupRoot struct {
+	BackupID string `json:"backup_id"`
+	Status   string `json:"status"`
+}
+
+type vectorDBRestoreStatusRoot struct {
+	BackupID string `json:"backup_id"`
+	Status   string `json:"status"`
+	Error    string `json:"error,omitempty"`
+}
+
+// List returns a list of vector databases visible with the caller's API token.
+func (svc *VectorDBsServiceOp) List(ctx context.Context, opts *ListOptions) ([]VectorDB, *Response, error) {
+	path := vectorDatabaseBasePath
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	resp.Meta = &Meta{Total: int(root.Total)}
+	return root.VectorDBs, resp, nil
+}
+
+// Get retrieves the details of a vector database.
+func (svc *VectorDBsServiceOp) Get(ctx context.Context, id string) (*VectorDB, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseSinglePath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.VectorDB, resp, nil
+}
+
+// Create creates a vector database.
+func (svc *VectorDBsServiceOp) Create(ctx context.Context, create *VectorDBCreateRequest) (*VectorDB, *Response, error) {
+	path := vectorDatabaseBasePath
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, create)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.VectorDB, resp, nil
+}
+
+// Update updates a vector database's configuration.
+func (svc *VectorDBsServiceOp) Update(ctx context.Context, id string, update *VectorDBUpdateRequest) (*VectorDB, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseSinglePath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, update)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.VectorDB, resp, nil
+}
+
+// Delete deletes a vector database. There is no way to recover an instance once
+// it has been destroyed.
+func (svc *VectorDBsServiceOp) Delete(ctx context.Context, id string) (*Response, error) {
+	path := fmt.Sprintf(vectorDatabaseSinglePath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// Resize resizes a vector database to a new resource tier.
+func (svc *VectorDBsServiceOp) Resize(ctx context.Context, id string, resize *VectorDBResizeRequest) (*VectorDB, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseResizePath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, resize)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.VectorDB, resp, nil
+}
+
+// UpdateTags replaces all tags on a vector database.
+func (svc *VectorDBsServiceOp) UpdateTags(ctx context.Context, id string, update *VectorDBUpdateTagsRequest) (*VectorDB, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseTagsPath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, update)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.VectorDB, resp, nil
+}
+
+// GetCredentials retrieves admin credentials for a vector database.
+func (svc *VectorDBsServiceOp) GetCredentials(ctx context.Context, id string) (*VectorDBAdminCredentials, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseCredentialsPath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBAdminCredentialsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &VectorDBAdminCredentials{
+		UserID:   root.UserID,
+		APIToken: root.APIToken,
+	}, resp, nil
+}
+
+// ListBackups returns the available backups for a vector database.
+// Only backups with status SUCCESS are returned.
+func (svc *VectorDBsServiceOp) ListBackups(ctx context.Context, id string) ([]VectorDBBackup, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseBackupsPath, id)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBBackupsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Backups, resp, nil
+}
+
+// RestoreBackup initiates a restore from a backup.
+// The restore is performed asynchronously; use GetRestoreStatus to monitor progress.
+func (svc *VectorDBsServiceOp) RestoreBackup(ctx context.Context, id, backupID string, restore *VectorDBRestoreBackupRequest) (*VectorDBRestoreBackupResponse, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseRestorePath, id, backupID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, restore)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRestoreBackupRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &VectorDBRestoreBackupResponse{
+		BackupID: root.BackupID,
+		Status:   root.Status,
+	}, resp, nil
+}
+
+// GetRestoreStatus returns the current status of a restore operation.
+func (svc *VectorDBsServiceOp) GetRestoreStatus(ctx context.Context, id, backupID string) (*VectorDBRestoreStatus, *Response, error) {
+	path := fmt.Sprintf(vectorDatabaseRestorePath, id, backupID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(vectorDBRestoreStatusRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &VectorDBRestoreStatus{
+		BackupID: root.BackupID,
+		Status:   root.Status,
+		Error:    root.Error,
+	}, resp, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.192.0
+# github.com/digitalocean/godo v1.193.0
 ## explicit; go 1.23.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
This PR adds support for database storage autoscale options.

It relies on the following Godo PR for getting and updating storage autoscale endpoints: https://github.com/digitalocean/godo/pull/1018

Tested using a main.tf file in examples to define a database cluster with storage autoscale options.

Attached below are the screenshots for the database resource and database data source.
<img width="1620" height="1470" alt="image" src="https://github.com/user-attachments/assets/dfdb9561-c65e-4347-865b-e789b4c4eaeb" />

**output for terraform plan** 

<img width="2012" height="1842" alt="image" src="https://github.com/user-attachments/assets/bd32717d-25a8-48d3-a69b-035f183c2500" />

**output for terraform apply**

<img width="1826" height="1736" alt="image" src="https://github.com/user-attachments/assets/3c43bb66-2f1f-4b4f-b55e-96a5e3d5b632" />

<img width="1280" height="728" alt="image" src="https://github.com/user-attachments/assets/246be0cf-564e-4877-bec0-125a717ca6dd" />

**database cluster got provisioned with mentioned settings** 

<img width="2626" height="1286" alt="image" src="https://github.com/user-attachments/assets/e0cae707-167a-48f8-8ddb-2987c16ba722" />

**output for terraform destroy** 

<img width="2098" height="1952" alt="image" src="https://github.com/user-attachments/assets/45a52f09-50e8-4a25-ae0b-2da9db360d85" />

**Works for Advanced Mysql engine type too**

<img width="2594" height="1388" alt="image" src="https://github.com/user-attachments/assets/1afda419-0e17-4ffe-8ece-7e1f5e380695" />


