### PR TITLE
Add DOKS DRA plugins and GPU partition mode

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -137,6 +137,36 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				},
 			},
 
+			nvidiaGpuDraDriverField: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			amdGpuDraDriverField: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			rdmaSharedDevicePluginField: {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -58,9 +58,7 @@ data "digitalocean_kubernetes_cluster" "foobar" {
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "cluster_autoscaler_configuration.0.expanders.0", "priority"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "routing_agent.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "p2p_oci_registry_plugin.0.enabled", "true"),
-					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_plugin.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_metrics_exporter_plugin.0.enabled", "true"),
-					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_device_plugin.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_dra_driver.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "amd_gpu_dra_driver.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "rdma_shared_device_plugin.0.enabled", "true"),
@@ -113,15 +111,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
     enabled = true
   }
 
-  amd_gpu_device_plugin {
-    enabled = true
-  }
-
   amd_gpu_device_metrics_exporter_plugin {
-    enabled = true
-  }
-
-  nvidia_gpu_device_plugin {
     enabled = true
   }
 

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -61,6 +61,8 @@ data "digitalocean_kubernetes_cluster" "foobar" {
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_plugin.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_metrics_exporter_plugin.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_device_plugin.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_dra_driver.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "amd_gpu_dra_driver.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "rdma_shared_device_plugin.0.enabled", "true"),
 				),
 			},
@@ -120,6 +122,14 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   }
 
   nvidia_gpu_device_plugin {
+    enabled = true
+  }
+
+  nvidia_gpu_dra_driver {
+    enabled = true
+  }
+
+  amd_gpu_dra_driver {
     enabled = true
   }
 

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -210,6 +210,7 @@ func expandNodePools(nodePools []interface{}) []*godo.KubernetesNodePool {
 	expandedNodePools := make([]*godo.KubernetesNodePool, 0, len(nodePools))
 	for _, rawPool := range nodePools {
 		pool := rawPool.(map[string]interface{})
+		gpuPartitionMode, _ := pool["gpu_partition_mode"].(string)
 		cr := &godo.KubernetesNodePool{
 			ID:               pool["id"].(string),
 			Name:             pool["name"].(string),
@@ -222,7 +223,7 @@ func expandNodePools(nodePools []interface{}) []*godo.KubernetesNodePool {
 			Labels:           expandLabels(pool["labels"].(map[string]interface{})),
 			Nodes:            expandNodes(pool["nodes"].([]interface{})),
 			Taints:           expandNodePoolTaints(pool["taint"].(*schema.Set).List()),
-			GPUPartitionMode: pool["gpu_partition_mode"].(string),
+			GPUPartitionMode: gpuPartitionMode,
 		}
 
 		expandedNodePools = append(expandedNodePools, cr)

--- a/digitalocean/kubernetes/kubernetes.go
+++ b/digitalocean/kubernetes/kubernetes.go
@@ -97,6 +97,16 @@ func nodePoolSchema(isResource bool) map[string]*schema.Schema {
 			Optional: true,
 			Elem:     nodePoolTaintSchema(),
 		},
+
+		"gpu_partition_mode": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				godo.KubernetesAMDPartitionModeSPXNPS1,
+				godo.KubernetesAMDPartitionModeDPXNPS2,
+			}, false),
+		},
 	}
 
 	if isResource {
@@ -201,17 +211,18 @@ func expandNodePools(nodePools []interface{}) []*godo.KubernetesNodePool {
 	for _, rawPool := range nodePools {
 		pool := rawPool.(map[string]interface{})
 		cr := &godo.KubernetesNodePool{
-			ID:        pool["id"].(string),
-			Name:      pool["name"].(string),
-			Size:      pool["size"].(string),
-			Count:     pool["node_count"].(int),
-			AutoScale: pool["auto_scale"].(bool),
-			MinNodes:  pool["min_nodes"].(int),
-			MaxNodes:  pool["max_nodes"].(int),
-			Tags:      tag.ExpandTags(pool["tags"].(*schema.Set).List()),
-			Labels:    expandLabels(pool["labels"].(map[string]interface{})),
-			Nodes:     expandNodes(pool["nodes"].([]interface{})),
-			Taints:    expandNodePoolTaints(pool["taint"].(*schema.Set).List()),
+			ID:               pool["id"].(string),
+			Name:             pool["name"].(string),
+			Size:             pool["size"].(string),
+			Count:            pool["node_count"].(int),
+			AutoScale:        pool["auto_scale"].(bool),
+			MinNodes:         pool["min_nodes"].(int),
+			MaxNodes:         pool["max_nodes"].(int),
+			Tags:             tag.ExpandTags(pool["tags"].(*schema.Set).List()),
+			Labels:           expandLabels(pool["labels"].(map[string]interface{})),
+			Nodes:            expandNodes(pool["nodes"].([]interface{})),
+			Taints:           expandNodePoolTaints(pool["taint"].(*schema.Set).List()),
+			GPUPartitionMode: pool["gpu_partition_mode"].(string),
 		}
 
 		expandedNodePools = append(expandedNodePools, cr)
@@ -402,6 +413,58 @@ func flattenNvidiaGpuDevicePluginOpts(opts *godo.KubernetesNvidiaGpuDevicePlugin
 	return result
 }
 
+func expandNvidiaGpuDraDriverOpts(raw []interface{}) *godo.KubernetesNvidiaGpuDraDriver {
+	if len(raw) == 0 || raw[0] == nil {
+		return &godo.KubernetesNvidiaGpuDraDriver{}
+	}
+
+	nvidiaGpuDraDriverObj := raw[0].(map[string]interface{})
+
+	return &godo.KubernetesNvidiaGpuDraDriver{
+		Enabled: godo.PtrTo(nvidiaGpuDraDriverObj["enabled"].(bool)),
+	}
+}
+
+func flattenNvidiaGpuDraDriverOpts(opts *godo.KubernetesNvidiaGpuDraDriver) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	if opts == nil {
+		return result
+	}
+
+	item := make(map[string]interface{})
+	item["enabled"] = opts.Enabled
+
+	result = append(result, item)
+
+	return result
+}
+
+func expandAmdGpuDraDriverOpts(raw []interface{}) *godo.KubernetesAmdGpuDraDriver {
+	if len(raw) == 0 || raw[0] == nil {
+		return &godo.KubernetesAmdGpuDraDriver{}
+	}
+
+	amdGpuDraDriverObj := raw[0].(map[string]interface{})
+
+	return &godo.KubernetesAmdGpuDraDriver{
+		Enabled: godo.PtrTo(amdGpuDraDriverObj["enabled"].(bool)),
+	}
+}
+
+func flattenAmdGpuDraDriverOpts(opts *godo.KubernetesAmdGpuDraDriver) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	if opts == nil {
+		return result
+	}
+
+	item := make(map[string]interface{})
+	item["enabled"] = opts.Enabled
+
+	result = append(result, item)
+
+	return result
+}
+
 func expandRdmaSharedDevicePluginOpts(raw []interface{}) *godo.KubernetesRdmaSharedDevicePlugin {
 	if len(raw) == 0 || raw[0] == nil {
 		return &godo.KubernetesRdmaSharedDevicePlugin{}
@@ -487,14 +550,15 @@ func flattenControlPlaneFirewallOpts(opts *godo.KubernetesControlPlaneFirewall) 
 
 func flattenNodePool(d *schema.ResourceData, keyPrefix string, pool *godo.KubernetesNodePool, parentTags ...string) []interface{} {
 	rawPool := map[string]interface{}{
-		"id":                pool.ID,
-		"name":              pool.Name,
-		"size":              pool.Size,
-		"actual_node_count": pool.Count,
-		"auto_scale":        pool.AutoScale,
-		"min_nodes":         pool.MinNodes,
-		"max_nodes":         pool.MaxNodes,
-		"taint":             pool.Taints,
+		"id":                 pool.ID,
+		"name":               pool.Name,
+		"size":               pool.Size,
+		"actual_node_count":  pool.Count,
+		"auto_scale":         pool.AutoScale,
+		"min_nodes":          pool.MinNodes,
+		"max_nodes":          pool.MaxNodes,
+		"taint":              pool.Taints,
+		"gpu_partition_mode": pool.GPUPartitionMode,
 	}
 
 	if pool.Tags != nil {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -32,6 +32,8 @@ const (
 	amdGpuDevicePluginField                = "amd_gpu_device_plugin"
 	amdGpuDeviceMetricsExporterPluginField = "amd_gpu_device_metrics_exporter_plugin"
 	nvidiaGpuDevicePluginField             = "nvidia_gpu_device_plugin"
+	nvidiaGpuDraDriverField                = "nvidia_gpu_dra_driver"
+	amdGpuDraDriverField                   = "amd_gpu_dra_driver"
 	rdmaSharedDevicePluginField            = "rdma_shared_device_plugin"
 	corednsAutoscalerField                 = "coredns_autoscaler"
 )
@@ -379,6 +381,36 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 				},
 			},
 
+			nvidiaGpuDraDriverField: {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			amdGpuDraDriverField: {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			rdmaSharedDevicePluginField: {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -491,15 +523,16 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 	for i, pool := range pools {
 		tags := append(pool.Tags, DigitaloceanKubernetesDefaultNodePoolTag)
 		poolCreateRequests[i] = &godo.KubernetesNodePoolCreateRequest{
-			Name:      pool.Name,
-			Size:      pool.Size,
-			Tags:      tags,
-			Labels:    pool.Labels,
-			Count:     pool.Count,
-			AutoScale: pool.AutoScale,
-			MinNodes:  pool.MinNodes,
-			MaxNodes:  pool.MaxNodes,
-			Taints:    pool.Taints,
+			Name:             pool.Name,
+			Size:             pool.Size,
+			Tags:             tags,
+			Labels:           pool.Labels,
+			Count:            pool.Count,
+			AutoScale:        pool.AutoScale,
+			MinNodes:         pool.MinNodes,
+			MaxNodes:         pool.MaxNodes,
+			Taints:           pool.Taints,
+			GPUPartitionMode: pool.GPUPartitionMode,
 		}
 	}
 
@@ -570,6 +603,14 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 
 	if nvidiaGpuDevicePlugin, ok := d.GetOk(nvidiaGpuDevicePluginField); ok {
 		opts.NvidiaGpuDevicePlugin = expandNvidiaGpuDevicePluginOpts(nvidiaGpuDevicePlugin.([]interface{}))
+	}
+
+	if nvidiaGpuDraDriver, ok := d.GetOk(nvidiaGpuDraDriverField); ok {
+		opts.NvidiaGpuDraDriver = expandNvidiaGpuDraDriverOpts(nvidiaGpuDraDriver.([]interface{}))
+	}
+
+	if amdGpuDraDriver, ok := d.GetOk(amdGpuDraDriverField); ok {
+		opts.AmdGpuDraDriver = expandAmdGpuDraDriverOpts(amdGpuDraDriver.([]interface{}))
 	}
 
 	if rdmaSharedDevicePlugin, ok := d.GetOk(rdmaSharedDevicePluginField); ok {
@@ -668,6 +709,14 @@ func digitaloceanKubernetesClusterRead(
 		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", nvidiaGpuDevicePluginField, err)
 	}
 
+	if err := d.Set(nvidiaGpuDraDriverField, flattenNvidiaGpuDraDriverOpts(cluster.NvidiaGpuDraDriver)); err != nil {
+		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", nvidiaGpuDraDriverField, err)
+	}
+
+	if err := d.Set(amdGpuDraDriverField, flattenAmdGpuDraDriverOpts(cluster.AmdGpuDraDriver)); err != nil {
+		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", amdGpuDraDriverField, err)
+	}
+
 	if err := d.Set(rdmaSharedDevicePluginField, flattenRdmaSharedDevicePluginOpts(cluster.RdmaSharedDevicePlugin)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", rdmaSharedDevicePluginField, err)
 	}
@@ -744,7 +793,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 	// Figure out the changes and then call the appropriate API methods
 	if d.HasChanges("name", "tags", "auto_upgrade", "surge_upgrade", "maintenance_policy", "ha",
 		controlPlaneFirewallField, "cluster_autoscaler_configuration", routingAgentField, p2pOciRegistryPluginField, amdGpuDevicePluginField,
-		amdGpuDeviceMetricsExporterPluginField, nvidiaGpuDevicePluginField, rdmaSharedDevicePluginField,
+		amdGpuDeviceMetricsExporterPluginField, nvidiaGpuDevicePluginField, nvidiaGpuDraDriverField, amdGpuDraDriverField, rdmaSharedDevicePluginField,
 		corednsAutoscalerField, "sso") {
 
 		opts := &godo.KubernetesClusterUpdateRequest{
@@ -759,6 +808,8 @@ func resourceDigitalOceanKubernetesClusterUpdate(ctx context.Context, d *schema.
 			AmdGpuDevicePlugin:                expandAmdGpuDevicePluginOpts(d.Get(amdGpuDevicePluginField).([]interface{})),
 			AmdGpuDeviceMetricsExporterPlugin: expandAmdGpuDeviceMetricsExporterPluginOpts(d.Get(amdGpuDeviceMetricsExporterPluginField).([]interface{})),
 			NvidiaGpuDevicePlugin:             expandNvidiaGpuDevicePluginOpts(d.Get(nvidiaGpuDevicePluginField).([]interface{})),
+			NvidiaGpuDraDriver:                expandNvidiaGpuDraDriverOpts(d.Get(nvidiaGpuDraDriverField).([]interface{})),
+			AmdGpuDraDriver:                   expandAmdGpuDraDriverOpts(d.Get(amdGpuDraDriverField).([]interface{})),
 			RdmaSharedDevicePlugin:            expandRdmaSharedDevicePluginOpts(d.Get(rdmaSharedDevicePluginField).([]interface{})),
 			CorednsAutoscaler:                 expandCorednsAutoscalerOpts(d.Get(corednsAutoscalerField).([]interface{})),
 			ClusterAutoscalerConfiguration:    expandCAConfigOptsForUpdate(d.GetChange("cluster_autoscaler_configuration")),

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -337,10 +337,11 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			},
 
 			amdGpuDevicePluginField: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{amdGpuDraDriverField},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -367,10 +368,11 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			},
 
 			nvidiaGpuDevicePluginField: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{nvidiaGpuDraDriverField},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -382,10 +384,11 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			},
 
 			nvidiaGpuDraDriverField: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{nvidiaGpuDevicePluginField},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -397,10 +400,11 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 			},
 
 			amdGpuDraDriverField: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{amdGpuDevicePluginField},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"testing"
@@ -1143,6 +1144,65 @@ func TestAccDigitalOceanKubernetesCluster_AmdGpuDraDriverEnabled(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanKubernetesCluster_NvidiaGpuDraConflictsWithDevicePlugin(t *testing.T) {
+	rName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDigitalOceanKubernetesConfigNvidiaGpuDraConflictsWithDevicePlugin(testClusterVersionPrevious, rName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`"nvidia_gpu_dra_driver": conflicts with nvidia_gpu_device_plugin`),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanKubernetesCluster_AmdGpuDraConflictsWithDevicePlugin(t *testing.T) {
+	rName := acceptance.RandomTestName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDigitalOceanKubernetesConfigAmdGpuDraConflictsWithDevicePlugin(testClusterVersionPrevious, rName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`"amd_gpu_dra_driver": conflicts with amd_gpu_device_plugin`),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanKubernetesCluster_GpuPartitionMode(t *testing.T) {
+	amdGPUSize := os.Getenv("DO_AMD_GPU_SIZE")
+	if amdGPUSize == "" {
+		t.Skip("DO_AMD_GPU_SIZE must be set to an AMD GPU–capable Droplet size for gpu_partition_mode acceptance tests")
+	}
+
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigGpuPartitionMode(testClusterVersionPrevious, rName, amdGPUSize),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.gpu_partition_mode", godo.KubernetesAMDPartitionModeSPXNPS1),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanKubernetesCluster_RdmaSharedDevicePluginEnabled(t *testing.T) {
 	rName := acceptance.RandomTestName()
 	var k8s godo.KubernetesCluster
@@ -1627,6 +1687,70 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   }
 }
 `, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigNvidiaGpuDraConflictsWithDevicePlugin(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
+  nvidia_gpu_device_plugin {
+    enabled = true
+  }
+  nvidia_gpu_dra_driver {
+    enabled = true
+  }
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigAmdGpuDraConflictsWithDevicePlugin(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
+  amd_gpu_device_plugin {
+    enabled = true
+  }
+  amd_gpu_dra_driver {
+    enabled = true
+  }
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigGpuPartitionMode(testClusterVersion string, rName string, size string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
+  node_pool {
+    name               = "default"
+    size               = "%s"
+    node_count         = 1
+    gpu_partition_mode = "%s"
+  }
+}
+`, testClusterVersion, rName, size, godo.KubernetesAMDPartitionModeSPXNPS1)
 }
 
 func testAccDigitalOceanKubernetesConfigRdmaSharedDevicePluginEnabled(testClusterVersion string, rName string) string {

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -104,6 +104,8 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "amd_gpu_device_metrics_exporter_plugin.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "coredns_autoscaler.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_device_plugin.0.enabled", "false"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_dra_driver.0.enabled", "false"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "amd_gpu_dra_driver.0.enabled", "false"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "rdma_shared_device_plugin.0.enabled", "false"),
 				),
 			},
@@ -1101,6 +1103,46 @@ func TestAccDigitalOceanKubernetesCluster_NvidiaGpuDevicePluginEnabled(t *testin
 	})
 }
 
+func TestAccDigitalOceanKubernetesCluster_NvidiaGpuDraDriverEnabled(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigNvidiaGpuDraDriverEnabled(testClusterVersionPrevious, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "nvidia_gpu_dra_driver.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanKubernetesCluster_AmdGpuDraDriverEnabled(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigAmdGpuDraDriverEnabled(testClusterVersionPrevious, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "amd_gpu_dra_driver.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanKubernetesCluster_RdmaSharedDevicePluginEnabled(t *testing.T) {
 	rName := acceptance.RandomTestName()
 	var k8s godo.KubernetesCluster
@@ -1536,6 +1578,46 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   version = data.digitalocean_kubernetes_versions.test.latest_version
   ha      = false
   nvidia_gpu_device_plugin {
+    enabled = true
+  }
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigNvidiaGpuDraDriverEnabled(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
+  nvidia_gpu_dra_driver {
+    enabled = true
+  }
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigAmdGpuDraDriverEnabled(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name    = "%s"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
+  ha      = false
+  amd_gpu_dra_driver {
     enabled = true
   }
   node_pool {

--- a/digitalocean/kubernetes/resource_kubernetes_node_pool.go
+++ b/digitalocean/kubernetes/resource_kubernetes_node_pool.go
@@ -89,6 +89,7 @@ func resourceDigitalOceanKubernetesNodePoolRead(ctx context.Context, d *schema.R
 	d.Set("max_nodes", pool.MaxNodes)
 	d.Set("nodes", flattenNodes(pool.Nodes))
 	d.Set("taint", flattenNodePoolTaints(pool.Taints))
+	d.Set("gpu_partition_mode", pool.GPUPartitionMode)
 
 	// Assign a node_count only if it's been set explicitly, since it's
 	// optional and we don't want to update with a 0 if it's not set.
@@ -209,15 +210,16 @@ func digitaloceanKubernetesNodePoolCreate(client *godo.Client, timeout time.Dura
 	tags = append(tags, customTags...)
 
 	req := &godo.KubernetesNodePoolCreateRequest{
-		Name:      pool["name"].(string),
-		Size:      pool["size"].(string),
-		Count:     pool["node_count"].(int),
-		Tags:      tags,
-		Labels:    expandLabels(pool["labels"].(map[string]interface{})),
-		AutoScale: pool["auto_scale"].(bool),
-		MinNodes:  pool["min_nodes"].(int),
-		MaxNodes:  pool["max_nodes"].(int),
-		Taints:    expandNodePoolTaints(pool["taint"].(*schema.Set).List()),
+		Name:             pool["name"].(string),
+		Size:             pool["size"].(string),
+		Count:            pool["node_count"].(int),
+		Tags:             tags,
+		Labels:           expandLabels(pool["labels"].(map[string]interface{})),
+		AutoScale:        pool["auto_scale"].(bool),
+		MinNodes:         pool["min_nodes"].(int),
+		MaxNodes:         pool["max_nodes"].(int),
+		Taints:           expandNodePoolTaints(pool["taint"].(*schema.Set).List()),
+		GPUPartitionMode: pool["gpu_partition_mode"].(string),
 	}
 
 	p, _, err := client.Kubernetes.CreateNodePool(context.Background(), clusterID, req)

--- a/digitalocean/kubernetes/resource_kubernetes_node_pool.go
+++ b/digitalocean/kubernetes/resource_kubernetes_node_pool.go
@@ -43,15 +43,16 @@ func resourceDigitalOceanKubernetesNodePoolCreate(ctx context.Context, d *schema
 	client := meta.(*config.CombinedConfig).GodoClient()
 
 	rawPool := map[string]interface{}{
-		"name":       d.Get("name"),
-		"size":       d.Get("size"),
-		"tags":       d.Get("tags"),
-		"labels":     d.Get("labels"),
-		"node_count": d.Get("node_count"),
-		"auto_scale": d.Get("auto_scale"),
-		"min_nodes":  d.Get("min_nodes"),
-		"max_nodes":  d.Get("max_nodes"),
-		"taint":      d.Get("taint"),
+		"name":               d.Get("name"),
+		"size":               d.Get("size"),
+		"tags":               d.Get("tags"),
+		"labels":             d.Get("labels"),
+		"node_count":         d.Get("node_count"),
+		"auto_scale":         d.Get("auto_scale"),
+		"min_nodes":          d.Get("min_nodes"),
+		"max_nodes":          d.Get("max_nodes"),
+		"taint":              d.Get("taint"),
+		"gpu_partition_mode": d.Get("gpu_partition_mode"),
 	}
 
 	timeout := d.Timeout(schema.TimeoutCreate)
@@ -209,6 +210,8 @@ func digitaloceanKubernetesNodePoolCreate(client *godo.Client, timeout time.Dura
 	tags := tag.ExpandTags(pool["tags"].(*schema.Set).List())
 	tags = append(tags, customTags...)
 
+	gpuPartitionMode, _ := pool["gpu_partition_mode"].(string)
+
 	req := &godo.KubernetesNodePoolCreateRequest{
 		Name:             pool["name"].(string),
 		Size:             pool["size"].(string),
@@ -219,7 +222,7 @@ func digitaloceanKubernetesNodePoolCreate(client *godo.Client, timeout time.Dura
 		MinNodes:         pool["min_nodes"].(int),
 		MaxNodes:         pool["max_nodes"].(int),
 		Taints:           expandNodePoolTaints(pool["taint"].(*schema.Set).List()),
-		GPUPartitionMode: pool["gpu_partition_mode"].(string),
+		GPUPartitionMode: gpuPartitionMode,
 	}
 
 	p, _, err := client.Kubernetes.CreateNodePool(context.Background(), clusterID, req)

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -168,6 +168,7 @@ The following arguments are supported:
   - `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - (Optional) A list of tag names applied to the node pool.
   - `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool. The labels are exposed in the Kubernetes API as labels in the metadata of the corresponding [Node resources](https://kubernetes.io/docs/concepts/architecture/nodes/).
+  - `gpu_partition_mode` - (Optional) The AMD GPU partition mode to use for nodes in this pool. Valid values are `AMD_PARTITION_MODE_SPX_NPS1` and `AMD_PARTITION_MODE_DPX_NPS2`. This can only be set when the pool is created.
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
 * `maintenance_policy` - (Optional) A block representing the cluster's maintenance window. Updates will be applied within this window. If not specified, a default maintenance window will be chosen. `auto_upgrade` must be set to `true` for this to have an effect.
   - `day` - (Required) The day of the maintenance window policy. May be one of "monday" through "sunday", or "any" to indicate an arbitrary week day.
@@ -178,18 +179,18 @@ The following arguments are supported:
   - `enabled` - (Required) Boolean flag whether the routing-agent should be enabled or not.
 * `p2p_oci_registry_plugin` - (Optional) Block containing options for the Peer-to-peer OCI registry plugin component. If not specified, the p2p-oci-registry-plugin component will not be installed in the cluster.
   - `enabled` - (Required) Boolean flag whether the p2p-oci-registry-plugin should be enabled or not.
-* `amd_gpu_device_plugin` - (Optional) Block containing options for the AMD GPU device plugin component. If not specified, the component will be enabled by default for clusters with AMD GPU nodes.
+* `amd_gpu_device_plugin` - (Optional) Block containing options for the AMD GPU device plugin component. If not specified, the component will be enabled by default for clusters with AMD GPU nodes. Mutually exclusive with `amd_gpu_dra_driver`.
   - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
-`amd_gpu_device_metrics_exporter_plugin` - (Optional) Block containing options for the AMD GPU device metrics exporter component. If not specified, the component will not be installed in the cluster.
-    - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
-* `nvidia_gpu_device_plugin` - (Optional) Block containing options for the NVIDIA GPU device plugin component. If not specified, the component will be enabled by default for clusters with NVIDIA GPU nodes.
+* `amd_gpu_device_metrics_exporter_plugin` - (Optional) Block containing options for the AMD GPU device metrics exporter component. If not specified, the component will not be installed in the cluster.
   - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
-* `nvidia_gpu_dra_driver` - (Optional) Block containing options for the NVIDIA GPU DRA driver component. Mutually exclusive with `nvidia_gpu_device_plugin`. Create-only to enable.
+* `nvidia_gpu_device_plugin` - (Optional) Block containing options for the NVIDIA GPU device plugin component. If not specified, the component will be enabled by default for clusters with NVIDIA GPU nodes. Mutually exclusive with `nvidia_gpu_dra_driver`.
   - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
-* `amd_gpu_dra_driver` - (Optional) Block containing options for the AMD GPU DRA driver component. Mutually exclusive with `amd_gpu_device_plugin`. Create-only to enable.
+* `nvidia_gpu_dra_driver` - (Optional) Block containing options for the NVIDIA GPU DRA driver component. Mutually exclusive with `nvidia_gpu_device_plugin`.
   - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
-`rdma_shared_device_plugin` - (Optional) Block containing options for the RDMA Shared Device Plugin (k8s-rdma-shared-dev-plugin) component. If not specified, the component will be enabled by default for clusters with GPU nodes connected to a dedicated high-speed networking fabric.
-    - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
+* `amd_gpu_dra_driver` - (Optional) Block containing options for the AMD GPU DRA driver component. Mutually exclusive with `amd_gpu_device_plugin`.
+  - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
+* `rdma_shared_device_plugin` - (Optional) Block containing options for the RDMA Shared Device Plugin (k8s-rdma-shared-dev-plugin) component. If not specified, the component will be enabled by default for clusters with GPU nodes connected to a dedicated high-speed networking fabric.
+  - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
 * `coredns_autoscaler` - (Optional) Block containing options for the CoreDNS Autoscaler component, which scales CoreDNS replicas in proportion to the cluster's size. Default: true (for 1.36.0 and later)
   - `enabled` - (Required) Boolean flag whether the CoreDNS Autoscaler should be enabled or not.
 * `cluster_autoscaler_configuration` - (Optional) Block containing options for cluster auto-scaling. For more information.

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -184,6 +184,10 @@ The following arguments are supported:
     - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
 * `nvidia_gpu_device_plugin` - (Optional) Block containing options for the NVIDIA GPU device plugin component. If not specified, the component will be enabled by default for clusters with NVIDIA GPU nodes.
   - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
+* `nvidia_gpu_dra_driver` - (Optional) Block containing options for the NVIDIA GPU DRA driver component. Mutually exclusive with `nvidia_gpu_device_plugin`. Create-only to enable.
+  - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
+* `amd_gpu_dra_driver` - (Optional) Block containing options for the AMD GPU DRA driver component. Mutually exclusive with `amd_gpu_device_plugin`. Create-only to enable.
+  - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
 `rdma_shared_device_plugin` - (Optional) Block containing options for the RDMA Shared Device Plugin (k8s-rdma-shared-dev-plugin) component. If not specified, the component will be enabled by default for clusters with GPU nodes connected to a dedicated high-speed networking fabric.
     - `enabled` - (Required) Boolean flag whether the component should be enabled or not.
 * `coredns_autoscaler` - (Optional) Block containing options for the CoreDNS Autoscaler component, which scales CoreDNS replicas in proportion to the cluster's size. Default: true (for 1.36.0 and later)

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -75,6 +75,7 @@ The following arguments are supported:
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
 * `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool. The labels are exposed in the Kubernetes API as labels in the metadata of the corresponding [Node resources](https://kubernetes.io/docs/concepts/architecture/nodes/).
 * `taint` - (Optional) A list of taints applied to all nodes in the pool.
+* `gpu_partition_mode` - (Optional) The AMD GPU partition mode to use for nodes in this pool. Valid values are `AMD_PARTITION_MODE_SPX_NPS1` and `AMD_PARTITION_MODE_DPX_NPS2`. This can only be set when the pool is created.
 
 This resource supports [customized create timeouts](https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts). The default timeout is 30 minutes.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.1
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/digitalocean/godo v1.201.0
+	github.com/digitalocean/godo v1.202.0
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.201.0 h1:p9UD10Nu2KewJxMr0IBWoMxJCU3kjnuaSzXI84QhgYU=
-github.com/digitalocean/godo v1.201.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.202.0 h1:mfOZOto3jYv/bVuZzNPDWJsGMB9Y/PgyU3EuI+auAIk=
+github.com/digitalocean/godo v1.202.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.202.0] - 2026-07-29
+
+- #1069 - @varshavaradarajan - doks: add isolated workers to kubernetes create call
+- #1067 - @nveerdixit - MARSOHS-551: Session.origin on HostedAgents (stack on OHS_endpoints)
+
 ## [1.201.0] - 2026-07-24
 
 - #1060 - @DO-rrao - Add GPU partition mode support to Droplets and Sizes

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.201.0"
+	libraryVersion = "1.202.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -92,10 +92,16 @@ type KubernetesClusterCreateRequest struct {
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	NvidiaGpuDraDriver                *KubernetesNvidiaGpuDraDriver                `json:"nvidia_gpu_dra_driver,omitempty"`
+	AmdGpuDraDriver                   *KubernetesAmdGpuDraDriver                   `json:"amd_gpu_dra_driver,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
 	P2pOciRegistryPlugin              *KubernetesP2pOciRegistry                    `json:"p2p_oci_registry_plugin,omitempty"`
+	// IsolatedWorkers enables isolated worker nodes. When true, the cluster's VPC
+	// must already have a NAT gateway attached, or the create request fails with a
+	// 422. This can only be set at creation time.
+	IsolatedWorkers bool `json:"isolated_workers,omitempty"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
@@ -111,6 +117,8 @@ type KubernetesClusterUpdateRequest struct {
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	NvidiaGpuDraDriver                *KubernetesNvidiaGpuDraDriver                `json:"nvidia_gpu_dra_driver,omitempty"`
+	AmdGpuDraDriver                   *KubernetesAmdGpuDraDriver                   `json:"amd_gpu_dra_driver,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
@@ -147,18 +155,26 @@ func (t Taint) String() string {
 	return fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
 }
 
+// Kubernetes GPU partition modes for AMD GPU node pools. Omitting the value
+// (or sending an empty string) leaves the pool unpartitioned.
+const (
+	KubernetesAMDPartitionModeSPXNPS1 = "AMD_PARTITION_MODE_SPX_NPS1"
+	KubernetesAMDPartitionModeDPXNPS2 = "AMD_PARTITION_MODE_DPX_NPS2"
+)
+
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
 // Kubernetes cluster.
 type KubernetesNodePoolCreateRequest struct {
-	Name      string            `json:"name,omitempty"`
-	Size      string            `json:"size,omitempty"`
-	Count     int               `json:"count,omitempty"`
-	Tags      []string          `json:"tags,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	Taints    []Taint           `json:"taints,omitempty"`
-	AutoScale bool              `json:"auto_scale,omitempty"`
-	MinNodes  int               `json:"min_nodes,omitempty"`
-	MaxNodes  int               `json:"max_nodes,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Size             string            `json:"size,omitempty"`
+	Count            int               `json:"count,omitempty"`
+	Tags             []string          `json:"tags,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Taints           []Taint           `json:"taints,omitempty"`
+	AutoScale        bool              `json:"auto_scale,omitempty"`
+	MinNodes         int               `json:"min_nodes,omitempty"`
+	MaxNodes         int               `json:"max_nodes,omitempty"`
+	GPUPartitionMode string            `json:"gpu_partition_mode,omitempty"`
 }
 
 // KubernetesNodePoolUpdateRequest represents a request to update a node pool in a
@@ -257,10 +273,13 @@ type KubernetesCluster struct {
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	NvidiaGpuDraDriver                *KubernetesNvidiaGpuDraDriver                `json:"nvidia_gpu_dra_driver,omitempty"`
+	AmdGpuDraDriver                   *KubernetesAmdGpuDraDriver                   `json:"amd_gpu_dra_driver,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
 	P2pOciRegistryPlugin              *KubernetesP2pOciRegistry                    `json:"p2p_oci_registry_plugin,omitempty"`
+	IsolatedWorkers                   bool                                         `json:"isolated_workers,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
@@ -329,6 +348,18 @@ type KubernetesAmdGpuDeviceMetricsExporterPlugin struct {
 // KubernetesNvidiaGpuDevicePlugin represents information about the NVIDIA GPU Device Plugin cluster plugin.
 // If a cluster has a node pool with an NVIDIA GPU it will be enabled by default.
 type KubernetesNvidiaGpuDevicePlugin struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// KubernetesNvidiaGpuDraDriver represents information about the NVIDIA GPU DRA Driver cluster plugin.
+// Mutually exclusive with the NVIDIA GPU Device Plugin.
+type KubernetesNvidiaGpuDraDriver struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// KubernetesAmdGpuDraDriver represents information about the AMD GPU DRA Driver cluster plugin.
+// Mutually exclusive with the AMD GPU Device Plugin.
+type KubernetesAmdGpuDraDriver struct {
 	Enabled *bool `json:"enabled"`
 }
 
@@ -507,16 +538,17 @@ type KubernetesClusterStatus struct {
 
 // KubernetesNodePool represents a node pool in a Kubernetes cluster.
 type KubernetesNodePool struct {
-	ID        string            `json:"id,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Size      string            `json:"size,omitempty"`
-	Count     int               `json:"count,omitempty"`
-	Tags      []string          `json:"tags,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	Taints    []Taint           `json:"taints,omitempty"`
-	AutoScale bool              `json:"auto_scale,omitempty"`
-	MinNodes  int               `json:"min_nodes,omitempty"`
-	MaxNodes  int               `json:"max_nodes,omitempty"`
+	ID               string            `json:"id,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Size             string            `json:"size,omitempty"`
+	Count            int               `json:"count,omitempty"`
+	Tags             []string          `json:"tags,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Taints           []Taint           `json:"taints,omitempty"`
+	AutoScale        bool              `json:"auto_scale,omitempty"`
+	MinNodes         int               `json:"min_nodes,omitempty"`
+	MaxNodes         int               `json:"max_nodes,omitempty"`
+	GPUPartitionMode string            `json:"gpu_partition_mode,omitempty"`
 
 	Nodes []*KubernetesNode `json:"nodes,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.201.0
+# github.com/digitalocean/godo v1.202.0
 ## explicit; go 1.23.0
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
- Add `nvidia_gpu_dra_driver` and `amd_gpu_dra_driver` to `digitalocean_kubernetes_cluster` (and datasource).
- Add `gpu_partition_mode` to kubernetes node pools (`AMD_PARTITION_MODE_SPX_NPS1` / `AMD_PARTITION_MODE_DPX_NPS2`, create-only).
- Update docs and acceptance test coverage.
- Depends on godo v1.202.0 (minor after current main, this PR to be precise https://github.com/digitalocean/godo/pull/1068 ). CI should fail before that, which is expected. 