### PR TITLE
apps: add SCHEDULED job kind and schedule block

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -915,8 +915,18 @@ func appSpecJobSchema() *schema.Resource {
 				"PRE_DEPLOY",
 				"POST_DEPLOY",
 				"FAILED_DEPLOY",
+				"SCHEDULED",
 			}, false),
 			Description: "The type of job and when it will be run during the deployment process.",
+		},
+		"schedule": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "The schedule for a job with a kind of `SCHEDULED`.",
+			Elem: &schema.Resource{
+				Schema: appSpecJobScheduleSchema(),
+			},
 		},
 		"termination": {
 			Type:     schema.TypeList,
@@ -932,6 +942,21 @@ func appSpecJobSchema() *schema.Resource {
 
 	return &schema.Resource{
 		Schema: jobSchema,
+	}
+}
+
+func appSpecJobScheduleSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"cron": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The cron expression that defines when the scheduled job runs.",
+		},
+		"time_zone": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The time zone in which the cron expression is evaluated, as a valid IANA time zone name (e.g. `America/New_York`). Defaults to UTC.",
+		},
 	}
 }
 
@@ -2502,6 +2527,11 @@ func expandAppSpecJobs(config []interface{}) []*godo.AppJobSpec {
 			s.Termination = expandAppTermination[godo.AppJobSpecTermination](termination)
 		}
 
+		schedule := job["schedule"].([]interface{})
+		if len(schedule) > 0 {
+			s.Schedule = expandAppSpecJobSchedule(schedule)
+		}
+
 		appJobs = append(appJobs, s)
 	}
 
@@ -2532,11 +2562,38 @@ func flattenAppSpecJobs(jobs []*godo.AppJobSpec) []map[string]interface{} {
 		r["alert"] = flattenAppAlerts(j.Alerts)
 		r["log_destination"] = flattenAppLogDestinations(j.LogDestinations)
 		r["termination"] = flattenAppTermination(j.Termination)
+		r["schedule"] = flattenAppSpecJobSchedule(j.Schedule)
 
 		result[i] = r
 	}
 
 	return result
+}
+
+func expandAppSpecJobSchedule(config []interface{}) *godo.AppJobSpecSchedule {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
+	schedule := config[0].(map[string]interface{})
+
+	return &godo.AppJobSpecSchedule{
+		Cron:     schedule["cron"].(string),
+		TimeZone: schedule["time_zone"].(string),
+	}
+}
+
+func flattenAppSpecJobSchedule(schedule *godo.AppJobSpecSchedule) []map[string]interface{} {
+	if schedule == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"cron":      schedule.Cron,
+			"time_zone": schedule.TimeZone,
+		},
+	}
 }
 
 func expandAppSpecFunctions(config []interface{}) []*godo.AppFunctionsSpec {

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -337,6 +337,14 @@ func TestAccDigitalOceanApp_Job(t *testing.T) {
 						"digitalocean_app.foobar", "spec.0.job.2.name", "example-failed-job"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_app.foobar", "spec.0.job.2.kind", "FAILED_DEPLOY"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.job.3.name", "example-scheduled-job"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.job.3.kind", "SCHEDULED"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.job.3.schedule.0.cron", "0 0 * * *"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.job.3.schedule.0.time_zone", "America/New_York"),
 				),
 			},
 		},
@@ -1966,6 +1974,26 @@ resource "digitalocean_app" "foobar" {
       instance_size_slug = "basic-xxs"
       kind               = "FAILED_DEPLOY"
       run_command        = "echo 'This is a failed deploy job.'"
+
+      image {
+        registry_type = "DOCKER_HUB"
+        registry      = "frolvlad"
+        repository    = "alpine-bash"
+        tag           = "latest"
+      }
+    }
+
+    job {
+      name               = "example-scheduled-job"
+      instance_count     = 1
+      instance_size_slug = "basic-xxs"
+      kind               = "SCHEDULED"
+      run_command        = "echo 'This is a scheduled job.'"
+
+      schedule {
+        cron      = "0 0 * * *"
+        time_zone = "America/New_York"
+      }
 
       image {
         registry_type = "DOCKER_HUB"

--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -227,6 +227,10 @@ A `job` can contain:
   - `PRE_DEPLOY`: Indicates a job that runs before an app deployment.
   - `POST_DEPLOY`: Indicates a job that runs after an app deployment.
   - `FAILED_DEPLOY`: Indicates a job that runs after a component fails to deploy.
+  - `SCHEDULED`: Indicates a job that runs periodically based on a cron expression. Requires a `schedule` block.
+* `schedule` - The schedule for a job with a `kind` of `SCHEDULED`.
+  - `cron` - The cron expression that defines when the scheduled job runs.
+  - `time_zone` - The time zone in which the cron expression is evaluated, as a valid IANA time zone name (e.g. `America/New_York`). Defaults to UTC.
 * `build_command` - An optional build command to run while building this component from source.
 * `dockerfile_path` - The path to a Dockerfile relative to the root of the repo. If set, overrides usage of buildpacks.
 * `source_dir` - An optional path to the working directory to use for the build.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -550,6 +550,10 @@ A `job` can contain:
   - `PRE_DEPLOY`: Indicates a job that runs before an app deployment.
   - `POST_DEPLOY`: Indicates a job that runs after an app deployment.
   - `FAILED_DEPLOY`: Indicates a job that runs after a component fails to deploy.
+  - `SCHEDULED`: Indicates a job that runs periodically based on a cron expression. Requires a `schedule` block.
+- `schedule` - The schedule for a job with a `kind` of `SCHEDULED`.
+  - `cron` - The cron expression that defines when the scheduled job runs.
+  - `time_zone` - The time zone in which the cron expression is evaluated, as a valid IANA time zone name (e.g. `America/New_York`). Defaults to UTC.
 - `build_command` - An optional build command to run while building this component from source.
 - `dockerfile_path` - The path to a Dockerfile relative to the root of the repo. If set, overrides usage of buildpacks.
 - `source_dir` - An optional path to the working directory to use for the build.


### PR DESCRIPTION
Adds SCHEDULED to the valid values for a job's kind in the digitalocean_app spec and introduces a new schedule block (cron, time_zone) so scheduled jobs can be fully managed via Terraform. Includes expand/flatten wiring, docs, and test coverage.

Fixes #1529