### PR TITLE
doks: add support for isolated workers

### DIFF
--- a/digitalocean/kubernetes/datasource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster.go
@@ -345,7 +345,10 @@ func DataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-
+			"isolated_workers": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"urn": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/datasource_kubernetes_cluster_test.go
@@ -49,6 +49,7 @@ data "digitalocean_kubernetes_cluster" "foobar" {
 					resource.TestCheckResourceAttrSet("data.digitalocean_kubernetes_cluster.foobar", "vpc_uuid"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_kubernetes_cluster.foobar", "worker_subnet_uuid"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_kubernetes_cluster.foobar", "auto_upgrade"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_kubernetes_cluster.foobar", "isolated_workers"),
 					resource.TestMatchResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "urn", expectedURNRegEx),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.day", "monday"),
 					resource.TestCheckResourceAttr("data.digitalocean_kubernetes_cluster.foobar", "maintenance_policy.0.start_time", "00:00"),

--- a/digitalocean/kubernetes/resource_kubernetes_cluster.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster.go
@@ -444,6 +444,13 @@ func ResourceDigitalOceanKubernetesCluster() *schema.Resource {
 					},
 				},
 			},
+
+			"isolated_workers": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -625,6 +632,10 @@ func resourceDigitalOceanKubernetesClusterCreate(ctx context.Context, d *schema.
 		opts.CorednsAutoscaler = expandCorednsAutoscalerOpts(corednsAutoscaler.([]interface{}))
 	}
 
+	if isolatedWorkers, ok := d.GetOk("isolated_workers"); ok {
+		opts.IsolatedWorkers = isolatedWorkers.(bool)
+	}
+
 	cluster, _, err := client.Kubernetes.Create(context.Background(), opts)
 	if err != nil {
 		return diag.Errorf("Error creating Kubernetes cluster: %s", err)
@@ -728,6 +739,8 @@ func digitaloceanKubernetesClusterRead(
 	if err := d.Set(corednsAutoscalerField, flattenCorednsAutoscalerOpts(cluster.CorednsAutoscaler)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting %s - error: %#v", corednsAutoscalerField, err)
 	}
+
+	d.Set("isolated_workers", cluster.IsolatedWorkers)
 
 	if err := d.Set("maintenance_policy", flattenMaintPolicyOpts(cluster.MaintenancePolicy)); err != nil {
 		return diag.Errorf("[DEBUG] Error setting maintenance_policy - error: %#v", err)

--- a/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
+++ b/digitalocean/kubernetes/resource_kubernetes_cluster_test.go
@@ -1223,6 +1223,26 @@ func TestAccDigitalOceanKubernetesCluster_RdmaSharedDevicePluginEnabled(t *testi
 	})
 }
 
+func TestAccDigitalOceanKubernetesCluster_IsolatedWorkersEnabled(t *testing.T) {
+	rName := acceptance.RandomTestName()
+	var k8s godo.KubernetesCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigIsolatedWorkersEnabled(testClusterVersionLatest, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "isolated_workers", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDigitalOceanKubernetesConfigBasic(testClusterVersion string, rName string) string {
 	return fmt.Sprintf(`%s
 
@@ -1764,6 +1784,25 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   rdma_shared_device_plugin {
     enabled = true
   }
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 1
+  }
+}
+`, testClusterVersion, rName)
+}
+
+func testAccDigitalOceanKubernetesConfigIsolatedWorkersEnabled(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name             = "%s"
+  region           = "nyc1"
+  version          = data.digitalocean_kubernetes_versions.test.latest_version
+  ha               = false
+  isolated_workers = true
+
   node_pool {
     name       = "default"
     size       = "s-1vcpu-2gb"

--- a/docs/data-sources/kubernetes_cluster.md
+++ b/docs/data-sources/kubernetes_cluster.md
@@ -46,6 +46,7 @@ The following attributes are exported:
 * `created_at` - The date and time when the Kubernetes cluster was created.
 * `updated_at` - The date and time when the Kubernetes cluster was last updated.
 * `auto_upgrade` - A boolean value indicating whether the cluster will be automatically upgraded to new patch releases during its maintenance window.
+* `isolated_workers` - A boolean value indicating whether the cluster has isolated worker nodes enabled.
 * `kube_config.0` - A representation of the Kubernetes cluster's kubeconfig with the following attributes:
   - `raw_config` - The full contents of the Kubernetes cluster's kubeconfig file.
   - `host` - The URL of the API server on the Kubernetes master node.

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -88,6 +88,28 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 
 Note that a data source is used to supply the version. This is needed to prevent configuration diff whenever a cluster is upgraded.
 
+### Isolated Workers Example
+
+Kubernetes clusters may also be configured to use [isolated worker nodes](https://docs.digitalocean.com/products/kubernetes/concepts/isolated-workers/).
+When enabled, each worker node runs on dedicated hardware. The cluster's VPC must have a NAT gateway attached.
+For example:
+
+```hcl
+resource "digitalocean_kubernetes_cluster" "foo" {
+  name             = "foo"
+  region           = "nyc1"
+  version          = "latest"
+  isolated_workers = true
+  vpc_uuid         = digitalocean_vpc.example.id
+
+  node_pool {
+    name       = "worker-pool"
+    size       = "s-2vcpu-2gb"
+    node_count = 3
+  }
+}
+```
+
 ### Kubernetes Terraform Provider Example
 
 The cluster's kubeconfig is exported as an attribute allowing you to use it with
@@ -158,6 +180,7 @@ The following arguments are supported:
 * `auto_upgrade` - (Optional) A boolean value indicating whether the cluster will be automatically upgraded to new patch releases during its maintenance window.
 * `surge_upgrade` - (Optional) Enable/disable surge upgrades for a cluster. Default: true
 * `ha` - (Optional) Enable/disable the high availability control plane for a cluster. Once enabled for a cluster, high availability cannot be disabled. Default: true (for 1.36.0 and later)
+* `isolated_workers` - (Optional) Enable/disable isolated worker nodes for the cluster. When enabled, each worker node runs on dedicated hardware. This can only be set at creation time. The cluster's VPC must have a NAT gateway attached. Default: false
 * `registry_integration` - (optional) Enables or disables the DigitalOcean container registry integration for the cluster. This requires that a container registry has first been created for the account. Default: false
 * `node_pool` - (Required) A block representing the cluster's default node pool. Additional node pools may be added to the cluster using the `digitalocean_kubernetes_node_pool` resource. The following arguments may be specified:
   - `name` - (Required) A name for the node pool.
@@ -216,6 +239,7 @@ In addition to the arguments listed above, the following additional attributes a
 * `created_at` - The date and time when the Kubernetes cluster was created.
 * `updated_at` - The date and time when the Kubernetes cluster was last updated.
 * `auto_upgrade` - A boolean value indicating whether the cluster will be automatically upgraded to new patch releases during its maintenance window.
+* `isolated_workers` - A boolean value indicating whether the cluster has isolated worker nodes enabled.
 * `kube_config.0` - A representation of the Kubernetes cluster's kubeconfig with the following attributes:
   - `raw_config` - The full contents of the Kubernetes cluster's kubeconfig file.
   - `host` - The URL of the API server on the Kubernetes master node.


### PR DESCRIPTION
This PR adds a new configuration field to kubernetes cluster create call for isolated workers. It has ForceNew set, which means that a cluster will be recreated upon changing the value for isolated_workers. 