### PR TITLE
fix: prevent panic in kafka topic create when API response omits the topic

### DIFF
--- a/digitalocean/database/resource_database_kafka_topic.go
+++ b/digitalocean/database/resource_database_kafka_topic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -310,13 +311,34 @@ func resourceDigitalOceanDatabaseKafkaTopicCreate(ctx context.Context, d *schema
 	}
 
 	log.Printf("[DEBUG] Database kafka topic create configuration: %#v", opts)
-	topic, _, err := client.Databases.CreateTopic(context.Background(), clusterID, opts)
+	_, _, err := client.Databases.CreateTopic(context.Background(), clusterID, opts)
 	if err != nil {
 		return diag.Errorf("Error creating database kafka topic: %s", err)
 	}
 
-	d.SetId(makeKafkaTopicID(clusterID, topic.Name))
-	log.Printf("[INFO] Database kafka topic name: %s", topic.Name)
+	// Topic creation is asynchronous: the API may respond before the topic
+	// is provisioned, without returning it in the response body. Derive the
+	// ID from the request rather than the response, and wait for the topic
+	// to become readable.
+	d.SetId(makeKafkaTopicID(clusterID, opts.Name))
+	log.Printf("[INFO] Database kafka topic name: %s", opts.Name)
+
+	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
+		topic, resp, err := client.Databases.GetTopic(ctx, clusterID, opts.Name)
+		if err != nil {
+			if resp != nil && resp.StatusCode == 404 {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(fmt.Errorf("Error retrieving kafka topic: %s", err))
+		}
+		if topic == nil {
+			return retry.RetryableError(fmt.Errorf("kafka topic %s is not available yet", opts.Name))
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return resourceDigitalOceanDatabaseKafkaTopicRead(ctx, d, meta)
 }
@@ -360,6 +382,10 @@ func resourceDigitalOceanDatabaseKafkaTopicRead(ctx context.Context, d *schema.R
 		}
 
 		return diag.Errorf("Error retrieving kafka topic: %s", err)
+	}
+
+	if topic == nil {
+		return diag.Errorf("Error retrieving kafka topic: no topic returned for %s", topicName)
 	}
 
 	d.Set("state", topic.State)

--- a/digitalocean/database/resource_database_kafka_topic_internal_test.go
+++ b/digitalocean/database/resource_database_kafka_topic_internal_test.go
@@ -1,0 +1,74 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Kafka topic creation is asynchronous: when the topic is not provisioned
+// in time, the API responds 202 with an acknowledgment body instead of the
+// documented 201 with the topic, and godo yields a nil topic with no
+// error. Create must not depend on the response payload, and must wait
+// until the topic is readable.
+func TestDatabaseKafkaTopicCreateNoTopicInResponse(t *testing.T) {
+	clusterID := "3f2549b8-9257-4e2f-a04c-e23547b2d685"
+	topicName := "topic-foobar"
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc(fmt.Sprintf("/v2/databases/%s/topics", clusterID), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %v, expected %v", r.Method, http.MethodPost)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"message":"topic cannot be performed. Reason: topic is still provisioning","id":"accepted"}`)
+	})
+
+	var gets int
+	mux.HandleFunc(fmt.Sprintf("/v2/databases/%s/topics/%s", clusterID, topicName), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		gets++
+		if gets == 1 {
+			// Still provisioning: a payload without the topic key.
+			fmt.Fprint(w, `{"id":"accepted"}`)
+			return
+		}
+		fmt.Fprintf(w, `{"topic": {"name": %q, "state": "active", "replication_factor": 2}}`, topicName)
+	})
+
+	cfg := &config.Config{
+		Token:       "test-token",
+		APIEndpoint: server.URL,
+	}
+	client, err := cfg.Client()
+	if err != nil {
+		t.Fatalf("error building client: %s", err)
+	}
+
+	d := schema.TestResourceDataRaw(t, ResourceDigitalOceanDatabaseKafkaTopic().Schema, map[string]interface{}{
+		"cluster_id":         clusterID,
+		"name":               topicName,
+		"partition_count":    3,
+		"replication_factor": 2,
+	})
+
+	if diags := resourceDigitalOceanDatabaseKafkaTopicCreate(context.Background(), d, client); diags.HasError() {
+		t.Fatalf("create returned error: %v", diags)
+	}
+
+	if want := makeKafkaTopicID(clusterID, topicName); d.Id() != want {
+		t.Errorf("id = %q, expected %q", d.Id(), want)
+	}
+	if state := d.Get("state").(string); state != "active" {
+		t.Errorf("state = %q, expected %q", state, "active")
+	}
+}


### PR DESCRIPTION
`digitalocean_database_kafka_topic` creation panics with a nil pointer dereference when the API creates the topic but responds without a topic payload:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database.resourceDigitalOceanDatabaseKafkaTopicCreate
    digitalocean/database/resource_database_kafka_topic.go:318
```

## Root cause

Kafka topic creation is asynchronous server-side. When the topic is not provisioned in time, the API responds `202 Accepted` with an acknowledgment body instead of the documented `201` with the topic object. Captured from a live cluster (the create handler blocked for ~20s first, `do-upstream-service-time: 20745`):

```
HTTP/2 202
{"message":"topic cannot be performed. Reason: topic is still provisioning","id":"accepted","request_id":"..."}
```

The topic *is* created and reaches `active` shortly after. But godo decodes this body into a `databaseTopicRoot` with a nil `Topic` and no error, and the create function dereferences `topic.Name` unguarded. Because the panic kills the plugin before the resource ID is recorded, the topic never lands in state - every retry crashes again and orphans another topic. Reproduced consistently (2/2 CI applies + probes) on a real cluster: Kafka 3.8, `db-s-2vcpu-2gb` x3, region `fra1`, provider v2.86.0 (the create path is unchanged through v2.93.0/main). `GetTopic` returns the same payload-less body while the topic is provisioning.

This is the create-path sibling of #1553, which fixed the same class of panic in the read path and noted the API "commonly returns ... partially populated configs (e.g. immediately after topic creation)".

## Changes

- Create derives the resource ID from the request (`opts.Name`), which is known client-side, instead of trusting the response payload.
- Create then waits (`retry.RetryContext`, same pattern as `resource_database_replica`) until `GetTopic` actually returns the topic, so the first apply converges instead of tainting the resource while the topic provisions.
- Read guards against a nil topic from `GetTopic` and returns an error instead of panicking on `topic.State`.
- Regression test replaying the captured API behavior (202 acknowledgment on create, payload-less body on first read): it panics with the exact production stack trace before this change and passes with it.

## Validation

Built the patched provider and ran it via `dev_overrides` against the live cluster exhibiting the behavior: create succeeded in a single apply (`Creation complete`, ID and `state = "active"` in state, follow-up plan shows `No changes`), followed by a clean destroy. Unit suite for `digitalocean/database` passes.
