### PR TITLE
MDROP-22: add terraform support for microdroplets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Changelog moved to Release Notes in [Github Releases](https://github.com/digitalocean/terraform-provider-digitalocean/releases)
 
+## Unreleased
+
+FEATURES:
+
+- MDROP-22: add `digitalocean_microdroplet` resource
+- MDROP-22: add `digitalocean_microdroplet_image` resource
+- MDROP-22: add `digitalocean_microdroplet` data source
+- MDROP-22: add `digitalocean_microdroplets` data source
+- MDROP-22: add `digitalocean_microdroplet_image` data source
+- MDROP-22: add `digitalocean_microdroplet_images` data source
+- MDROP-22: add `digitalocean_microdroplet_checkpoints` data source
+
 ## 2.48.2
 
 BUGFIXES:

--- a/digitalocean/microdroplet/datasource_microdroplet.go
+++ b/digitalocean/microdroplet/datasource_microdroplet.go
@@ -1,0 +1,91 @@
+package microdroplet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// DataSourceDigitalOceanMicroDroplet returns a data source that looks up a
+// MicroDroplet by `id` or by `name`.
+func DataSourceDigitalOceanMicroDroplet() *schema.Resource {
+	recordSchema := microDropletDataSourceSchema()
+	recordSchema["id"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		Description:  "MicroDroplet ID",
+		ValidateFunc: validation.NoZeroValues,
+		ExactlyOneOf: []string{"id", "name"},
+	}
+	recordSchema["name"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		Description:  "MicroDroplet name",
+		ValidateFunc: validation.NoZeroValues,
+		ExactlyOneOf: []string{"id", "name"},
+	}
+
+	return &schema.Resource{
+		ReadContext: dataSourceDigitalOceanMicroDropletRead,
+		Schema:      recordSchema,
+	}
+}
+
+func dataSourceDigitalOceanMicroDropletRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	var found *godo.MicroDroplet
+	if id, ok := d.GetOk("id"); ok {
+		m, _, err := client.MicroDroplets.Get(ctx, id.(string))
+		if err != nil {
+			return diag.Errorf("Error retrieving MicroDroplet: %s", err)
+		}
+		found = m
+	} else if name, ok := d.GetOk("name"); ok {
+		matches, err := listMicroDropletsByName(ctx, client, name.(string))
+		if err != nil {
+			return diag.Errorf("Error listing MicroDroplets: %s", err)
+		}
+		switch len(matches) {
+		case 0:
+			return diag.Errorf("no MicroDroplet found with name %s", name.(string))
+		case 1:
+			found = &matches[0]
+		default:
+			return diag.Errorf("too many MicroDroplets found with name %s (found %d, expected 1)", name.(string), len(matches))
+		}
+	}
+
+	if err := setMicroDropletAttributes(d, found); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func listMicroDropletsByName(ctx context.Context, client *godo.Client, name string) ([]godo.MicroDroplet, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	var out []godo.MicroDroplet
+	for {
+		batch, resp, err := client.MicroDroplets.ListByName(ctx, name, opts)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, batch...)
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("error paging MicroDroplets: %w", err)
+		}
+		opts.Page = page + 1
+	}
+	return out, nil
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_checkpoints.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_checkpoints.go
@@ -1,0 +1,124 @@
+package microdroplet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/datalist"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// DataSourceDigitalOceanMicroDropletCheckpoints returns a plural data source
+// over the checkpoints belonging to a given MicroDroplet. Checkpoints are
+// created automatically by DigitalOcean when a MicroDroplet pauses; they are
+// read-only from the customer API, so no matching resource is provided.
+func DataSourceDigitalOceanMicroDropletCheckpoints() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema:        microDropletCheckpointSchema(),
+		ResultAttributeName: "checkpoints",
+		GetRecords:          getDigitalOceanMicroDropletCheckpoints,
+		FlattenRecord:       flattenMicroDropletCheckpoint,
+		ExtraQuerySchema: map[string]*schema.Schema{
+			"microdroplet_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "ID of the MicroDroplet whose checkpoints should be listed",
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+	return datalist.NewResource(dataListConfig)
+}
+
+func microDropletCheckpointSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Checkpoint ID",
+		},
+		"microdroplet_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "ID of the parent MicroDroplet",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Checkpoint name",
+		},
+		"status": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Lifecycle status of the checkpoint",
+		},
+		"memory_bytes": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Size of the persisted memory image, in bytes",
+		},
+		"disk_bytes": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Size of the persisted disk image, in bytes",
+		},
+		"created_at": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The creation timestamp for the checkpoint",
+		},
+	}
+}
+
+func flattenMicroDropletCheckpoint(rawRecord, _ interface{}, _ map[string]interface{}) (map[string]interface{}, error) {
+	c, ok := rawRecord.(godo.MicroDropletCheckpoint)
+	if !ok {
+		return nil, fmt.Errorf("unexpected record type %T", rawRecord)
+	}
+	return map[string]interface{}{
+		"id":              c.ID,
+		"microdroplet_id": c.MicroDropletID,
+		"name":            c.Name,
+		"status":          string(c.Status),
+		"memory_bytes":    int(c.MemoryBytes),
+		"disk_bytes":      int(c.DiskBytes),
+		"created_at":      c.Created,
+	}, nil
+}
+
+// getDigitalOceanMicroDropletCheckpoints paginates the ListCheckpoints godo
+// endpoint for the MicroDroplet identified by the required `microdroplet_id`
+// query attribute.
+func getDigitalOceanMicroDropletCheckpoints(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	microdropletID, _ := extra["microdroplet_id"].(string)
+	if microdropletID == "" {
+		return nil, fmt.Errorf("microdroplet_id is required")
+	}
+
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+
+	var records []interface{}
+	for {
+		batch, resp, err := client.MicroDroplets.ListCheckpoints(context.Background(), microdropletID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving checkpoints for MicroDroplet %s: %w", microdropletID, err)
+		}
+		for _, c := range batch {
+			records = append(records, c)
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("error paging MicroDroplet checkpoints: %w", err)
+		}
+		opts.Page = page + 1
+	}
+	return records, nil
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_checkpoints_test.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_checkpoints_test.go
@@ -1,0 +1,51 @@
+package microdroplet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccDataSourceDigitalOceanMicroDropletCheckpoints_Basic pauses a fresh
+// MicroDroplet (which triggers checkpoint creation platform-side) and then
+// reads the digitalocean_microdroplet_checkpoints data source. Because
+// checkpoint creation is asynchronous, we only assert that the datasource
+// returns a well-formed list and that `checkpoints.#` is populated. Callers
+// pausing on production traffic will get a non-zero count once the platform
+// has captured the checkpoint.
+func TestAccDataSourceDigitalOceanMicroDropletCheckpoints_Basic(t *testing.T) {
+	name := acceptance.RandomTestName()
+
+	pausedConfig := fmt.Sprintf(testAccMicroDropletConfig_State,
+		name, testMicroDropletImage, string(godo.MicroDropletStatePaused))
+
+	dsConfig := `
+data "digitalocean_microdroplet_checkpoints" "by_id" {
+  microdroplet_id = digitalocean_microdroplet.foobar.id
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{Config: pausedConfig},
+			{
+				Config: pausedConfig + dsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_microdroplet_checkpoints.by_id",
+						"checkpoints.#",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_microdroplet_checkpoints.by_id",
+						"microdroplet_id",
+					),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_image.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_image.go
@@ -1,0 +1,100 @@
+package microdroplet
+
+import (
+	"context"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// DataSourceDigitalOceanMicroDropletImage returns a data source that looks up
+// a MicroDroplet image by `id` or by `name`. Name lookup requires paging the
+// full image list since the API has no `ListByName` for images.
+func DataSourceDigitalOceanMicroDropletImage() *schema.Resource {
+	recordSchema := microDropletImageDataSourceSchema()
+	recordSchema["id"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		Description:  "MicroDroplet image ID",
+		ValidateFunc: validation.NoZeroValues,
+		ExactlyOneOf: []string{"id", "name"},
+	}
+	recordSchema["name"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		Description:  "MicroDroplet image name",
+		ValidateFunc: validation.NoZeroValues,
+		ExactlyOneOf: []string{"id", "name"},
+	}
+
+	return &schema.Resource{
+		ReadContext: dataSourceDigitalOceanMicroDropletImageRead,
+		Schema:      recordSchema,
+	}
+}
+
+func dataSourceDigitalOceanMicroDropletImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	var found *godo.MicroDropletImage
+	if id, ok := d.GetOk("id"); ok {
+		img, _, err := client.MicroDropletImages.Get(ctx, id.(string))
+		if err != nil {
+			return diag.Errorf("Error retrieving MicroDroplet image: %s", err)
+		}
+		found = img
+	} else if name, ok := d.GetOk("name"); ok {
+		images, err := listAllMicroDropletImages(ctx, client)
+		if err != nil {
+			return diag.Errorf("Error listing MicroDroplet images: %s", err)
+		}
+		var matches []godo.MicroDropletImage
+		for _, img := range images {
+			if img.Name == name.(string) {
+				matches = append(matches, img)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return diag.Errorf("no MicroDroplet image found with name %s", name.(string))
+		case 1:
+			found = &matches[0]
+		default:
+			return diag.Errorf("too many MicroDroplet images found with name %s (found %d, expected 1)", name.(string), len(matches))
+		}
+	}
+
+	d.SetId(found.ID)
+	d.Set("name", found.Name)
+	d.Set("source", found.Source)
+	d.Set("status", string(found.Status))
+	d.Set("created_at", found.Created)
+	d.Set("urn", found.URN())
+	return nil
+}
+
+func listAllMicroDropletImages(ctx context.Context, client *godo.Client) ([]godo.MicroDropletImage, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	var all []godo.MicroDropletImage
+	for {
+		batch, resp, err := client.MicroDropletImages.List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+		opts.Page = page + 1
+	}
+	return all, nil
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_image_test.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_image_test.go
@@ -1,0 +1,57 @@
+package microdroplet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanMicroDropletImage_ByID(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletImageConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplet_image" "byid" {
+  id = digitalocean_microdroplet_image.foobar.id
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplet_image.byid", "name", name),
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplet_image.byid", "urn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanMicroDropletImage_ByName(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletImageConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplet_image" "byname" {
+  name = digitalocean_microdroplet_image.foobar.name
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplet_image.byname", "name", name),
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplet_image.byname", "id"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_images.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_images.go
@@ -1,0 +1,20 @@
+package microdroplet
+
+import (
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/datalist"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DataSourceDigitalOceanMicroDropletImages returns a plural data source over
+// the MicroDroplet images endpoint. No extra server-side filters — godo has
+// no filtered list endpoint for images. Use `filter` and `sort` from the
+// datalist framework for client-side narrowing.
+func DataSourceDigitalOceanMicroDropletImages() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema:        microDropletImageDataSourceSchema(),
+		ResultAttributeName: "micro_droplet_images",
+		GetRecords:          getDigitalOceanMicroDropletImages,
+		FlattenRecord:       flattenMicroDropletImage,
+	}
+	return datalist.NewResource(dataListConfig)
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_images_test.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_images_test.go
@@ -1,0 +1,61 @@
+package microdroplet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanMicroDropletImages_All(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletImageConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplet_images" "all" {
+  depends_on = [digitalocean_microdroplet_image.foobar]
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplet_images.all", "micro_droplet_images.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanMicroDropletImages_Filter(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletImageConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := fmt.Sprintf(`
+data "digitalocean_microdroplet_images" "byname" {
+  depends_on = [digitalocean_microdroplet_image.foobar]
+
+  filter {
+    key    = "name"
+    values = ["%s"]
+  }
+}`, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplet_images.byname", "micro_droplet_images.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplet_images.byname", "micro_droplet_images.0.name", name),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/microdroplet/datasource_microdroplet_test.go
+++ b/digitalocean/microdroplet/datasource_microdroplet_test.go
@@ -1,0 +1,58 @@
+package microdroplet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanMicroDroplet_ByID(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplet" "byid" {
+  id = digitalocean_microdroplet.foobar.id
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplet.byid", "name", name),
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplet.byid", "urn"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplet.byid", "endpoint"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanMicroDroplet_ByName(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplet" "byname" {
+  name = digitalocean_microdroplet.foobar.name
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplet.byname", "name", name),
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplet.byname", "id"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/microdroplet/datasource_microdroplets.go
+++ b/digitalocean/microdroplet/datasource_microdroplets.go
@@ -1,0 +1,31 @@
+package microdroplet
+
+import (
+	"github.com/digitalocean/terraform-provider-digitalocean/internal/datalist"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DataSourceDigitalOceanMicroDroplets returns a plural data source over the
+// MicroDroplets endpoint with optional `region` and `name` server-side
+// filters. `filter` and `sort` (from the datalist framework) apply on top.
+func DataSourceDigitalOceanMicroDroplets() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema:        microDropletDataSourceSchema(),
+		ResultAttributeName: "micro_droplets",
+		GetRecords:          getDigitalOceanMicroDroplets,
+		FlattenRecord:       flattenMicroDroplet,
+		ExtraQuerySchema: map[string]*schema.Schema{
+			"region": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"region"},
+			},
+		},
+	}
+	return datalist.NewResource(dataListConfig)
+}

--- a/digitalocean/microdroplet/datasource_microdroplets_test.go
+++ b/digitalocean/microdroplet/datasource_microdroplets_test.go
@@ -1,0 +1,81 @@
+package microdroplet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanMicroDroplets_All(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplets" "all" {
+  depends_on = [digitalocean_microdroplet.foobar]
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplets.all", "micro_droplets.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanMicroDroplets_ByRegion(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := `
+data "digitalocean_microdroplets" "region" {
+  region     = "nyc3"
+  depends_on = [digitalocean_microdroplet.foobar]
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_microdroplets.region", "micro_droplets.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanMicroDroplets_ByName(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceConfig := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+	dataSourceConfig := fmt.Sprintf(`
+data "digitalocean_microdroplets" "byname" {
+  name       = "%s"
+  depends_on = [digitalocean_microdroplet.foobar]
+}`, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: resourceConfig},
+			{
+				Config: resourceConfig + dataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplets.byname", "micro_droplets.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_microdroplets.byname", "micro_droplets.0.name", name),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/microdroplet/import_microdroplet_test.go
+++ b/digitalocean/microdroplet/import_microdroplet_test.go
@@ -1,0 +1,60 @@
+package microdroplet_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDigitalOceanMicroDroplet_importBasic(t *testing.T) {
+	resourceName := "digitalocean_microdroplet.foobar"
+	name := acceptance.RandomTestName()
+	config := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// `state` is settable-with-default; the API does not persist
+				// user intent so we can't verify it round-trips exactly.
+				ImportStateVerifyIgnore: []string{"state"},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "not-a-real-uuid",
+				ExpectError:       regexp.MustCompile(`(not found|Cannot import non-existent remote object)`),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanMicroDropletImage_importBasic(t *testing.T) {
+	resourceName := "digitalocean_microdroplet_image.foobar"
+	name := acceptance.RandomTestName()
+	config := fmt.Sprintf(testAccMicroDropletImageConfig_Basic, name, testMicroDropletImage)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletImageDestroy,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/digitalocean/microdroplet/microdroplet.go
+++ b/digitalocean/microdroplet/microdroplet.go
@@ -1,0 +1,494 @@
+package microdroplet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/tag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// stateValues is the closed set accepted by the settable `state` attribute on
+// digitalocean_microdroplet. The API also exposes transient values (creating,
+// pausing, resuming, ...) but users should never set those directly.
+var stateValues = []string{
+	string(godo.MicroDropletStateRunning),
+	string(godo.MicroDropletStatePaused),
+}
+
+// networkingValues enumerates the accepted values for the `networking`
+// attribute on digitalocean_microdroplet.
+var networkingValues = []string{
+	string(godo.MicroDropletNetworkingPublic),
+	string(godo.MicroDropletNetworkingVPC),
+}
+
+// httpProtocolValues enumerates the accepted values for the `http_protocol`
+// attribute on digitalocean_microdroplet. The control plane accepts only
+// `http` (HTTP/1.1) and `http2`; `https` is not a valid platform value.
+var httpProtocolValues = []string{
+	string(godo.MicroDropletHTTPProtocolHTTP),
+	string(godo.MicroDropletHTTPProtocolHTTP2),
+}
+
+// tagsSchemaForceNew returns tag.TagsSchema() with ForceNew set. Tags are
+// accepted by MicroDropletCreateRequest but the MicroDroplets API exposes no
+// endpoint to mutate them afterwards, so any change has to recreate the
+// resource. Marking ForceNew keeps Terraform's plan honest — without it,
+// changes would silently no-op on apply.
+func tagsSchemaForceNew() *schema.Schema {
+	s := tag.TagsSchema()
+	s.ForceNew = true
+	return s
+}
+
+// microDropletResourceSchema returns the resource-side schema used by
+// ResourceDigitalOceanMicroDroplet. The data source schemas reuse this via
+// microDropletDataSourceSchema which recasts everything to Computed.
+func microDropletResourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			Description:  "Name of the MicroDroplet",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"region": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			Description:  "DigitalOcean region slug where the MicroDroplet is deployed",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"size": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			Description:  "MicroDroplet size slug",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"image": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			Description:  "MicroDroplet image UUID or URN",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"networking": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			Description:  "Networking mode: 'public' or 'vpc'",
+			ValidateFunc: validation.StringInSlice(networkingValues, false),
+		},
+		"vpc_uuid": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			Description:  "UUID of the VPC to attach the MicroDroplet to. Only valid when networking is 'vpc'.",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"http_port": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ForceNew:     true,
+			Description:  "Port the MicroDroplet exposes over HTTP",
+			ValidateFunc: validation.IntBetween(1, 65535),
+		},
+		"http_protocol": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Description:  "HTTP protocol: 'http' or 'http2'",
+			ValidateFunc: validation.StringInSlice(httpProtocolValues, false),
+		},
+		"environment": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Environment variables passed to the MicroDroplet",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"auto_pause": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    true,
+			MaxItems:    1,
+			Description: "Auto-pause configuration. Forces recreation on change: the MicroDroplets API has no in-place update path for auto_pause.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:        schema.TypeBool,
+						Required:    true,
+						Description: "Whether auto-pause is enabled",
+					},
+					"idle_timeout": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						Computed:     true,
+						Description:  "Idle timeout as a Go duration string (e.g. '5m', '30s')",
+						ValidateFunc: validation.NoZeroValues,
+					},
+				},
+			},
+		},
+		"auto_resume": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    true,
+			Description: "Whether the MicroDroplet should auto-resume on request. Forces recreation on change: the MicroDroplets API has no in-place update path for auto_resume.",
+		},
+		"tags": tagsSchemaForceNew(),
+		"state": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          string(godo.MicroDropletStateRunning),
+			Description:      "Desired lifecycle state: 'running' or 'paused'. Changes are applied by calling the microdroplet pause / resume action endpoints.",
+			ValidateFunc:     validation.StringInSlice(stateValues, false),
+			DiffSuppressFunc: suppressStateDiffWhenAutoPause,
+		},
+		"current_state": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Observed lifecycle state of the MicroDroplet",
+		},
+		"endpoint": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Public endpoint URL for the MicroDroplet",
+		},
+		"created_at": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The creation timestamp for the MicroDroplet",
+		},
+		"urn": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The uniform resource name (URN) for the MicroDroplet",
+		},
+	}
+}
+
+// microDropletDataSourceSchema returns the resource schema recast so every
+// attribute is Computed and safe to expose on the datasource. Filter/select
+// attributes (id, name) are re-set to Optional+Computed by the caller.
+func microDropletDataSourceSchema() map[string]*schema.Schema {
+	base := microDropletResourceSchema()
+	for k, v := range base {
+		clone := *v
+		clone.Required = false
+		clone.Optional = false
+		clone.ForceNew = false
+		clone.Default = nil
+		clone.ValidateFunc = nil
+		clone.DiffSuppressFunc = nil
+		clone.Computed = true
+		// MaxItems/MinItems are only meaningful for configurable attributes;
+		// the plugin SDK rejects them on Computed-only fields.
+		clone.MaxItems = 0
+		clone.MinItems = 0
+		base[k] = &clone
+	}
+	// godo.MicroDroplet has no Tags field, so tags cannot round-trip through
+	// the datasource. Dropping the attribute is more honest than exposing an
+	// always-empty set that would silently break filter { key = "tags" }.
+	delete(base, "tags")
+	return base
+}
+
+// microDropletImageResourceSchema returns the resource-side schema used by
+// ResourceDigitalOceanMicroDropletImage.
+func microDropletImageResourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			Description:  "Name of the MicroDroplet image",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"source": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			Description:  "Source OCI reference for the MicroDroplet image",
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"status": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Lifecycle status of the MicroDroplet image",
+		},
+		"created_at": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The creation timestamp for the MicroDroplet image",
+		},
+		"urn": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The uniform resource name (URN) for the MicroDroplet image",
+		},
+	}
+}
+
+func microDropletImageDataSourceSchema() map[string]*schema.Schema {
+	base := microDropletImageResourceSchema()
+	for k, v := range base {
+		clone := *v
+		clone.Required = false
+		clone.Optional = false
+		clone.ForceNew = false
+		clone.Default = nil
+		clone.ValidateFunc = nil
+		clone.DiffSuppressFunc = nil
+		clone.Computed = true
+		clone.MaxItems = 0
+		clone.MinItems = 0
+		base[k] = &clone
+	}
+	return base
+}
+
+// suppressStateDiffWhenAutoPause suppresses spurious `state` diffs when
+// auto_pause is enabled: the API can flip the observed state to `paused` at
+// any time, and Terraform should not fight the platform in that case. The
+// diff is only suppressed when moving from `paused` (observed) to `running`
+// (config) — the reverse (user explicitly requesting `paused`) always applies.
+func suppressStateDiffWhenAutoPause(_, oldValue, newValue string, d *schema.ResourceData) bool {
+	if !autoPauseEnabled(d) {
+		return false
+	}
+	return oldValue == string(godo.MicroDropletStatePaused) &&
+		newValue == string(godo.MicroDropletStateRunning)
+}
+
+// autoPauseEnabled returns true when the resource config declares an
+// `auto_pause` block with `enabled = true`.
+func autoPauseEnabled(d *schema.ResourceData) bool {
+	raw, ok := d.GetOk("auto_pause")
+	if !ok {
+		return false
+	}
+	list, ok := raw.([]interface{})
+	if !ok || len(list) == 0 || list[0] == nil {
+		return false
+	}
+	entry, ok := list[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	enabled, _ := entry["enabled"].(bool)
+	return enabled
+}
+
+// expandAutoPause turns the `auto_pause` HCL block into a godo AutoPauseConfig.
+// Returns nil when the block is empty.
+func expandAutoPause(raw interface{}) *godo.AutoPauseConfig {
+	list, ok := raw.([]interface{})
+	if !ok || len(list) == 0 || list[0] == nil {
+		return nil
+	}
+	entry, ok := list[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	cfg := &godo.AutoPauseConfig{}
+	if v, ok := entry["enabled"].(bool); ok {
+		cfg.Enabled = godo.PtrTo(v)
+	}
+	if v, ok := entry["idle_timeout"].(string); ok && v != "" {
+		cfg.IdleTimeout = v
+	}
+	return cfg
+}
+
+// flattenAutoPause converts a godo AutoPauseConfig back into the list-of-map
+// shape that Terraform expects for a single-item block.
+func flattenAutoPause(cfg *godo.AutoPauseConfig) []interface{} {
+	if cfg == nil {
+		return nil
+	}
+	entry := map[string]interface{}{}
+	if cfg.Enabled != nil {
+		entry["enabled"] = *cfg.Enabled
+	} else {
+		entry["enabled"] = false
+	}
+	entry["idle_timeout"] = cfg.IdleTimeout
+	return []interface{}{entry}
+}
+
+// expandEnvironment converts the `environment` map[string]interface{} that
+// Terraform produces into the map[string]string that godo expects.
+func expandEnvironment(raw interface{}) map[string]string {
+	m, ok := raw.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// setMicroDropletAttributes writes the state observed on a godo.MicroDroplet
+// into the ResourceData without touching the settable `state` attribute
+// (which reflects user intent, not observed state).
+//
+// `tags` are deliberately not written back: godo.MicroDroplet has no Tags
+// field, so we cannot verify what the platform actually stored. The resource
+// keeps whatever tags the user configured at create time in state; changing
+// them recreates the resource (see tagsSchemaForceNew).
+func setMicroDropletAttributes(d *schema.ResourceData, m *godo.MicroDroplet) error {
+	if m == nil {
+		return fmt.Errorf("cannot set attributes from nil MicroDroplet")
+	}
+	d.SetId(m.ID)
+	d.Set("name", m.Name)
+	d.Set("region", m.Region)
+	d.Set("size", m.Size)
+	d.Set("image", m.Image)
+	d.Set("networking", string(m.Networking))
+	d.Set("endpoint", m.Endpoint)
+	d.Set("current_state", string(m.State))
+	d.Set("created_at", m.Created)
+	d.Set("urn", m.URN())
+
+	if err := d.Set("auto_pause", flattenAutoPause(m.AutoPause)); err != nil {
+		return fmt.Errorf("error setting auto_pause: %w", err)
+	}
+	if m.AutoResume != nil {
+		d.Set("auto_resume", *m.AutoResume)
+	}
+	return nil
+}
+
+// flattenMicroDroplet flattens a godo.MicroDroplet into the map shape the
+// datalist datasource expects.
+func flattenMicroDroplet(rawRecord, _ interface{}, _ map[string]interface{}) (map[string]interface{}, error) {
+	m, ok := rawRecord.(godo.MicroDroplet)
+	if !ok {
+		return nil, fmt.Errorf("unexpected record type %T", rawRecord)
+	}
+	out := map[string]interface{}{
+		"id":            m.ID,
+		"name":          m.Name,
+		"region":        m.Region,
+		"size":          m.Size,
+		"image":         m.Image,
+		"networking":    string(m.Networking),
+		"endpoint":      m.Endpoint,
+		"current_state": string(m.State),
+		"state":         string(m.State),
+		"created_at":    m.Created,
+		"urn":           m.URN(),
+		"auto_pause":    flattenAutoPause(m.AutoPause),
+	}
+	if m.AutoResume != nil {
+		out["auto_resume"] = *m.AutoResume
+	} else {
+		out["auto_resume"] = false
+	}
+	return out, nil
+}
+
+// flattenMicroDropletImage flattens a godo.MicroDropletImage for the datalist
+// datasource.
+func flattenMicroDropletImage(rawRecord, _ interface{}, _ map[string]interface{}) (map[string]interface{}, error) {
+	i, ok := rawRecord.(godo.MicroDropletImage)
+	if !ok {
+		return nil, fmt.Errorf("unexpected record type %T", rawRecord)
+	}
+	return map[string]interface{}{
+		"id":         i.ID,
+		"name":       i.Name,
+		"source":     i.Source,
+		"status":     string(i.Status),
+		"created_at": i.Created,
+		"urn":        i.URN(),
+	}, nil
+}
+
+// getDigitalOceanMicroDroplets is the GetRecords callback for the plural
+// MicroDroplet datasource. It supports optional region and name filters via
+// the ExtraQuerySchema.
+func getDigitalOceanMicroDroplets(meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	region, _ := extra["region"].(string)
+	name, _ := extra["name"].(string)
+
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+
+	var records []interface{}
+	for {
+		var (
+			batch []godo.MicroDroplet
+			resp  *godo.Response
+			err   error
+		)
+		switch {
+		case region != "":
+			batch, resp, err = client.MicroDroplets.ListByRegion(context.Background(), region, opts)
+		case name != "":
+			batch, resp, err = client.MicroDroplets.ListByName(context.Background(), name, opts)
+		default:
+			batch, resp, err = client.MicroDroplets.List(context.Background(), opts)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving MicroDroplets: %w", err)
+		}
+		for _, m := range batch {
+			records = append(records, m)
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("error paging MicroDroplets: %w", err)
+		}
+		opts.Page = page + 1
+	}
+	return records, nil
+}
+
+// getDigitalOceanMicroDropletImages is the GetRecords callback for the plural
+// MicroDroplet image datasource.
+func getDigitalOceanMicroDropletImages(meta interface{}, _ map[string]interface{}) ([]interface{}, error) {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	var records []interface{}
+	for {
+		batch, resp, err := client.MicroDropletImages.List(context.Background(), opts)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving MicroDroplet images: %w", err)
+		}
+		for _, i := range batch {
+			records = append(records, i)
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("error paging MicroDroplet images: %w", err)
+		}
+		opts.Page = page + 1
+	}
+	return records, nil
+}

--- a/digitalocean/microdroplet/microdroplet.go
+++ b/digitalocean/microdroplet/microdroplet.go
@@ -127,13 +127,15 @@ func microDropletResourceSchema() map[string]*schema.Schema {
 					"enabled": {
 						Type:        schema.TypeBool,
 						Required:    true,
-						Description: "Whether auto-pause is enabled",
+						ForceNew:    true,
+						Description: "Whether auto-pause is enabled. Forces recreation on change (no in-place API path).",
 					},
 					"idle_timeout": {
 						Type:         schema.TypeString,
 						Optional:     true,
 						Computed:     true,
-						Description:  "Idle timeout as a Go duration string (e.g. '5m', '30s')",
+						ForceNew:     true,
+						Description:  "Idle timeout as a Go duration string (e.g. '5m', '30s'). Forces recreation on change (no in-place API path).",
 						ValidateFunc: validation.NoZeroValues,
 					},
 				},

--- a/digitalocean/microdroplet/resource_microdroplet.go
+++ b/digitalocean/microdroplet/resource_microdroplet.go
@@ -1,0 +1,233 @@
+package microdroplet
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/tag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceDigitalOceanMicroDroplet returns the digitalocean_microdroplet
+// resource schema.
+func ResourceDigitalOceanMicroDroplet() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDigitalOceanMicroDropletCreate,
+		ReadContext:   resourceDigitalOceanMicroDropletRead,
+		UpdateContext: resourceDigitalOceanMicroDropletUpdate,
+		DeleteContext: resourceDigitalOceanMicroDropletDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: microDropletResourceSchema(),
+	}
+}
+
+func resourceDigitalOceanMicroDropletCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	req := &godo.MicroDropletCreateRequest{
+		Name:   d.Get("name").(string),
+		Region: d.Get("region").(string),
+		Size:   d.Get("size").(string),
+		Image:  d.Get("image").(string),
+	}
+
+	if v, ok := d.GetOk("networking"); ok {
+		req.Networking = godo.MicroDropletNetworking(v.(string))
+	}
+	if v, ok := d.GetOk("vpc_uuid"); ok {
+		req.VPCUUID = v.(string)
+	}
+	if v, ok := d.GetOk("http_port"); ok {
+		req.HTTPPort = uint32(v.(int))
+	}
+	if v, ok := d.GetOk("http_protocol"); ok {
+		req.HTTPProtocol = godo.MicroDropletHTTPProtocol(v.(string))
+	}
+	if v, ok := d.GetOk("environment"); ok {
+		req.Environment = expandEnvironment(v)
+	}
+	if v, ok := d.GetOk("auto_pause"); ok {
+		req.AutoPause = expandAutoPause(v)
+	}
+	if v, ok := d.GetOkExists("auto_resume"); ok {
+		req.AutoResume = godo.PtrTo(v.(bool))
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		req.Tags = tag.ExpandTags(v.(*schema.Set).List())
+	}
+
+	log.Printf("[DEBUG] MicroDroplet create request: %+v", req)
+
+	m, _, err := client.MicroDroplets.Create(ctx, req)
+	if err != nil {
+		return diag.Errorf("Error creating MicroDroplet: %s", err)
+	}
+
+	d.SetId(m.ID)
+	log.Printf("[INFO] MicroDroplet created, ID: %s", d.Id())
+
+	if _, err := waitForMicroDropletState(
+		ctx, client, d.Id(),
+		godo.MicroDropletStateRunning,
+		// `unknown` is a legal transient right after POST — treat it as
+		// pending so the waiter doesn't bail with `unexpected state 'unknown'`.
+		[]godo.MicroDropletState{godo.MicroDropletStateUnknown, godo.MicroDropletStateCreating},
+		d.Timeout(schema.TimeoutCreate),
+	); err != nil {
+		return diag.Errorf("Error waiting for MicroDroplet (%s) to become running: %s", d.Id(), err)
+	}
+
+	// Config asked for paused — transition after create so we deterministically
+	// observe the "running -> paused" flow rather than racing the API.
+	if desired := d.Get("state").(string); desired == string(godo.MicroDropletStatePaused) {
+		if err := transitionMicroDropletState(ctx, client, d.Id(), godo.MicroDropletStatePaused, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceDigitalOceanMicroDropletRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanMicroDropletRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	m, resp, err := client.MicroDroplets.Get(ctx, d.Id())
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			log.Printf("[WARN] MicroDroplet (%s) not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error retrieving MicroDroplet: %s", err)
+	}
+
+	if err := setMicroDropletAttributes(d, m); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+// resourceDigitalOceanMicroDropletUpdate handles the only in-place mutation
+// the MicroDroplets API supports: the desired lifecycle `state` (running /
+// paused) via the Pause and Resume action endpoints.
+//
+// Every other user-configurable attribute on the resource — auto_pause,
+// auto_resume, tags, environment, http_port, http_protocol, networking, etc.
+// — is marked ForceNew because godo's MicroDropletsService exposes no update
+// endpoint for them. Without ForceNew, plan changes would silently no-op on
+// apply (clean plan, "1 changed", no API call, then Read overwrites state)
+// causing invisible drift like a user lowering auto_pause.idle_timeout to
+// cut cost but the platform keeping the old timeout.
+func resourceDigitalOceanMicroDropletUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	if d.HasChange("state") {
+		target := godo.MicroDropletState(d.Get("state").(string))
+		if err := transitionMicroDropletState(ctx, client, d.Id(), target, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceDigitalOceanMicroDropletRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanMicroDropletDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	resp, err := client.MicroDroplets.Delete(ctx, d.Id())
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return diag.Errorf("Error deleting MicroDroplet: %s", err)
+	}
+
+	log.Printf("[INFO] MicroDroplet deleted, ID: %s", d.Id())
+	d.SetId("")
+	return nil
+}
+
+// transitionMicroDropletState invokes the dedicated Pause / Resume action
+// endpoint on the MicroDroplets API and then polls until the observed state
+// matches. Used both by CreateContext (create-then-pause) and UpdateContext
+// (user-driven pause/resume).
+//
+// godo's Pause / Resume are documented as synchronous, but we still poll
+// afterwards as a belt-and-suspenders check: fake API servers used in tests
+// and edge cases in the platform can return before the state is fully
+// reflected on Get.
+func transitionMicroDropletState(ctx context.Context, client *godo.Client, id string, target godo.MicroDropletState, timeout time.Duration) error {
+	var pending []godo.MicroDropletState
+	switch target {
+	case godo.MicroDropletStatePaused:
+		// Include `unknown` — the API can briefly report it between the
+		// action returning and the state settling on Get.
+		pending = []godo.MicroDropletState{godo.MicroDropletStateUnknown, godo.MicroDropletStateRunning, godo.MicroDropletStatePausing}
+		log.Printf("[INFO] Pausing MicroDroplet (%s)", id)
+		if _, _, err := client.MicroDroplets.Pause(ctx, id); err != nil {
+			return fmt.Errorf("error pausing MicroDroplet (%s): %w", id, err)
+		}
+	case godo.MicroDropletStateRunning:
+		pending = []godo.MicroDropletState{godo.MicroDropletStateUnknown, godo.MicroDropletStatePaused, godo.MicroDropletStateResuming}
+		log.Printf("[INFO] Resuming MicroDroplet (%s)", id)
+		if _, _, err := client.MicroDroplets.Resume(ctx, id); err != nil {
+			return fmt.Errorf("error resuming MicroDroplet (%s): %w", id, err)
+		}
+	default:
+		return fmt.Errorf("unsupported target MicroDroplet state %q", target)
+	}
+
+	if _, err := waitForMicroDropletState(ctx, client, id, target, pending, timeout); err != nil {
+		return fmt.Errorf("error waiting for MicroDroplet (%s) to reach state %s: %w", id, target, err)
+	}
+	return nil
+}
+
+// waitForMicroDropletState polls MicroDroplets.Get until the observed state
+// matches target, or the timeout elapses. `pending` should list every state
+// that is legally a step on the way to `target`.
+func waitForMicroDropletState(ctx context.Context, client *godo.Client, id string, target godo.MicroDropletState, pending []godo.MicroDropletState, timeout time.Duration) (interface{}, error) {
+	log.Printf("[INFO] Waiting for MicroDroplet (%s) to reach state %s", id, target)
+
+	pendingStrs := make([]string, len(pending))
+	for i, s := range pending {
+		pendingStrs[i] = string(s)
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending:    pendingStrs,
+		Target:     []string{string(target)},
+		Refresh:    microDropletStateRefreshFunc(ctx, client, id),
+		Timeout:    timeout,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func microDropletStateRefreshFunc(ctx context.Context, client *godo.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		m, _, err := client.MicroDroplets.Get(ctx, id)
+		if err != nil {
+			return nil, "", err
+		}
+		if m.State == godo.MicroDropletStateFailed {
+			return m, string(m.State), fmt.Errorf("MicroDroplet %s entered failed state", id)
+		}
+		return m, string(m.State), nil
+	}
+}

--- a/digitalocean/microdroplet/resource_microdroplet_image.go
+++ b/digitalocean/microdroplet/resource_microdroplet_image.go
@@ -1,0 +1,133 @@
+package microdroplet
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceDigitalOceanMicroDropletImage returns the
+// digitalocean_microdroplet_image resource schema. Images are immutable —
+// there is no UpdateContext. All fields are ForceNew.
+func ResourceDigitalOceanMicroDropletImage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDigitalOceanMicroDropletImageCreate,
+		ReadContext:   resourceDigitalOceanMicroDropletImageRead,
+		DeleteContext: resourceDigitalOceanMicroDropletImageDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: microDropletImageResourceSchema(),
+	}
+}
+
+func resourceDigitalOceanMicroDropletImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	req := &godo.MicroDropletImageCreateRequest{
+		Name:   d.Get("name").(string),
+		Source: d.Get("source").(string),
+	}
+
+	log.Printf("[DEBUG] MicroDroplet image create request: %+v", req)
+	image, _, err := client.MicroDropletImages.Create(ctx, req)
+	if err != nil {
+		return diag.Errorf("Error creating MicroDroplet image: %s", err)
+	}
+
+	d.SetId(image.ID)
+	log.Printf("[INFO] MicroDroplet image created, ID: %s", d.Id())
+
+	if _, err := waitForMicroDropletImage(ctx, client, d.Id(), godo.MicroDropletImageStatusAvailable, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("Error waiting for MicroDroplet image (%s) to become available: %s", d.Id(), err)
+	}
+
+	return resourceDigitalOceanMicroDropletImageRead(ctx, d, meta)
+}
+
+func resourceDigitalOceanMicroDropletImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	image, resp, err := client.MicroDropletImages.Get(ctx, d.Id())
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			log.Printf("[WARN] MicroDroplet image (%s) not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error retrieving MicroDroplet image: %s", err)
+	}
+
+	if image.Status == godo.MicroDropletImageStatusDeleted {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(image.ID)
+	d.Set("name", image.Name)
+	d.Set("source", image.Source)
+	d.Set("status", string(image.Status))
+	d.Set("created_at", image.Created)
+	d.Set("urn", image.URN())
+	return nil
+}
+
+func resourceDigitalOceanMicroDropletImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	resp, err := client.MicroDropletImages.Delete(ctx, d.Id())
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return diag.Errorf("Error deleting MicroDroplet image: %s", err)
+	}
+
+	log.Printf("[INFO] MicroDroplet image deleted, ID: %s", d.Id())
+	d.SetId("")
+	return nil
+}
+
+// waitForMicroDropletImage polls MicroDropletImages.Get until the observed
+// status matches target, or the timeout elapses.
+func waitForMicroDropletImage(ctx context.Context, client *godo.Client, id string, target godo.MicroDropletImageStatus, timeout time.Duration) (interface{}, error) {
+	log.Printf("[INFO] Waiting for MicroDroplet image (%s) to have status %s", id, target)
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			string(godo.MicroDropletImageStatusUnknown),
+			string(godo.MicroDropletImageStatusImporting),
+		},
+		Target:     []string{string(target)},
+		Refresh:    microDropletImageStateRefreshFunc(ctx, client, id),
+		Timeout:    timeout,
+		Delay:      5 * time.Second,
+		MinTimeout: 10 * time.Second,
+	}
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func microDropletImageStateRefreshFunc(ctx context.Context, client *godo.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		image, _, err := client.MicroDropletImages.Get(ctx, id)
+		if err != nil {
+			return nil, "", err
+		}
+		if image.Status == godo.MicroDropletImageStatusFailed {
+			return image, string(image.Status), fmt.Errorf("MicroDroplet image %s entered failed state", id)
+		}
+		return image, string(image.Status), nil
+	}
+}

--- a/digitalocean/microdroplet/resource_microdroplet_image_test.go
+++ b/digitalocean/microdroplet/resource_microdroplet_image_test.go
@@ -1,0 +1,83 @@
+package microdroplet_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDigitalOceanMicroDropletImage_Basic(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet_image.foobar"
+	config := fmt.Sprintf(testAccMicroDropletImageConfig_Basic, name, testMicroDropletImage)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletImageExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "source", testMicroDropletImage),
+					resource.TestCheckResourceAttr(resourceName, "status", string(godo.MicroDropletImageStatusAvailable)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMicroDropletImageExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID set for MicroDroplet image resource: %s", name)
+		}
+
+		img, _, err := client.MicroDropletImages.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if img.ID != rs.Primary.ID {
+			return fmt.Errorf("MicroDroplet image not found: %s / %s", name, rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckMicroDropletImageDestroy(s *terraform.State) error {
+	client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_microdroplet_image" {
+			continue
+		}
+		img, _, err := client.MicroDropletImages.Get(context.Background(), rs.Primary.ID)
+		if err == nil && img.Status != godo.MicroDropletImageStatusDeleted {
+			return fmt.Errorf("MicroDroplet image %s still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+const testAccMicroDropletImageConfig_Basic = `
+resource "digitalocean_microdroplet_image" "foobar" {
+  name   = "%s"
+  source = "%s"
+}
+`

--- a/digitalocean/microdroplet/resource_microdroplet_test.go
+++ b/digitalocean/microdroplet/resource_microdroplet_test.go
@@ -131,24 +131,33 @@ func TestAccDigitalOceanMicroDroplet_ResumeAfterPause(t *testing.T) {
 }
 
 // TestAccDigitalOceanMicroDroplet_RecreateOnAutoPauseChange verifies that
-// auto_pause is genuinely ForceNew: adding or changing the block recreates
-// the resource (new ID) rather than silently no-op'ing on the Update path.
+// auto_pause is genuinely ForceNew at every level users can edit: adding
+// the block, changing idle_timeout inside an existing block, and flipping
+// enabled true -> false all recreate the resource (new ID) rather than
+// silently no-op'ing on the Update path.
+//
 // The MicroDroplets API has no endpoint to mutate auto_pause in place, so
-// this recreate is the only way changes actually take effect.
+// recreate is the only way changes actually take effect. Without ForceNew
+// on the nested `enabled` and `idle_timeout` schemas, edits inside an
+// existing block produced RequiresNew=false plans that Update swallowed —
+// leaving a perpetual diff for users tuning or disabling auto-pause.
 func TestAccDigitalOceanMicroDroplet_RecreateOnAutoPauseChange(t *testing.T) {
 	name := acceptance.RandomTestName()
 	resourceName := "digitalocean_microdroplet.foobar"
 
 	without := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
-	with := fmt.Sprintf(testAccMicroDropletConfig_AutoPause, name, testMicroDropletImage, "10m")
+	withFive := fmt.Sprintf(testAccMicroDropletConfig_AutoPause, name, testMicroDropletImage, "5m")
+	withTen := fmt.Sprintf(testAccMicroDropletConfig_AutoPause, name, testMicroDropletImage, "10m")
+	withDisabled := fmt.Sprintf(testAccMicroDropletConfig_AutoPauseDisabled, name, testMicroDropletImage)
 
-	var firstID, secondID string
+	var firstID, secondID, thirdID, fourthID string
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckMicroDropletDestroy,
 		Steps: []resource.TestStep{
+			// Baseline: no auto_pause block.
 			{
 				Config: without,
 				Check: resource.ComposeTestCheckFunc(
@@ -156,14 +165,38 @@ func TestAccDigitalOceanMicroDroplet_RecreateOnAutoPauseChange(t *testing.T) {
 					captureMicroDropletID(resourceName, &firstID),
 				),
 			},
+			// Add the block (0 -> 1). Existing coverage.
 			{
-				Config: with,
+				Config: withFive,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.idle_timeout", "5m"),
+					captureMicroDropletID(resourceName, &secondID),
+					assertIDChanged(&firstID, &secondID),
+				),
+			},
+			// Edit idle_timeout inside the existing block (5m -> 10m). Guarded
+			// by ForceNew on the nested `idle_timeout` field.
+			{
+				Config: withTen,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMicroDropletExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.idle_timeout", "10m"),
-					captureMicroDropletID(resourceName, &secondID),
-					assertIDChanged(&firstID, &secondID),
+					captureMicroDropletID(resourceName, &thirdID),
+					assertIDChanged(&secondID, &thirdID),
+				),
+			},
+			// Flip enabled true -> false inside the existing block. Guarded
+			// by ForceNew on the nested `enabled` field.
+			{
+				Config: withDisabled,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.enabled", "false"),
+					captureMicroDropletID(resourceName, &fourthID),
+					assertIDChanged(&thirdID, &fourthID),
 				),
 			},
 		},
@@ -310,6 +343,23 @@ resource "digitalocean_microdroplet" "foobar" {
   auto_pause {
     enabled      = true
     idle_timeout = "%s"
+  }
+}
+`
+
+// testAccMicroDropletConfig_AutoPauseDisabled exercises the enabled=false
+// path so tests can assert that flipping the toggle inside an existing block
+// recreates the resource (guarded by ForceNew on the nested `enabled` field).
+// idle_timeout is omitted because the schema marks it Optional+Computed.
+const testAccMicroDropletConfig_AutoPauseDisabled = `
+resource "digitalocean_microdroplet" "foobar" {
+  name   = "%s"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = "%s"
+
+  auto_pause {
+    enabled = false
   }
 }
 `

--- a/digitalocean/microdroplet/resource_microdroplet_test.go
+++ b/digitalocean/microdroplet/resource_microdroplet_test.go
@@ -1,0 +1,338 @@
+package microdroplet_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/acceptance"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDigitalOceanMicroDroplet_Basic(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet.foobar"
+	config := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "region", testMicroDropletRegion),
+					resource.TestCheckResourceAttr(resourceName, "size", testMicroDropletSize),
+					resource.TestCheckResourceAttr(resourceName, "state", string(godo.MicroDropletStateRunning)),
+					resource.TestCheckResourceAttr(resourceName, "current_state", string(godo.MicroDropletStateRunning)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanMicroDroplet_Full(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet.foobar"
+	config := fmt.Sprintf(testAccMicroDropletConfig_Full, name, testMicroDropletImage)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "http_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "http_protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.idle_timeout", "5m"),
+					resource.TestCheckResourceAttr(resourceName, "auto_resume", "true"),
+					resource.TestCheckResourceAttr(resourceName, "environment.FOO", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanMicroDroplet_Pause(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet.foobar"
+
+	running := fmt.Sprintf(testAccMicroDropletConfig_State, name, testMicroDropletImage, string(godo.MicroDropletStateRunning))
+	paused := fmt.Sprintf(testAccMicroDropletConfig_State, name, testMicroDropletImage, string(godo.MicroDropletStatePaused))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: running,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", string(godo.MicroDropletStateRunning)),
+					resource.TestCheckResourceAttr(resourceName, "current_state", string(godo.MicroDropletStateRunning)),
+				),
+			},
+			{
+				Config: paused,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", string(godo.MicroDropletStatePaused)),
+					resource.TestCheckResourceAttr(resourceName, "current_state", string(godo.MicroDropletStatePaused)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanMicroDroplet_ResumeAfterPause(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet.foobar"
+
+	paused := fmt.Sprintf(testAccMicroDropletConfig_State, name, testMicroDropletImage, string(godo.MicroDropletStatePaused))
+	running := fmt.Sprintf(testAccMicroDropletConfig_State, name, testMicroDropletImage, string(godo.MicroDropletStateRunning))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: paused,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current_state", string(godo.MicroDropletStatePaused)),
+				),
+			},
+			{
+				Config: running,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current_state", string(godo.MicroDropletStateRunning)),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDigitalOceanMicroDroplet_RecreateOnAutoPauseChange verifies that
+// auto_pause is genuinely ForceNew: adding or changing the block recreates
+// the resource (new ID) rather than silently no-op'ing on the Update path.
+// The MicroDroplets API has no endpoint to mutate auto_pause in place, so
+// this recreate is the only way changes actually take effect.
+func TestAccDigitalOceanMicroDroplet_RecreateOnAutoPauseChange(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet.foobar"
+
+	without := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, testMicroDropletImage)
+	with := fmt.Sprintf(testAccMicroDropletConfig_AutoPause, name, testMicroDropletImage, "10m")
+
+	var firstID, secondID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: without,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					captureMicroDropletID(resourceName, &firstID),
+				),
+			},
+			{
+				Config: with,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_pause.0.idle_timeout", "10m"),
+					captureMicroDropletID(resourceName, &secondID),
+					assertIDChanged(&firstID, &secondID),
+				),
+			},
+		},
+	})
+}
+
+// captureMicroDropletID snapshots the current primary ID of the named
+// resource into out, so a subsequent step can assert whether the resource
+// was recreated (ID changed) or updated in place (ID retained).
+func captureMicroDropletID(name string, out *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+		*out = rs.Primary.ID
+		return nil
+	}
+}
+
+// assertIDChanged fails if the two captured IDs match, i.e. Terraform kept
+// the resource in place when the test expected a ForceNew recreate.
+func assertIDChanged(before, after *string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if *before == "" || *after == "" {
+			return fmt.Errorf("captured IDs not populated (before=%q after=%q)", *before, *after)
+		}
+		if *before == *after {
+			return fmt.Errorf("expected MicroDroplet to be recreated (ForceNew), but ID stayed %q", *before)
+		}
+		return nil
+	}
+}
+
+func TestAccDigitalOceanMicroDroplet_ImmutableFields(t *testing.T) {
+	name := acceptance.RandomTestName()
+	resourceName := "digitalocean_microdroplet.foobar"
+
+	firstImage := testMicroDropletImage
+	secondImage := testMicroDropletImageAlt
+
+	first := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, firstImage)
+	second := fmt.Sprintf(testAccMicroDropletConfig_Basic, name, secondImage)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMicroDropletDestroy,
+		Steps: []resource.TestStep{
+			{Config: first},
+			{
+				Config: second,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMicroDropletExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "image", secondImage),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMicroDropletExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID set for MicroDroplet resource: %s", name)
+		}
+
+		m, _, err := client.MicroDroplets.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if m.ID != rs.Primary.ID {
+			return fmt.Errorf("MicroDroplet not found: %s / %s", name, rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckMicroDropletDestroy(s *terraform.State) error {
+	client := acceptance.TestAccProvider.Meta().(*config.CombinedConfig).GodoClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_microdroplet" {
+			continue
+		}
+		_, _, err := client.MicroDroplets.Get(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("MicroDroplet %s still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+const (
+	// testMicroDropletRegion is the region used across microdroplet acceptance
+	// tests. Override with DO_MICRODROPLET_REGION if the default is not
+	// available on the test account.
+	testMicroDropletRegion = "nyc3"
+
+	// testMicroDropletSize is the smallest MicroDroplet size slug.
+	testMicroDropletSize = "microdroplet-1"
+
+	// testMicroDropletImage is a MicroDroplet image reference known to the
+	// test account.
+	testMicroDropletImage = "docker.io/library/nginx:latest"
+
+	// testMicroDropletImageAlt is a second image reference used to prove
+	// ForceNew semantics on `image` changes.
+	testMicroDropletImageAlt = "docker.io/library/httpd:latest"
+)
+
+const testAccMicroDropletConfig_Basic = `
+resource "digitalocean_microdroplet" "foobar" {
+  name   = "%s"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = "%s"
+}
+`
+
+const testAccMicroDropletConfig_State = `
+resource "digitalocean_microdroplet" "foobar" {
+  name   = "%s"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = "%s"
+  state  = "%s"
+}
+`
+
+const testAccMicroDropletConfig_AutoPause = `
+resource "digitalocean_microdroplet" "foobar" {
+  name   = "%s"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = "%s"
+
+  auto_pause {
+    enabled      = true
+    idle_timeout = "%s"
+  }
+}
+`
+
+const testAccMicroDropletConfig_Full = `
+resource "digitalocean_microdroplet" "foobar" {
+  name          = "%s"
+  region        = "nyc3"
+  size          = "microdroplet-1"
+  image         = "%s"
+  http_port     = 8080
+  http_protocol = "http"
+  auto_resume   = true
+
+  auto_pause {
+    enabled      = true
+    idle_timeout = "5m"
+  }
+
+  environment = {
+    FOO = "bar"
+  }
+
+  tags = ["tf-acc-test-microdroplet"]
+}
+`

--- a/digitalocean/microdroplet/sweep.go
+++ b/digitalocean/microdroplet/sweep.go
@@ -1,0 +1,93 @@
+package microdroplet
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/sweep"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("digitalocean_microdroplet", &resource.Sweeper{
+		Name: "digitalocean_microdroplet",
+		F:    sweepMicroDroplets,
+	})
+	resource.AddTestSweepers("digitalocean_microdroplet_image", &resource.Sweeper{
+		Name: "digitalocean_microdroplet_image",
+		// Images may be referenced by MicroDroplets, so sweep them second.
+		Dependencies: []string{"digitalocean_microdroplet"},
+		F:            sweepMicroDropletImages,
+	})
+}
+
+func sweepMicroDroplets(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opt := &godo.ListOptions{PerPage: 200}
+	for {
+		mds, resp, err := client.MicroDroplets.List(context.Background(), opt)
+		if err != nil {
+			return err
+		}
+		for _, m := range mds {
+			if !strings.HasPrefix(m.Name, sweep.TestNamePrefix) {
+				continue
+			}
+			log.Printf("[DEBUG] Destroying MicroDroplet %s (%s)", m.Name, m.ID)
+			if _, err := client.MicroDroplets.Delete(context.Background(), m.ID); err != nil {
+				return err
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return err
+		}
+		opt.Page = page + 1
+	}
+	return nil
+}
+
+func sweepMicroDropletImages(region string) error {
+	meta, err := sweep.SharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+	client := meta.(*config.CombinedConfig).GodoClient()
+
+	opt := &godo.ListOptions{PerPage: 200}
+	for {
+		images, resp, err := client.MicroDropletImages.List(context.Background(), opt)
+		if err != nil {
+			return err
+		}
+		for _, img := range images {
+			if !strings.HasPrefix(img.Name, sweep.TestNamePrefix) {
+				continue
+			}
+			log.Printf("[DEBUG] Destroying MicroDroplet image %s (%s)", img.Name, img.ID)
+			if _, err := client.MicroDropletImages.Delete(context.Background(), img.ID); err != nil {
+				return err
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return err
+		}
+		opt.Page = page + 1
+	}
+	return nil
+}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/image"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer"
+	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/microdroplet"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/monitoring"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/nfs"
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/partnernetworkconnect"
@@ -132,6 +133,11 @@ func Provider() *schema.Provider {
 			"digitalocean_kubernetes_cluster":                      kubernetes.DataSourceDigitalOceanKubernetesCluster(),
 			"digitalocean_kubernetes_versions":                     kubernetes.DataSourceDigitalOceanKubernetesVersions(),
 			"digitalocean_loadbalancer":                            loadbalancer.DataSourceDigitalOceanLoadbalancer(),
+			"digitalocean_microdroplet":                            microdroplet.DataSourceDigitalOceanMicroDroplet(),
+			"digitalocean_microdroplet_checkpoints":                microdroplet.DataSourceDigitalOceanMicroDropletCheckpoints(),
+			"digitalocean_microdroplet_image":                      microdroplet.DataSourceDigitalOceanMicroDropletImage(),
+			"digitalocean_microdroplet_images":                     microdroplet.DataSourceDigitalOceanMicroDropletImages(),
+			"digitalocean_microdroplets":                           microdroplet.DataSourceDigitalOceanMicroDroplets(),
 			"digitalocean_project":                                 project.DataSourceDigitalOceanProject(),
 			"digitalocean_projects":                                project.DataSourceDigitalOceanProjects(),
 			"digitalocean_record":                                  domain.DataSourceDigitalOceanRecord(),
@@ -222,6 +228,8 @@ func Provider() *schema.Provider {
 			"digitalocean_kubernetes_cluster":                         kubernetes.ResourceDigitalOceanKubernetesCluster(),
 			"digitalocean_kubernetes_node_pool":                       kubernetes.ResourceDigitalOceanKubernetesNodePool(),
 			"digitalocean_loadbalancer":                               loadbalancer.ResourceDigitalOceanLoadbalancer(),
+			"digitalocean_microdroplet":                               microdroplet.ResourceDigitalOceanMicroDroplet(),
+			"digitalocean_microdroplet_image":                         microdroplet.ResourceDigitalOceanMicroDropletImage(),
 			"digitalocean_monitor_alert":                              monitoring.ResourceDigitalOceanMonitorAlert(),
 			"digitalocean_project":                                    project.ResourceDigitalOceanProject(),
 			"digitalocean_project_resources":                          project.ResourceDigitalOceanProjectResources(),

--- a/digitalocean/sweep/sweep_test.go
+++ b/digitalocean/sweep/sweep_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/image"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/kubernetes"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/loadbalancer"
+	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/microdroplet"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/monitoring"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/project"
 	_ "github.com/digitalocean/terraform-provider-digitalocean/digitalocean/reservedip"

--- a/docs/data-sources/microdroplet.md
+++ b/docs/data-sources/microdroplet.md
@@ -1,0 +1,35 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplet"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplet
+
+Fetches a single [DigitalOcean MicroDroplet](https://docs.digitalocean.com/products/microdroplets/) by `id` or by `name`.
+
+## Example Usage
+
+```hcl
+data "digitalocean_microdroplet" "byid" {
+  id = "506f78a4-e098-11e5-ad9f-000f53306ae1"
+}
+
+data "digitalocean_microdroplet" "byname" {
+  name = "my-microdroplet"
+}
+```
+
+## Argument Reference
+
+Exactly one of the following must be provided:
+
+* `id` - (Optional) The MicroDroplet UUID.
+* `name` - (Optional) The MicroDroplet name. Errors if zero or more than one match.
+
+## Attributes Reference
+
+The following attributes are exported. See the [resource docs](../resources/microdroplet.md) for descriptions:
+
+* `region`, `size`, `image`, `networking`, `vpc_uuid`, `http_port`, `http_protocol`, `environment`, `auto_pause`, `auto_resume`, `endpoint`, `current_state`, `created_at`, `urn`.
+
+~> **Note:** `tags` are intentionally not exported. The MicroDroplets API does not return the tags attached at create time, so the data source cannot round-trip them. See the [resource docs](../resources/microdroplet.md) for details.

--- a/docs/data-sources/microdroplet_checkpoints.md
+++ b/docs/data-sources/microdroplet_checkpoints.md
@@ -1,0 +1,57 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplet_checkpoints"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplet_checkpoints
+
+Fetches the list of checkpoints belonging to a [DigitalOcean MicroDroplet](https://docs.digitalocean.com/products/microdroplets/).
+
+Checkpoints are read-only artifacts: DigitalOcean captures one automatically each time a MicroDroplet is paused, preserving the memory and disk state needed to resume. They cannot be created or deleted directly through the customer API, so this provider only exposes them as a data source.
+
+## Example Usage
+
+```hcl
+resource "digitalocean_microdroplet" "example" {
+  name   = "example-microdroplet"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = "docker.io/library/nginx:latest"
+
+  auto_pause {
+    enabled      = true
+    idle_timeout = "5m"
+  }
+}
+
+data "digitalocean_microdroplet_checkpoints" "example" {
+  microdroplet_id = digitalocean_microdroplet.example.id
+}
+
+output "checkpoint_ids" {
+  value = [for c in data.digitalocean_microdroplet_checkpoints.example.checkpoints : c.id]
+}
+```
+
+## Argument Reference
+
+* `microdroplet_id` - (Required) ID of the MicroDroplet whose checkpoints should be listed.
+* `filter` - (Optional) Repeatable client-side filter block:
+  * `key` - (Required) Field to match. Valid keys include `id`, `name`, `status`.
+  * `values` - (Required) List of values to match on `key`.
+  * `all` - (Optional) Require every value to match. Defaults to `false`.
+  * `match_by` - (Optional) `exact`, `re`, or `substring`. Defaults to `exact`.
+* `sort` - (Optional) Repeatable client-side sort block:
+  * `key` - (Required) Field to sort by (e.g. `created_at`).
+  * `direction` - (Optional) `asc` (default) or `desc`.
+
+## Attributes Reference
+
+* `checkpoints` - A list of checkpoint records. Each entry contains:
+  * `id` - Checkpoint ID.
+  * `microdroplet_id` - ID of the parent MicroDroplet.
+  * `name` - Checkpoint name.
+  * `status` - Lifecycle status of the checkpoint (e.g. `CHECKPOINT_AVAILABLE`).
+  * `memory_bytes` - Size of the persisted memory image, in bytes.
+  * `disk_bytes` - Size of the persisted disk image, in bytes.
+  * `created_at` - RFC3339 timestamp of when the checkpoint was created.

--- a/docs/data-sources/microdroplet_image.md
+++ b/docs/data-sources/microdroplet_image.md
@@ -1,0 +1,36 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplet_image"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplet_image
+
+Fetches a single [DigitalOcean MicroDroplet image](https://docs.digitalocean.com/products/microdroplets/) by `id` or by `name`.
+
+Name lookups page through the full image list on the account since the API has no filtered list endpoint for images.
+
+## Example Usage
+
+```hcl
+data "digitalocean_microdroplet_image" "byid" {
+  id = "4a2c9f10-3d18-4b6a-9e3d-2b7f8e0f1c11"
+}
+
+data "digitalocean_microdroplet_image" "byname" {
+  name = "my-app-v1"
+}
+```
+
+## Argument Reference
+
+Exactly one of the following must be provided:
+
+* `id` - (Optional) The MicroDroplet image UUID.
+* `name` - (Optional) The MicroDroplet image name. Errors if zero or more than one match.
+
+## Attributes Reference
+
+* `source` - The OCI reference used when the image was imported.
+* `status` - Lifecycle status.
+* `created_at` - RFC3339 timestamp of when the image was created.
+* `urn` - The uniform resource name (URN) for the MicroDroplet image.

--- a/docs/data-sources/microdroplet_images.md
+++ b/docs/data-sources/microdroplet_images.md
@@ -1,0 +1,43 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplet_images"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplet_images
+
+Fetches a list of [DigitalOcean MicroDroplet images](https://docs.digitalocean.com/products/microdroplets/) on the account. No server-side filters — narrow the results using `filter` and `sort`.
+
+## Example Usage
+
+```hcl
+data "digitalocean_microdroplet_images" "all" {}
+
+data "digitalocean_microdroplet_images" "available" {
+  filter {
+    key    = "status"
+    values = ["IMAGE_AVAILABLE"]
+  }
+}
+
+data "digitalocean_microdroplet_images" "newest_first" {
+  sort {
+    key       = "created_at"
+    direction = "desc"
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Repeatable client-side filter block:
+  * `key` - (Required) Field to match.
+  * `values` - (Required) List of values to match on `key`.
+  * `all` - (Optional) Require every value to match. Defaults to `false`.
+  * `match_by` - (Optional) `exact`, `re`, or `substring`. Defaults to `exact`.
+* `sort` - (Optional) Repeatable client-side sort block:
+  * `key` - (Required) Field to sort by.
+  * `direction` - (Optional) `asc` (default) or `desc`.
+
+## Attributes Reference
+
+* `micro_droplet_images` - A list of MicroDroplet image records. Each record has the same attribute set as the `digitalocean_microdroplet_image` data source.

--- a/docs/data-sources/microdroplets.md
+++ b/docs/data-sources/microdroplets.md
@@ -1,0 +1,46 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplets"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplets
+
+Fetches a list of [DigitalOcean MicroDroplets](https://docs.digitalocean.com/products/microdroplets/) with optional `region` and `name` server-side filters, plus `filter` and `sort` blocks for client-side narrowing.
+
+## Example Usage
+
+```hcl
+data "digitalocean_microdroplets" "all" {}
+
+data "digitalocean_microdroplets" "nyc3" {
+  region = "nyc3"
+}
+
+data "digitalocean_microdroplets" "by_name" {
+  name = "my-microdroplet"
+}
+
+data "digitalocean_microdroplets" "running" {
+  filter {
+    key    = "current_state"
+    values = ["running"]
+  }
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) Server-side filter: only include MicroDroplets in this region. Conflicts with `name`.
+* `name` - (Optional) Server-side filter: only include MicroDroplets whose name matches exactly. Conflicts with `region`.
+* `filter` - (Optional) Repeatable client-side filter block:
+  * `key` - (Required) Field to match.
+  * `values` - (Required) List of values to match on `key`.
+  * `all` - (Optional) Require every value to match. Defaults to `false`.
+  * `match_by` - (Optional) `exact`, `re`, or `substring`. Defaults to `exact`.
+* `sort` - (Optional) Repeatable client-side sort block:
+  * `key` - (Required) Field to sort by.
+  * `direction` - (Optional) `asc` (default) or `desc`.
+
+## Attributes Reference
+
+* `micro_droplets` - A list of MicroDroplet records. Each record has the same attribute set as the `digitalocean_microdroplet` data source.

--- a/docs/resources/microdroplet.md
+++ b/docs/resources/microdroplet.md
@@ -1,0 +1,86 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplet"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplet
+
+Provides a [DigitalOcean MicroDroplet](https://docs.digitalocean.com/products/microdroplets/) resource. MicroDroplets run OCI images and can auto-pause when idle to reduce cost.
+
+## Example Usage
+
+```hcl
+resource "digitalocean_microdroplet" "example" {
+  name   = "example-microdroplet"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = "docker.io/library/nginx:latest"
+
+  http_port     = 8080
+  http_protocol = "http"
+
+  auto_pause {
+    enabled      = true
+    idle_timeout = "5m"
+  }
+
+  auto_resume = true
+
+  environment = {
+    LOG_LEVEL = "info"
+  }
+
+  tags = ["web", "prod"]
+}
+```
+
+### Pausing and resuming
+
+The `state` attribute is settable and defaults to `running`. Changing it to `paused` calls the MicroDroplet pause action endpoint; changing it back to `running` calls the resume action endpoint. Neither triggers recreation:
+
+```hcl
+resource "digitalocean_microdroplet" "example" {
+  # ...
+  state = "paused"
+}
+```
+
+Setting `state = "running"` on a paused MicroDroplet resumes it. When `auto_pause` is enabled, the platform may transition the MicroDroplet to `paused` on its own — Terraform suppresses the diff in that case so it does not fight the platform.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the MicroDroplet. Forces recreation on change.
+* `region` - (Required) DigitalOcean region slug for the MicroDroplet's location. Forces recreation on change.
+* `size` - (Required) MicroDroplet size slug. Forces recreation on change.
+* `image` - (Required) MicroDroplet image reference (UUID or URN). Forces recreation on change.
+* `networking` - (Optional) Networking mode: `public` (default) or `vpc`. Forces recreation on change.
+* `vpc_uuid` - (Optional) UUID of a VPC to attach to. Only valid when `networking = "vpc"`. Forces recreation on change.
+* `http_port` - (Optional) HTTP port to expose. Forces recreation on change.
+* `http_protocol` - (Optional) HTTP protocol: `http` or `http2`. Forces recreation on change.
+* `environment` - (Optional) Map of environment variables passed to the MicroDroplet at boot. Forces recreation on change.
+* `auto_pause` - (Optional) Auto-pause configuration block. Forces recreation on change: the MicroDroplets API has no in-place update path for auto_pause.
+  * `enabled` - (Required) Whether auto-pause is enabled.
+  * `idle_timeout` - (Optional) Idle timeout as a Go duration string (e.g. `5m`, `30s`).
+* `auto_resume` - (Optional) Whether the MicroDroplet auto-resumes when it receives a request. Forces recreation on change: the MicroDroplets API has no in-place update path for auto_resume.
+* `tags` - (Optional) Set of tags applied to the MicroDroplet at create time. Forces recreation on change: MicroDroplets are not exposed via the shared `/v2/tags` API, so tags cannot be added, removed, or verified after creation. They also do not populate on `terraform import` or on `digitalocean_microdroplet` / `digitalocean_microdroplets` data sources.
+* `state` - (Optional) Desired lifecycle state. One of `running` (default) or `paused`. Changes are applied by invoking the pause / resume action endpoints and do not recreate the resource. This is the only attribute the provider can mutate in place.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The MicroDroplet UUID.
+* `urn` - The uniform resource name (URN) for the MicroDroplet.
+* `endpoint` - Public endpoint URL for the MicroDroplet.
+* `current_state` - Observed lifecycle state of the MicroDroplet (may differ transiently from `state` while a transition is in progress).
+* `created_at` - RFC3339 timestamp of when the MicroDroplet was created.
+
+## Import
+
+A MicroDroplet can be imported using its `id`, e.g.
+
+```
+terraform import digitalocean_microdroplet.example 506f78a4-e098-11e5-ad9f-000f53306ae1
+```

--- a/docs/resources/microdroplet_image.md
+++ b/docs/resources/microdroplet_image.md
@@ -1,0 +1,50 @@
+---
+page_title: "DigitalOcean: digitalocean_microdroplet_image"
+subcategory: "MicroDroplets"
+---
+
+# digitalocean_microdroplet_image
+
+Provides a [DigitalOcean MicroDroplet image](https://docs.digitalocean.com/products/microdroplets/) resource. Images are OCI references imported into DigitalOcean and consumed by `digitalocean_microdroplet` resources.
+
+Both `name` and `source` are immutable — changing either recreates the image. There is no in-place update; images are create-only and delete-only.
+
+## Example Usage
+
+```hcl
+resource "digitalocean_microdroplet_image" "example" {
+  name   = "my-app-v1"
+  source = "docker.io/myorg/my-app:v1"
+}
+
+resource "digitalocean_microdroplet" "example" {
+  name   = "my-app"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = digitalocean_microdroplet_image.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the MicroDroplet image. Forces recreation on change.
+* `source` - (Required) OCI reference to import (e.g. `docker.io/library/nginx:latest` or a DOCR ref). Forces recreation on change.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The MicroDroplet image UUID.
+* `urn` - The uniform resource name (URN) for the MicroDroplet image.
+* `status` - Lifecycle status (`IMAGE_AVAILABLE` once import completes).
+* `created_at` - RFC3339 timestamp of when the image was created.
+
+## Import
+
+A MicroDroplet image can be imported using its `id`, e.g.
+
+```
+terraform import digitalocean_microdroplet_image.example 4a2c9f10-3d18-4b6a-9e3d-2b7f8e0f1c11
+```

--- a/examples/microdroplet/main.tf
+++ b/examples/microdroplet/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = ">= 2.49.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  # export DIGITALOCEAN_TOKEN="Your API TOKEN"
+}
+
+# Import a MicroDroplet image from a public OCI reference. Image import is
+# asynchronous; Terraform waits until the import completes before proceeding.
+resource "digitalocean_microdroplet_image" "web" {
+  name   = "example-nginx"
+  source = "docker.io/library/nginx:latest"
+}
+
+# Provision a MicroDroplet backed by the imported image. auto_pause causes the
+# MicroDroplet to pause automatically after 5 minutes of idleness, and
+# auto_resume brings it back up on the next request.
+resource "digitalocean_microdroplet" "web" {
+  name   = "example-microdroplet"
+  region = "nyc3"
+  size   = "microdroplet-1"
+  image  = digitalocean_microdroplet_image.web.id
+
+  http_port     = 80
+  http_protocol = "http"
+
+  auto_pause {
+    enabled      = true
+    idle_timeout = "5m"
+  }
+
+  auto_resume = true
+
+  environment = {
+    LOG_LEVEL = "info"
+  }
+
+  tags = ["example", "microdroplet"]
+}
+
+# Read all checkpoints belonging to the MicroDroplet. Checkpoints are captured
+# automatically by DigitalOcean each time the MicroDroplet pauses.
+data "digitalocean_microdroplet_checkpoints" "web" {
+  microdroplet_id = digitalocean_microdroplet.web.id
+}
+
+output "endpoint" {
+  description = "Public endpoint URL for the MicroDroplet"
+  value       = digitalocean_microdroplet.web.endpoint
+}
+
+output "checkpoint_ids" {
+  description = "IDs of all checkpoints captured for this MicroDroplet"
+  value       = [for c in data.digitalocean_microdroplet_checkpoints.web.checkpoints : c.id]
+}


### PR DESCRIPTION
Add resources and data sources for DigitalOcean MicroDroplets and MicroDroplet images, plus a data source for reading MicroDroplet checkpoints.

New:
- digitalocean_microdroplet (resource)
- digitalocean_microdroplet_image (resource)
- digitalocean_microdroplet (data source)
- digitalocean_microdroplets (data source, plural)
- digitalocean_microdroplet_image (data source)
- digitalocean_microdroplet_images (data source, plural)
- digitalocean_microdroplet_checkpoints (data source, plural; read-only, since checkpoints are captured automatically by DO when a MicroDroplet pauses)

State transitions on the microdroplet resource use the dedicated pause / resume action endpoints exposed in godo v1.200.0, rather than a PATCH on the resource, matching the doctl implementation.

Bumps github.com/digitalocean/godo v1.163.0 -> v1.200.0 (required: the microdroplet client and MicroDropletCheckpoint type were introduced in v1.200.0). Follow-on fixes in unrelated packages caused by the bump:

- genai: client.GenAI -> client.GradientAI (godo renamed the field)
- app: AppIngressSpecRuleStringMatch.{Prefix,Exact} are now *string
- kubernetes: KubernetesClusterCreateRequest.HA is now *bool