### PR TITLE
fix(reservedip): tolerate 404 on the reserved IP assignment action poll (BYOIP)

### DIFF
--- a/digitalocean/reservedip/resource_reserved_ip_assignment.go
+++ b/digitalocean/reservedip/resource_reserved_ip_assignment.go
@@ -170,6 +170,14 @@ func newReservedIPAssignmentStateRefreshFunc(
 	d *schema.ResourceData, attribute string, meta interface{}, actionID int, check reservedIPAssignmentCheck) retry.StateRefreshFunc {
 	client := meta.(*config.CombinedConfig).GodoClient()
 	ipAddress := d.Get("ip_address").(string)
+	return reservedIPAssignmentRefreshFunc(client, ipAddress, actionID, check)
+}
+
+// reservedIPAssignmentRefreshFunc polls the assign/unassign action status and,
+// when the action endpoint 404s, falls back to the reserved IP itself as the
+// source of truth. It is split out from newReservedIPAssignmentStateRefreshFunc
+// so it can be unit tested against a mock client.
+func reservedIPAssignmentRefreshFunc(client *godo.Client, ipAddress string, actionID int, check reservedIPAssignmentCheck) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
 		log.Printf("[INFO] Refreshing the reserved IP state")

--- a/digitalocean/reservedip/resource_reserved_ip_assignment.go
+++ b/digitalocean/reservedip/resource_reserved_ip_assignment.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/digitalocean/godo"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -56,7 +58,7 @@ func resourceDigitalOceanReservedIPAssignmentCreate(ctx context.Context, d *sche
 			"Error Assigning reserved IP (%s) to the droplet: %s", ipAddress, err)
 	}
 
-	_, unassignedErr := waitForReservedIPAssignmentReady(ctx, d, "completed", []string{"new", "in-progress"}, "status", meta, action.ID)
+	_, unassignedErr := waitForReservedIPAssignmentReady(ctx, d, "completed", []string{"new", "in-progress"}, "status", meta, action.ID, reservedIPAssignmentCheck{dropletID: dropletID, assign: true})
 	if unassignedErr != nil {
 		return diag.Errorf(
 			"Error waiting for reserved IP (%s) to be Assigned: %s", ipAddress, unassignedErr)
@@ -105,7 +107,7 @@ func resourceDigitalOceanReservedIPAssignmentDelete(ctx context.Context, d *sche
 			return diag.Errorf("Error unassigning reserved IP (%s) from the droplet: %s", ipAddress, err)
 		}
 
-		_, unassignedErr := waitForReservedIPAssignmentReady(ctx, d, "completed", []string{"new", "in-progress"}, "status", meta, action.ID)
+		_, unassignedErr := waitForReservedIPAssignmentReady(ctx, d, "completed", []string{"new", "in-progress"}, "status", meta, action.ID, reservedIPAssignmentCheck{dropletID: dropletID, assign: false})
 		if unassignedErr != nil {
 			return diag.Errorf(
 				"Error waiting for reserved IP (%s) to be unassigned: %s", ipAddress, unassignedErr)
@@ -118,8 +120,34 @@ func resourceDigitalOceanReservedIPAssignmentDelete(ctx context.Context, d *sche
 	return nil
 }
 
+// reservedIPAssignmentCheck describes the end-state we expect once an
+// assign/unassign action settles. It lets us confirm completion by reading the
+// reserved IP directly when the action-status endpoint returns 404 - which is
+// persistent for BYOIP-prefix reserved IPs, whose returned action ID never
+// becomes queryable. Without this fallback, polling the missing action loops
+// until the timeout even though DigitalOcean already completed the assignment.
+type reservedIPAssignmentCheck struct {
+	dropletID int
+	assign    bool // true: expect the IP attached to dropletID; false: expect it detached
+}
+
+// reservedIPActionNotFound reports whether the action-status lookup came back as
+// a 404 (the action ID is not, or not yet, queryable).
+func reservedIPActionNotFound(resp *godo.Response, err error) bool {
+	if err == nil {
+		return false
+	}
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return true
+	}
+	if godoErr, ok := err.(*godo.ErrorResponse); ok && godoErr.Response != nil && godoErr.Response.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return false
+}
+
 func waitForReservedIPAssignmentReady(
-	ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, actionID int) (interface{}, error) {
+	ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, actionID int, check reservedIPAssignmentCheck) (interface{}, error) {
 	log.Printf(
 		"[INFO] Waiting for reserved IP (%s) to have %s of %s",
 		d.Get("ip_address").(string), attribute, target)
@@ -127,7 +155,7 @@ func waitForReservedIPAssignmentReady(
 	stateConf := &retry.StateChangeConf{
 		Pending:    pending,
 		Target:     []string{target},
-		Refresh:    newReservedIPAssignmentStateRefreshFunc(d, attribute, meta, actionID),
+		Refresh:    newReservedIPAssignmentStateRefreshFunc(d, attribute, meta, actionID, check),
 		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -139,14 +167,37 @@ func waitForReservedIPAssignmentReady(
 }
 
 func newReservedIPAssignmentStateRefreshFunc(
-	d *schema.ResourceData, attribute string, meta interface{}, actionID int) retry.StateRefreshFunc {
+	d *schema.ResourceData, attribute string, meta interface{}, actionID int, check reservedIPAssignmentCheck) retry.StateRefreshFunc {
 	client := meta.(*config.CombinedConfig).GodoClient()
+	ipAddress := d.Get("ip_address").(string)
 	return func() (interface{}, string, error) {
 
 		log.Printf("[INFO] Refreshing the reserved IP state")
-		action, _, err := client.ReservedIPActions.Get(context.Background(), d.Get("ip_address").(string), actionID)
+		action, resp, err := client.ReservedIPActions.Get(context.Background(), ipAddress, actionID)
+		if reservedIPActionNotFound(resp, err) {
+			// The assign/unassign call returns an action ID immediately, but the
+			// action may not be queryable yet - and for BYOIP-prefix reserved IPs it
+			// never becomes queryable. Rather than poll the missing action until the
+			// timeout, fall back to the reserved IP itself as the source of truth.
+			reservedIP, _, ripErr := client.ReservedIPs.Get(context.Background(), ipAddress)
+			if ripErr != nil {
+				log.Printf("[DEBUG] Reserved IP (%s) action (%d) returned 404; reserved IP read failed (%s); will retry", ipAddress, actionID, ripErr)
+				return nil, "", nil
+			}
+
+			attachedToTarget := reservedIP.Droplet != nil && reservedIP.Droplet.ID == check.dropletID
+			if attachedToTarget == check.assign {
+				log.Printf("[INFO] Reserved IP (%s) action (%d) not queryable; confirmed desired state on the reserved IP -> completed", ipAddress, actionID)
+				return reservedIP, "completed", nil
+			}
+
+			// Not yet in the desired state. Return a non-nil result so the poll stays
+			// "in-progress" without consuming a NotFoundChecks tick.
+			log.Printf("[DEBUG] Reserved IP (%s) action (%d) returned 404; reserved IP not yet in desired state; will retry", ipAddress, actionID)
+			return reservedIP, "in-progress", nil
+		}
 		if err != nil {
-			return nil, "", fmt.Errorf("Error retrieving reserved IP (%s) ActionId (%d): %s", d.Get("ip_address").(string), actionID, err)
+			return nil, "", fmt.Errorf("Error retrieving reserved IP (%s) ActionId (%d): %s", ipAddress, actionID, err)
 		}
 
 		log.Printf("[INFO] The reserved IP Action Status is %s", action.Status)

--- a/digitalocean/reservedip/resource_reserved_ip_assignment_internal_test.go
+++ b/digitalocean/reservedip/resource_reserved_ip_assignment_internal_test.go
@@ -1,0 +1,132 @@
+package reservedip
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
+
+func TestReservedIPActionNotFound(t *testing.T) {
+	notFoundResp := &godo.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}
+	okResp := &godo.Response{Response: &http.Response{StatusCode: http.StatusOK}}
+	godoNotFound := &godo.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}
+
+	tests := []struct {
+		name string
+		resp *godo.Response
+		err  error
+		want bool
+	}{
+		{name: "no error", resp: okResp, err: nil, want: false},
+		{name: "404 via response", resp: notFoundResp, err: fmt.Errorf("not found"), want: true},
+		{name: "404 via godo.ErrorResponse", resp: nil, err: godoNotFound, want: true},
+		{name: "non-404 error", resp: okResp, err: fmt.Errorf("boom"), want: false},
+		{name: "error with nil response", resp: nil, err: fmt.Errorf("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reservedIPActionNotFound(tt.resp, tt.err); got != tt.want {
+				t.Errorf("reservedIPActionNotFound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// newTestGodoClient returns a godo client whose requests are routed to the given
+// test server.
+func newTestGodoClient(t *testing.T, serverURL string) *godo.Client {
+	t.Helper()
+	client := godo.NewClient(nil)
+	u, err := url.Parse(serverURL + "/")
+	if err != nil {
+		t.Fatalf("parsing test server URL: %s", err)
+	}
+	client.BaseURL = u
+	return client
+}
+
+// TestReservedIPAssignmentRefreshFunc_ActionNotFound verifies that when the
+// action-status endpoint 404s (as it does permanently for BYOIP-prefix reserved
+// IPs), the refresh func falls back to the reserved IP itself and reports
+// "completed"/"in-progress" based on the actual attachment, instead of erroring
+// or polling the missing action forever.
+func TestReservedIPAssignmentRefreshFunc_ActionNotFound(t *testing.T) {
+	const (
+		ip        = "192.0.2.10"
+		actionID  = 123456
+		dropletID = 42
+	)
+
+	tests := []struct {
+		name          string
+		check         reservedIPAssignmentCheck
+		reservedIPDOC string // body for GET /v2/reserved_ips/{ip}
+		wantState     string
+		wantNilResult bool
+	}{
+		{
+			name:          "assign completed - attached to target droplet",
+			check:         reservedIPAssignmentCheck{dropletID: dropletID, assign: true},
+			reservedIPDOC: fmt.Sprintf(`{"reserved_ip":{"ip":%q,"droplet":{"id":%d},"region":{"slug":"ams3"}}}`, ip, dropletID),
+			wantState:     "completed",
+		},
+		{
+			name:          "assign pending - not yet attached",
+			check:         reservedIPAssignmentCheck{dropletID: dropletID, assign: true},
+			reservedIPDOC: fmt.Sprintf(`{"reserved_ip":{"ip":%q,"droplet":null,"region":{"slug":"ams3"}}}`, ip),
+			wantState:     "in-progress",
+		},
+		{
+			name:          "unassign completed - detached",
+			check:         reservedIPAssignmentCheck{dropletID: dropletID, assign: false},
+			reservedIPDOC: fmt.Sprintf(`{"reserved_ip":{"ip":%q,"droplet":null,"region":{"slug":"ams3"}}}`, ip),
+			wantState:     "completed",
+		},
+		{
+			name:          "unassign pending - still attached to target",
+			check:         reservedIPAssignmentCheck{dropletID: dropletID, assign: false},
+			reservedIPDOC: fmt.Sprintf(`{"reserved_ip":{"ip":%q,"droplet":{"id":%d},"region":{"slug":"ams3"}}}`, ip, dropletID),
+			wantState:     "in-progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			// The action ID never becomes queryable: always 404.
+			mux.HandleFunc(fmt.Sprintf("/v2/reserved_ips/%s/actions/%d", ip, actionID),
+				func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+					fmt.Fprint(w, `{"id":"not_found","message":"The resource you requested could not be found."}`)
+				})
+			// The reserved IP itself is the source of truth.
+			mux.HandleFunc(fmt.Sprintf("/v2/reserved_ips/%s", ip),
+				func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprint(w, tt.reservedIPDOC)
+				})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := newTestGodoClient(t, server.URL)
+			result, state, err := reservedIPAssignmentRefreshFunc(client, ip, actionID, tt.check)()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			// A non-nil result is required so StateChangeConf does not count the
+			// poll against NotFoundChecks while we wait in "in-progress".
+			if result == nil {
+				t.Errorf("result = nil, want non-nil reserved IP so the poll is not treated as not-found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1557

## Problem

`digitalocean_reserved_ip_assignment` kicks off an assign/unassign action and then polls its status at `GET /v2/reserved_ips/{ip}/actions/{action_id}`.

For reserved IPs that come from a **BYOIP prefix**, the returned `action_id` is never queryable, so that poll returns `404 ... The resource you requested could not be found` — and the apply fails:

```
Error: Error waiting for reserved IP (<byoip>) to be Assigned:
Error retrieving reserved IP (<byoip>) ActionId (<id>):
GET .../v2/reserved_ips/<byoip>/actions/<id>: 404 ... The resource you requested could not be found.
```

The assign/unassign has actually **completed** on DigitalOcean's side — only the action-status poll 404s — so the assignment ends up missing from Terraform state and re-applying just hits the same 404. DO-allocated reserved IPs are unaffected (their action IDs are queryable). Naively retrying the 404 instead is no better: for BYOIP the action never appears, so the poll loops until the 60-minute timeout.

## Fix

When the action-status lookup 404s, stop trusting the (permanently-missing) action and fall back to the **reserved IP itself** as the source of truth: read `GET /v2/reserved_ips/{ip}` and compare its attached droplet against the expected end-state.

- **assign** → `completed` once the IP is attached to the target droplet
- **unassign** → `completed` once the IP is no longer attached to the target droplet
- otherwise keep polling (`in-progress`), returning a non-nil result so the poll is not counted against `NotFoundChecks`

This converges immediately for both DO-allocated and BYOIP addresses, and the non-404 path is unchanged.

## Tests

Added unit tests (`resource_reserved_ip_assignment_internal_test.go`):

- `TestReservedIPActionNotFound` — 404 detection via both the response and `godo.ErrorResponse`, and non-404 errors ignored.
- `TestReservedIPAssignmentRefreshFunc_ActionNotFound` — drives the refresh func against an httptest server whose action endpoint always 404s and asserts the `completed`/`in-progress` fallback for both assign and unassign, always with a non-nil result.

```
$ go test ./digitalocean/reservedip/
ok      github.com/digitalocean/terraform-provider-digitalocean/digitalocean/reservedip
```

The refresh body was extracted into `reservedIPAssignmentRefreshFunc(client, ip, actionID, check)` so it can be tested with a mock godo client; behaviour for the existing (non-404) path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)