### PR TITLE
CON-13852, CON-13399: Expose CoreDNS Autoscaler toggle on DOKS cluster

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -136,6 +136,21 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				},
 			},
 
+			corednsAutoscalerField: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"version": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -401,6 +401,34 @@ func flattenRdmaSharedDevicePluginOpts(opts *godo.KubernetesRdmaSharedDevicePlug
 	return result
 }
 
+func expandCorednsAutoscalerOpts(raw []interface{}) *godo.KubernetesCorednsAutoscaler {
+	if len(raw) == 0 || raw[0] == nil {
+		return &godo.KubernetesCorednsAutoscaler{}
+	}
+
+	corednsAutoscalerObj := raw[0].(map[string]interface{})
+
+	corednsAutoscaler := &godo.KubernetesCorednsAutoscaler{
+		Enabled: godo.PtrTo(corednsAutoscalerObj["enabled"].(bool)),
+	}
+
+	return corednsAutoscaler
+}
+
+func flattenCorednsAutoscalerOpts(opts *godo.KubernetesCorednsAutoscaler) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	if opts == nil {
+		return result
+	}
+
+	item := make(map[string]interface{})
+	item["enabled"] = opts.Enabled
+
+	result = append(result, item)
+
+	return result
+}
+
 func flattenMaintPolicyOpts(opts *godo.KubernetesMaintenancePolicy) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 	item := make(map[string]interface{})

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -31,6 +31,7 @@ const (
 	amdGpuDeviceMetricsExporterPluginField = "amd_gpu_device_metrics_exporter_plugin"
 	nvidiaGpuDevicePluginField             = "nvidia_gpu_device_plugin"
 	rdmaSharedDevicePluginField            = "rdma_shared_device_plugin"
+	corednsAutoscalerField                 = "coredns_autoscaler"
 )
 
 // ExpandHAFromConfig returns the HA value for the create request. When ha is not
@@ -375,6 +376,21 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 					},
 				},
 			},
+
+			corednsAutoscalerField: {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -539,6 +555,10 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 		opts.RdmaSharedDevicePlugin = expandRdmaSharedDevicePluginOpts(rdmaSharedDevicePlugin.([]interface{}))
 	}
 
+	if corednsAutoscaler, ok := d.GetOk(corednsAutoscalerField); ok {
+		opts.CorednsAutoscaler = expandCorednsAutoscalerOpts(corednsAutoscaler.([]interface{}))
+	}
+
 	cluster, _, err := client.Kubernetes.Create(context.Background(), opts)
 	if err != nil {
 		return diag.Errorf("Error creating Kubernetes cluster: %s", err)
@@ -627,6 +647,10 @@ func digitaloceanKubernetesClusterRead(
 		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", rdmaSharedDevicePluginField, err)
 	}
 
+	if err := d.Set(corednsAutoscalerField, flattenCorednsAutoscalerOpts(cluster.CorednsAutoscaler)); err != nil {
+		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", corednsAutoscalerField, err)
+	}
+
 	if err := d.Set("maintenance_policy", flattenMaintPolicyOpts(cluster.MaintenancePolicy)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting maintenance_policy - error: %#v", err)
 	}
@@ -695,7 +719,8 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 	// Figure out the changes and then call the appropriate API methods
 	if d.HasChanges("name", "tags", "auto_upgrade", "surge_upgrade", "maintenance_policy", "ha",
 		controlPlaneFirewallField, "cluster_autoscaler_configuration", routingAgentField, amdGpuDevicePluginField,
-		amdGpuDeviceMetricsExporterPluginField, nvidiaGpuDevicePluginField, rdmaSharedDevicePluginField, "sso") {
+		amdGpuDeviceMetricsExporterPluginField, nvidiaGpuDevicePluginField, rdmaSharedDevicePluginField,
+		corednsAutoscalerField, "sso") {
 
 		opts := &godo.KubernetesClusterUpdateRequest{
 			Name:                              d.Get("name").(string),
@@ -709,6 +734,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 			AmdGpuDeviceMetricsExporterPlugin: expandAmdGpuDeviceMetricsExporterPluginOpts(d.Get(amdGpuDeviceMetricsExporterPluginField).([]interface{})),
 			NvidiaGpuDevicePlugin:             expandNvidiaGpuDevicePluginOpts(d.Get(nvidiaGpuDevicePluginField).([]interface{})),
 			RdmaSharedDevicePlugin:            expandRdmaSharedDevicePluginOpts(d.Get(rdmaSharedDevicePluginField).([]interface{})),
+			CorednsAutoscaler:                 expandCorednsAutoscalerOpts(d.Get(corednsAutoscalerField).([]interface{})),
 			ClusterAutoscalerConfiguration:    expandCAConfigOptsForUpdate(d.GetChange("cluster_autoscaler_configuration")),
 			SSO:                               expandSSOOpts(d.Get("sso").([]interface{})),
 		}

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -100,6 +100,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "routing_agent.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_plugin.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_metrics_exporter_plugin.0.enabled", "false"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "coredns_autoscaler.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_device_plugin.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "rdma_shared_device_plugin.0.enabled", "false"),
 				),
@@ -998,6 +999,26 @@ func TestAccDigitalOceanKubernetesCluster_RoutingAgentEnabled(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanKubernetesCluster_CorednsAutoscalerEnabled(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigCorednsAutoscalerEnabled(testClusterVersionPrevious, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "coredns_autoscaler.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanKubernetesCluster_AmdGpuDevicePluginEnabled(t *testing.T) {
 	rName := acceptance.RandomTestName()
 	var k8s godo.KubernetesCluster
@@ -1393,6 +1414,26 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   version = data.digitalocean_kubernetes_versions.test.latest_version
   ha      = false
   routing_agent {
+    enabled = true
+  }
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigCorednsAutoscalerEnabled(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
+  coredns_autoscaler {
     enabled = true
   }
   node_pool {

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -184,6 +184,8 @@ The following arguments are supported:
   - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
 `rdma_shared_device_plugin` - (Optional) Block containing options for the RDMA Shared Device Plugin (k8s-rdma-shared-dev-plugin) component. If not specified, the component will be enabled by default for clusters with GPU nodes connected to a dedicated high-speed networking fabric.
     - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
+* `coredns_autoscaler` - (Optional) Block containing options for the CoreDNS Autoscaler component, which scales CoreDNS replicas in proportion to the cluster's size. Default: true (for 1.36.0 and later)
+  - `enabled` - (Required) Boolean flag whether the CoreDNS Autoscaler should be enabled or not.
 * `cluster_autoscaler_configuration` - (Optional) Block containing options for cluster auto-scaling. For more information.
   - `scale_down_utilization_threshold` - (Optional) Float setting the Node utilization level, defined as sum of requested resources divided by capacity, in which a node can be considered for scale down.
   - `scale_down_unneeded_time` - (Optional) String setting how long a node should be unneeded before it's eligible for scale down.
@@ -240,6 +242,8 @@ In addition to the arguments listed above, the following additional attributes a
   - `enabled` - Boolean flag whether the component is enabled or not.
 * `amd_gpu_device_metrics_exporter_plugin` - Block containing options for the AMD GPU device metrics exporter component.
   - `enabled` - Boolean flag whether the component is enabled or not.
+* `coredns_autoscaler` - Block containing options for the CoreDNS Autoscaler component, which scales CoreDNS replicas in proportion to the cluster's size. Default: true (for 1.36.0 and later)
+  - `enabled` - Boolean flag whether the CoreDNS Autoscaler is enabled or not.
 
 ## Import
 


### PR DESCRIPTION
Adds `coredns_autoscaler` block to the `digitalocean_kubernetes_cluster` resource

```
resource "digitalocean_kubernetes_cluster" "example" {
  name    = ""
  region  = ""
  version = "1.36.0-do.0"
  coredns_autoscaler {
    enabled = true
  }
  node_pool { ... }
}
```