### PR TITLE
feat: Handle terrafrom import volume attachment

### DIFF
--- a/digitalocean/volume/resource_volume_attachment.go
+++ b/digitalocean/volume/resource_volume_attachment.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/digitalocean/terraform-provider-digitalocean/digitalocean/config"
@@ -35,6 +37,10 @@ func ResourceDigitalOceanVolumeAttachment() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDigitalOceanVolumeAttachmentImport,
 		},
 	}
 }
@@ -147,4 +153,26 @@ func resourceDigitalOceanVolumeAttachmentDelete(ctx context.Context, d *schema.R
 	}
 
 	return nil
+}
+
+func resourceDigitalOceanVolumeAttachmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), ",")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("expected import ID in the format 'droplet_id,volume_id', got: %q", d.Id())
+	}
+
+	dropletID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid droplet_id %q: %s", parts[0], err)
+	}
+
+	if err := d.Set("droplet_id", dropletID); err != nil {
+		return nil, err
+	}
+	if err := d.Set("volume_id", parts[1]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/digitalocean/volume/resource_volume_attachment_test.go
+++ b/digitalocean/volume/resource_volume_attachment_test.go
@@ -299,3 +299,46 @@ resource "digitalocean_volume_attachment" "foobar" {
   volume_id  = digitalocean_volume.%s.id
 }`, vName, vSecondName, dName, activeVolume)
 }
+
+func TestAccDigitalOceanVolumeAttachment_ImportBasic(t *testing.T) {
+	rName := acceptance.RandomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanVolumeAttachmentConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanVolumeAttachmentExists("digitalocean_volume_attachment.foobar"),
+				),
+			},
+			{
+				ResourceName:            "digitalocean_volume_attachment.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"id"},
+				ImportStateIdFunc: testAccDigitalOceanVolumeAttachmentImportID(
+					"digitalocean_droplet.foobar",
+					"digitalocean_volume.foobar",
+				),
+			},
+		},
+	})
+}
+
+func testAccDigitalOceanVolumeAttachmentImportID(dropletResource, volumeResource string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		dropletRS, ok := s.RootModule().Resources[dropletResource]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", dropletResource)
+		}
+		volumeRS, ok := s.RootModule().Resources[volumeResource]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", volumeResource)
+		}
+
+		return fmt.Sprintf("%s,%s", dropletRS.Primary.ID, volumeRS.Primary.ID), nil
+	}
+}


### PR DESCRIPTION
## Description

Adds `terraform import` support to `digitalocean_volume_attachment`, which
previously had no importer configured — unlike `digitalocean_volume`,
`digitalocean_volume_snapshot`, and other resources in this provider that
document a working import command.

Closes #<issue-number>

## Why a composite import ID

`digitalocean_volume_attachment` has no independent remote identifier of its
own - the resource's local ID is generated via `id.PrefixedUniqueId(...)` at
create time and includes a non-deterministic suffix, so it can't be
reconstructed from `droplet_id`/`volume_id` alone for import purposes.

Since a DigitalOcean volume can only be attached to one droplet at a time,
`volume_id` is a stable and sufficient key to look up the attachment via the
API. Import therefore accepts a composite ID:
```
terraform import digitalocean_volume_attachment.foobar <droplet_id>,<volume_id>
```

and sets the resource's local ID to `volume_id` after import (rather than
generating a new `PrefixedUniqueId`), which is why `id` is excluded from the
import state comparison in the added acceptance test - the pre-import ID
(random suffix) and post-import ID (`volume_id`) are expected to differ; only
`droplet_id` and `volume_id` need to match.

## Changes

- Added `Importer` with a `StateContext` function to
  `resourceDigitalOceanVolumeAttachment()` that parses a
  `"droplet_id,volume_id"` string, sets both fields, and delegates to the
  existing `Read` to populate the rest of state.
- Added `TestAccDigitalOceanVolumeAttachment_ImportBasic` acceptance test.
- Updated `docs/resources/volume_attachment.md` with an "Importing" section
  and example command.