### PR TITLE
database: don't panic when CreateTopic/GetTopic returns no topic

### DIFF
--- a/digitalocean/database/resource_database_kafka_topic.go
+++ b/digitalocean/database/resource_database_kafka_topic.go
@@ -315,8 +315,17 @@ func resourceDigitalOceanDatabaseKafkaTopicCreate(ctx context.Context, d *schema
 		return diag.Errorf("Error creating database kafka topic: %s", err)
 	}
 
-	d.SetId(makeKafkaTopicID(clusterID, topic.Name))
-	log.Printf("[INFO] Database kafka topic name: %s", topic.Name)
+	// The API can return a successful response without a topic object, in
+	// which case godo yields a nil topic alongside a nil error. The topic
+	// name is client-chosen, so fall back to the requested name rather than
+	// dereferencing the response.
+	topicName := opts.Name
+	if topic != nil && topic.Name != "" {
+		topicName = topic.Name
+	}
+
+	d.SetId(makeKafkaTopicID(clusterID, topicName))
+	log.Printf("[INFO] Database kafka topic name: %s", topicName)
 
 	return resourceDigitalOceanDatabaseKafkaTopicRead(ctx, d, meta)
 }
@@ -360,6 +369,13 @@ func resourceDigitalOceanDatabaseKafkaTopicRead(ctx context.Context, d *schema.R
 		}
 
 		return diag.Errorf("Error retrieving kafka topic: %s", err)
+	}
+
+	// Same defensive guard as Create: a successful response without a topic
+	// object yields a nil topic with a nil error. Treat it as not found.
+	if topic == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("state", topic.State)


### PR DESCRIPTION
## Summary

`digitalocean_database_kafka_topic` crashes the whole provider with a nil-pointer panic when the DBaaS API returns a successful create response without a topic object — godo's `CreateTopic` then yields a nil `*DatabaseTopic` alongside a nil error, and the resource dereferences `topic.Name` unguarded.

Hit in the wild on v2.95.0, creating a topic on a just-provisioned Kafka cluster:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd74576]

github.com/digitalocean/terraform-provider-digitalocean/digitalocean/database.resourceDigitalOceanDatabaseKafkaTopicCreate(...)
        digitalocean/database/resource_database_kafka_topic.go:318 +0x3f6
```

## Fix

- **Create**: the topic name is client-chosen, so fall back to the requested name when the response omits the topic, then proceed to the usual `Read` (which verifies the topic actually exists and clears state on 404 — so a create that silently failed still surfaces correctly instead of crashing).
- **Read**: same guard — a nil topic with a nil error is treated as not found (`d.SetId("")`), matching the existing 404 handling.

No behavior change when the API returns the topic as normal.

## Test plan

- [x] `go build` / `go vet` / `gofmt` clean
- The panic path requires the API to omit the topic body, which the standard acceptance tests can't force; the guard is a straightforward nil check. Happy to add a mocked unit test if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
