### PR TITLE
fix: persist empty metrics_endpoints to stop perpetual plan drift

### DIFF
--- a/digitalocean/database/resource_database_cluster.go
+++ b/digitalocean/database/resource_database_cluster.go
@@ -767,6 +767,7 @@ func setUIConnectionInfo(database *godo.Database, d *schema.ResourceData) error 
 
 func setMetricsEndpoints(database *godo.Database, d *schema.ResourceData) error {
 	if len(database.MetricsEndpoints) == 0 {
+		d.Set("metrics_endpoints", []string{})
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes non-idempotent `terraform plan` for `digitalocean_database_cluster` when the DigitalOcean API returns no `metrics_endpoints` (commonly reported for MongoDB).

- Persist `metrics_endpoints = []` in state when the API omits or returns an empty list, instead of leaving the attribute unset (`null`).
- Stops recurring in-place update plans that only showed `+ metrics_endpoints = (known after apply)` even though apply did not change cluster configuration.

## Problem

`metrics_endpoints` is a computed `TypeList`. On read, `setMetricsEndpoints` skipped `d.Set` when `len(database.MetricsEndpoints) == 0`. State stayed `null` while Terraform expected a known list value after refresh.

That produced a perpetual plan loop:

```text
# digitalocean_database_cluster.example will be updated in-place
  ~ resource "digitalocean_database_cluster" "example" {
      + metrics_endpoints = (known after apply)
    }
  