### PR TITLE
fix: Accept JOB_INVOCATION_FAILED app-level alert (#1573)

### DIFF
--- a/digitalocean/app/app_spec.go
+++ b/digitalocean/app/app_spec.go
@@ -245,6 +245,7 @@ func appSpecAppLevelAlerts() *schema.Resource {
 					string(godo.AppAlertSpecRule_DomainLive),
 					string(godo.AppAlertSpecRule_AutoscaleFailed),
 					string(godo.AppAlertSpecRule_AutoscaleSucceeded),
+					string(godo.AppAlertSpecRule_JobInvocationFailed),
 				}, false),
 			},
 			"disabled": {

--- a/digitalocean/app/resource_app_test.go
+++ b/digitalocean/app/resource_app_test.go
@@ -343,6 +343,27 @@ func TestAccDigitalOceanApp_Job(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanApp_JobInvocationFailedAlert(t *testing.T) {
+	var app godo.App
+	appName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanAppConfig_jobInvocationFailedAlert, appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanAppExists("digitalocean_app.foobar", &app),
+					resource.TestCheckResourceAttr(
+						"digitalocean_app.foobar", "spec.0.alert.0.rule", "JOB_INVOCATION_FAILED"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanApp_StaticSite(t *testing.T) {
 	var app godo.App
 	appName := acceptance.RandomTestName()
@@ -1966,6 +1987,32 @@ resource "digitalocean_app" "foobar" {
       instance_size_slug = "basic-xxs"
       kind               = "FAILED_DEPLOY"
       run_command        = "echo 'This is a failed deploy job.'"
+
+      image {
+        registry_type = "DOCKER_HUB"
+        registry      = "frolvlad"
+        repository    = "alpine-bash"
+        tag           = "latest"
+      }
+    }
+  }
+}`
+
+var testAccCheckDigitalOceanAppConfig_jobInvocationFailedAlert = `
+resource "digitalocean_app" "foobar" {
+  spec {
+    name   = "%s"
+    region = "ams"
+
+    alert {
+      rule = "JOB_INVOCATION_FAILED"
+    }
+
+    job {
+      name               = "example-scheduled-job"
+      instance_count     = 1
+      instance_size_slug = "basic-xxs"
+      run_command        = "echo 'This is a scheduled job.'"
 
       image {
         registry_type = "DOCKER_HUB"

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -285,7 +285,7 @@ The following arguments are supported:
   - `scope` - The visibility scope of the environment variable. One of `RUN_TIME`, `BUILD_TIME`, or `RUN_AND_BUILD_TIME` (default).
   - `type` - The type of the environment variable, `GENERAL` or `SECRET`.
 * `alert` - Describes an alert policy for the app.
-  - `rule` - The type of the alert to configure. Top-level app alert policies can be: `DEPLOYMENT_CANCELLED`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_LIVE`, `DEPLOYMENT_STARTED`, `DOMAIN_FAILED`, `DOMAIN_LIVE`, `AUTOSCALE_FAILED`, or `AUTOSCALE_SUCCEEDED`.
+  - `rule` - The type of the alert to configure. Top-level app alert policies can be: `DEPLOYMENT_CANCELLED`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_LIVE`, `DEPLOYMENT_STARTED`, `DOMAIN_FAILED`, `DOMAIN_LIVE`, `AUTOSCALE_FAILED`, `AUTOSCALE_SUCCEEDED`, or `JOB_INVOCATION_FAILED` (applies to scheduled job components).
   - `disabled` - Determines whether the alert is disabled (default: `false`).
   - `destinations` - Specification for alert destination.
     - `emails` - Determines which emails receive alerts. The emails must be team members. If not set, the team's email is used by default.


### PR DESCRIPTION
## Description

App Platform exposes a **"Failed job invocation"** alert (`JOB_INVOCATION_FAILED`)
for scheduled job components, but the provider's app-level alert schema does not
include it in its allow-list. As a result, `terraform plan`/`validate` rejects the
configuration before any API call is made:

Error: expected spec.0.alert.0.rule to be one of [DEPLOYMENT_FAILED DEPLOYMENT_LIVE DEPLOYMENT_STARTED DEPLOYMENT_CANCELED DOMAIN_FAILED DOMAIN_LIVE AUTOSCALE_FAILED AUTOSCALE_SUCCEEDED], got JOB_INVOCATION_FAILED


This PR adds `JOB_INVOCATION_FAILED` to the app-level (`spec.alert.rule`)
validation allow-list so the alert can be managed via Terraform. The value is
already defined in godo as `godo.AppAlertSpecRule_JobInvocationFailed`.

Fixes #1573

## Changes

- `digitalocean/app/app_spec.go`: add `godo.AppAlertSpecRule_JobInvocationFailed`
  to the app-level alert `rule` allow-list in `appSpecAppLevelAlerts()`.
- `docs/resources/app.md`: document `JOB_INVOCATION_FAILED` in the top-level app
  alert `rule` list.
- `digitalocean/app/resource_app_test.go`: add
  `TestAccDigitalOceanApp_JobInvocationFailedAlert` covering an app-level
  `alert { rule = "JOB_INVOCATION_FAILED" }`.

No expand/flatten changes are required: alert rules are passed through generically
via `expandAppAlerts`/`flattenAppAlerts` as strings.

## Example

```hcl
resource "digitalocean_app" "example" {
  spec {
    name   = "example-jobs-app"
    region = "fra"

    alert {
      rule = "JOB_INVOCATION_FAILED"
    }

    job {
      name               = "example-scheduled-job"
      instance_count     = 1
      instance_size_slug = "basic-xxs"
      # image / schedule / etc.
    }
  }
}
```